### PR TITLE
Raises error if kit.subkits and kits.features both used

### DIFF
--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -50,6 +50,13 @@ sub load {
 	bail("#R{[ERROR]} Environment file $env->{file} does not exist.")
 		unless -f $env->path($env->{file});
 
+	bail("#R{[ERROR]} Both #C{kit.features} and deprecated #C{kit.subkits} were found during the environment\n".
+			 "build-out using the following files:\n#M{  %s}\n\n".
+			 "This can cause conflicts and unexpected behaviour.  Please replace all occurrences of\n".
+			 "#C{subkits} with #C{features} under the #C{kit} toplevel key.\n",
+			 join("\n  ",$env->actual_environment_files)
+	) if ($env->defines('kit.features') && $env->defines('kit.subkits'));
+
 	unless (in_callback || envset("GENESIS_LEGACY")) {
 		my ($env_name, $env_key) = $env->lookup(['genesis.env','params.env']);
 		bail("\n#R{[ERROR]} Environment file #C{$env->{file}} environment name mismatch: #C{$env_key: $env_name}")


### PR DESCRIPTION
Eons ago, we renamed the concept known as `subkits` to `features`, as we
felt it better reflected the behaviour.  However, we continued to allow
the use of the `subkits` key under the top-level `kit` key.  This has
caused the rare conflict when a hierarchal yml file (such as corp.yaml)
contained `kit.subkits`, and the dependent environment file (such as
corp-myenv.yml) contained `kit.features` (or vice versa).  In this case,
`features` presence would trump `subkits` and the latter would be
ignored.

This commit causes an error to be raised when any mixed usage is
encountered.