### PR TITLE
Soft-fail on bad LANG setting

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -2357,7 +2357,14 @@ sub main {
 	my ($cmd, @args);
 	while (@_ > 0) {
 		my $arg = shift @_;
-		$arg = decode($ENV{LANG},$arg) if $ENV{LANG};
+
+		if ($ENV{LANG}) {
+			eval {$arg = decode($ENV{LANG},$arg)};
+			if ($@) {
+				warn "#Y{[WARNING]} Environment variable \$LANG contains invalid value.  Some output may be garbled as a result";
+			}
+		}
+
 		if ($cmd || $arg =~ m/^-+/) {
 			push @args, $arg;
 			push @args, shift @_ if $arg eq '-C';


### PR DESCRIPTION
While having LANG environmental variable set will enable the correct decoding of the arguments, if the client is using a bad or unknown LANG setting, this causes genesis execution to be blocked.

It is better to run genesis with the potential of garbled output (non-ASCII characters) than block it from being run altogether, so now if we encounter a LANG value that causes an error, we simply warn and continue.