### PR TITLE
Extract human_root to humanize_path

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -724,12 +724,7 @@ sub {
 	$top->embed($ENV{GENESIS_CALLBACK_BIN} || $0);
 
 	my $root = $top->path;
-	my $pwd = Cwd::abs_path(Cwd::getcwd());
-	my $human_root = (substr($root, 0, length($pwd) + 1) eq $pwd . '/')
-		? '.' . substr($root, length($pwd))
-		: (substr($root, 0, length($ENV{HOME}) + 1) eq $ENV{HOME} . '/')
-		? "~" . substr($root, length($pwd)) : $root;
-
+	my $human_root = humanize_path($root);
 	pushd($root);
 	if ($options{'link-dev-kit'}) {
 		debug("Kit: linking dev to $abs_target");

--- a/lib/Genesis.pm
+++ b/lib/Genesis.pm
@@ -50,6 +50,7 @@ our @EXPORT = qw/
 	chdir_or_fail chmod_or_fail
 	symlink_or_fail
 	copy_or_fail
+	humanize_path
 
 	load_json
 	load_yaml load_yaml_file
@@ -559,6 +560,15 @@ sub chmod_or_fail {
 	-e $path or die "$path: $!\n";
 	chmod $mode, $path
 		or die "Could not change mode of $path: $!\n";
+}
+
+sub humanize_path {
+	my $path = shift;
+	my $pwd = Cwd::abs_path($ENV{GENESIS_CALLER_DIR} || Cwd::getcwd());
+	(substr($path, 0, length($pwd) + 1) eq $pwd . '/')
+		? '.' . substr($path, length($pwd))
+		: (substr($path, 0, length($ENV{HOME}) + 1) eq $ENV{HOME} . '/')
+		? "~" . substr($path, length($ENV{HOME})) : $path;
 }
 
 sub load_json {

--- a/lib/Genesis.pm
+++ b/lib/Genesis.pm
@@ -565,10 +565,13 @@ sub chmod_or_fail {
 sub humanize_path {
 	my $path = shift;
 	my $pwd = Cwd::abs_path($ENV{GENESIS_CALLER_DIR} || Cwd::getcwd());
-	(substr($path, 0, length($pwd) + 1) eq $pwd . '/')
+	my $new_path = (substr($path, 0, length($pwd) + 1) eq $pwd . '/')
 		? '.' . substr($path, length($pwd))
 		: (substr($path, 0, length($ENV{HOME}) + 1) eq $ENV{HOME} . '/')
 		? "~" . substr($path, length($ENV{HOME})) : $path;
+	while ($new_path =~ s/\/[^\/]*\/\.\.\//\//) {};
+	$new_path =~ s/^\.\/\.\.\//..\//;
+	$new_path;
 }
 
 sub load_json {

--- a/t/00-utils.t
+++ b/t/00-utils.t
@@ -234,6 +234,13 @@ subtest 'fs utilities' => sub {
 	pushd("$tmp/dir"); is Cwd::getcwd, "$tmp/dir", "pushd put us where we wanted to go (again)";
 	popd();            is Cwd::getcwd, "$tmp/dir", "popd put us back in the previous \$tmp/dir...";
 	popd();            is Cwd::getcwd, "$here",    "popd put us back in our old cwd";
+
+	chdir '/'; is humanize_path($ENV{HOME}.'/dir'), '~/dir', "humanize_path shows path relative to \$HOME";
+	is humanize_path($ENV{HOME}.'/big/long/path/to/nonexistant.file'), '~/big/long/path/to/nonexistant.file', "humanize_path shows long path relative to \$HOME";
+	chdir $here; is humanize_path($here.'/dir'), './dir', "humanize_path shows path relative to pwd";
+	is humanize_path($here.'/big/long/../../path/to/nonexistant.file'), './path/to/nonexistant.file', "humanize_path shows long path relative to pwd";
+	is humanize_path($here.'/../diff_repo/some_file.yml'), '../diff_repo/some_file.yml', "humanize_path shows uptree path relative to pwd";
+	is humanize_path($tmp), $tmp, "humanize_path shows full path when not relative to \$HOME or pwd";
 };
 
 subtest 'semantic versioning' => sub {


### PR DESCRIPTION
Internal-facing refactor to provide users with relative paths instead of full absolute paths on output