### PR TITLE
`bail` now correctly escapes single argument calls

### DIFF
--- a/lib/Genesis.pm
+++ b/lib/Genesis.pm
@@ -235,7 +235,7 @@ sub error {
 sub bail {
 	my @err = @_;
 	unshift @err, "%s" if $#err == 0;
-	$! = 1; die csprintf(@_)."$/";
+	$! = 1; die csprintf(@err)."$/";
 }
 
 sub bug {


### PR DESCRIPTION
Minor fix:  the escape was coded, just wasn't used.