### PR TITLE
Add kit provider feature

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -855,6 +855,7 @@ specified by those options.  See Kit Provider options below for more details.
 OPTIONS
 $GLOBAL_USAGE
   -d, --default       Use default genesis-community provider
+  -v, --verbose       Show details of the kits the current kit provider supports.
 
 ${\Genesis::Kit::Provider->opts_help()}
 

--- a/bin/genesis
+++ b/bin/genesis
@@ -856,6 +856,7 @@ OPTIONS
 $GLOBAL_USAGE
   -d, --default       Use default genesis-community provider
   -v, --verbose       Show details of the kits the current kit provider supports.
+      --export-config Export the current kit provider information.
 
 ${\Genesis::Kit::Provider->opts_help()}
 
@@ -866,7 +867,12 @@ sub {
 	options(\@_, \%options, qw/
 		default|d
 		verbose|v
+		export-config
 	/);
+	my $cfg_export = delete($options{'export-config'});
+	bail "Option #M{--export-config} cannot be used with any other options"
+		if ($cfg_export && scalar(keys(%options)));
+
   my $verbose = delete($options{verbose});
 	if (delete($options{default})) {
 		$options{'kit-provider'} = 'genesis-community';
@@ -884,6 +890,11 @@ sub {
 			exit 1;
 		}
 		$kit_provider_lookup = "new";
+	}
+
+	if ($cfg_export) {
+		printf "%s\n", JSON::PP::encode_json({$top->kit_provider->config});
+		exit 0
 	}
 
 	waiting_on("\nCollecting information on %s kit provider for #C{%s} deployment at #M{%s} ...", $kit_provider_lookup, $top->type, humanize_path($top->path));

--- a/bin/genesis
+++ b/bin/genesis
@@ -31,8 +31,9 @@ use Encode;
 use Genesis;
 use Genesis::UI;
 use Genesis::Top;
-use Genesis::Kit::Compiler;
 use Genesis::Kit;
+use Genesis::Kit::Compiler;
+use Genesis::Kit::Provider;
 use Genesis::CI::Legacy; # but we'd rather not...
 
 $Genesis::VERSION = "(development)";
@@ -532,6 +533,7 @@ $GLOBAL_USAGE
   #C{init}              Initialize a new Genesis deployment.
   #G{new}               Create a new Genesis deployment environment.
   #G{check}             Check a deployment manifest for errors, without deploying it.
+  kit-provider      Check or set the kit provider for the Genesis deployment.
   secrets-provider  Check or set the secrets provider for the Genesis deployment.
   #G{check-secrets}     Check for missing credentials (passwords, keys, etc.).
   #G{add-secrets}       Generate missing credentials (passwords, keys, etc.).
@@ -630,7 +632,7 @@ sub {
 	my %options;
 	options(\@_, \%options, qw/
 	/);
-	usage(1) if @_;
+	usage(1, "Too many arguments: ".join(', ',@_)) if @_;
 	print "Genesis v$Genesis::VERSION$Genesis::BUILD\n";
 });
 
@@ -671,7 +673,7 @@ $GLOBAL_USAGE
                       directory, this will link the specified directory to the
                       dev directory.
       --vault         Name of a 'safe' target (a Vault) to store newly generated
-                      credentials in. If not specified, it will be interactively 
+                      credentials in. If not specified, it will be interactively
                       prompted for.
   -d, --directory     By default, the directory in which the Genesis deployment
                       will be created in will be named ./<name>-deployments.
@@ -680,9 +682,12 @@ $GLOBAL_USAGE
   name                If the name argument is not specified, it will default to
                       the same name as the kit.  You must specify either name
                       or kit.
+
+${\Genesis::Kit::Provider->opts_help()}
 EOF
 sub {
 	my %options;
+	Genesis::Kit::Provider->parse_opts(\@_, \%options);
 	options(\@_, \%options, qw/
 		kit|k=s
 		vault=s
@@ -834,6 +839,82 @@ sub {
 });
 
 # }}}
+# genesis kit-provider - set, clear or get the kit provider information {{{
+
+command("kit-provider", <<EOF,
+genesis v$Genesis::VERSION$Genesis::BUILD
+USAGE: genesis kit-provider [-d|--default] [<provider-options>]
+
+Without any options, will display the current kit provider information, its
+status and its kits (version counts are included with the --verbose option)
+
+With --kit-provider-* options, will set the kit provider to a new provider
+specified by those options.  See Kit Provider options below for more details.
+
+OPTIONS
+$GLOBAL_USAGE
+  -d, --default       Use default genesis-community provider
+
+${\Genesis::Kit::Provider->opts_help()}
+
+EOF
+sub {
+	my %options;
+	Genesis::Kit::Provider->parse_opts(\@_, \%options);
+	options(\@_, \%options, qw/
+		default|d
+		verbose|v
+	/);
+  my $verbose = delete($options{verbose});
+	if (delete($options{default})) {
+		$options{'kit-provider'} = 'genesis-community';
+	}
+	usage(1) if @_ > 0;
+	check_prereqs();
+
+	my $top = Genesis::Top->new('.');
+	my $err;
+	my $kit_provider_lookup = "current";
+	if (scalar(grep {$_ =~ /^kit-provider/} keys %options)) {
+		$err = $top->set_kit_provider(%options);
+		if ($err) {
+			error "\n#R{[ERROR]} Current kit provider was not changed - reason:\n\n$err\n";
+			exit 1;
+		}
+		$kit_provider_lookup = "new";
+	}
+
+	waiting_on("\nCollecting information on %s kit provider for #C{%s} deployment at #M{%s} ...", $kit_provider_lookup, $top->type, humanize_path($top->path));
+	my %info;
+	eval {
+		%info = $top->kit_provider_info($verbose);
+	};
+	explain("done.\n");
+	bail "#R{[ERROR]} $@\n" if $@;
+
+	explain("         Type: #M{%s}\n", $info{type});
+	explain("%13s: #C{%s}", $_, $info{$_}) for (@{$info{extras} || []});
+	explain("\n       Status: #%s{%s}\n", $info{status} eq "ok" ? "G" : "R", $info{status});
+
+	my $kit_list;
+	if (ref($info{kits}) eq "HASH" && scalar(keys(%{$info{kits}}))) {
+		my $width = (sort {$b <=> $a} map {length($_)} keys %{$info{kits}})[0];
+		$kit_list = join("\n               ",
+										 map {
+											 sprintf("#%s{%-${width}s} [%s]", $_ eq $top->type ? 'G' : '-', $_, $info{kits}->{$_})
+										} sort keys(%{$info{kits}})
+								);
+	} elsif (ref($info{kits}) eq "ARRAY" && scalar(@{$info{kits}})) {
+		$kit_list = join("\n               ", map {sprintf("#%s{%s}", $_ eq $top->type ? 'G' : '-', $_)} @{$info{kits}});
+	} elsif (ref($info{kits}) eq "" && ($info{kits} || "") =~ /^[1-9][0-9]*$/) {
+		$kit_list = $info{kits} . "kit" . ($info{kits} == 1 ? "" : "s");
+	} else {
+		$kit_list = "#Yi{None}";
+	}
+	explain("         Kits: %s\n\n", $kit_list) if $info{status} eq "ok";
+});
+
+# }}}
 # genesis new - create a new Genesis deployment environment (YAML file) {{{
 
 command("new", <<EOF,
@@ -898,7 +979,7 @@ sub {
 
 	# determine the kit to use (dev or compiled)
 	$options{kit} ||= '';
-	my $kit = $top->find_kit(split '/', $options{kit});
+	my $kit = $top->local_kit_version($options{kit});
 	if (!$kit) {
 		if (!$options{kit}) {
 			die "Unable to determine the correct version of the Genesis Kit to use.\n".
@@ -1552,6 +1633,7 @@ $GLOBAL_USAGE
 
 Remote and updates supports further options
       --prereleases     Include pre-release versions of kits
+      --drafts          Include draft versions of the kits
       --[no-]details    Determines if release date and details are shown.
                         Defaults to show for --updated, not show for others.
 EOF
@@ -1572,20 +1654,27 @@ sub {
 		if $options{remote} && $options{updates};
 	check_prereqs(no_repo_needed => $options{remote});
 
+	my $top = Genesis::Top->new('.');
+
 	my (%kits, %latest);
 	$options{details} = $options{updates} unless defined $options{details};
 	if ($options{remote}) {
-		my @kit_names = ($name ? ($name) : Genesis::Kit->downloadable($options{filter}));
+		my @kit_names = ($name ? ($name) : $top->remote_kit_names($options{filter}));
 		for my $kit (@kit_names) {
-			$kits{$kit} = {Genesis::Kit->versions($kit, latest=>$options{latest}, prerelease=>$options{prereleases})};
+			my %versions;
+			$versions{$_->{version}} = $_
+				for ($top->remote_kit_versions($kit, latest=>$options{latest}, include_prereleases=>$options{prereleases}, include_drafts=>$options{drafts}));
+			$kits{$kit} = \%versions;
 		}
 
 	} elsif ($options{updates}) {
-		my $available_kits = Genesis::Top->new('.')->compiled_kits;
+		my $available_kits = $top->local_kits;
 		for my $k (keys %$available_kits) {
 			$kits{$k} = {};
 			$latest{$k} = (reverse sort by_semver keys(%{$available_kits->{$k}}))[0];
-			my %versions = Genesis::Kit->versions($k, latest=>$options{latest}, prerelease=>$options{prereleases});
+			my %versions;
+			$versions{$_->{version}} = $_
+				for ($top->remote_kit_versions($k, latest=>$options{latest}, include_prereleases=>$options{prereleases}, include_drafts=>$options{drafts}));
 			for my $v (reverse sort by_semver keys(%versions)) {
 				last if $latest{$k} && by_semver($v,$latest{$k}) < 1;
 				$kits{$k}{$v} = $versions{$v};
@@ -1593,17 +1682,14 @@ sub {
 		}
 
 	} else {
-		my $available_kits = Genesis::Top->new('.')->compiled_kits;
+		my $available_kits = $top->local_kits;
 		for my $k (keys %$available_kits) {
 			next if $name && $name ne $k;
 			$kits{$k} ||= {};
 			my @versions = keys %{$available_kits->{$k}};
-			@versions = grep {$_} (reverse sort by_semver @versions)[0..(($options{latest} || 1)-1)]
+			@versions = reverse grep {$_} (reverse sort by_semver @versions)[0..(($options{latest} || 1)-1)]
 				if defined $options{latest};
-			my %details = $options{details}
-				? Genesis::Kit->versions($k, prerelease=>1, draft=>1)
-				: ();
-			$kits{$k}{$_} = ($details{$_} || {}) for (@versions);
+			$kits{$k}{$_} = {} for (@versions); # local kits don't have details - TODO: Package them with release notes
 		}
 	}
 
@@ -1936,7 +2022,7 @@ sub {
 
 	my @kits = @_;
 	my $top = Genesis::Top->new('.');
-	my @possible_kits = keys %{$top->compiled_kits};
+	my @possible_kits = keys %{$top->local_kits};
 
 	unless (scalar(@kits)) {
 		bail "No local kits found; you must specify the name of the kit to fetch"
@@ -2019,18 +2105,18 @@ sub {
 	#   BOSH_CLIENT_SECRET         - Password/Client-Secret to authenticate with
 
 	my @undefined = grep { !$ENV{$_} }
-		qw/CURRENT_ENV
-		   GIT_BRANCH GIT_PRIVATE_KEY
-		   OUT_DIR WORKING_DIR
-		   VAULT_ROLE_ID VAULT_SECRET_ID VAULT_ADDR/;
+	qw/CURRENT_ENV
+	GIT_BRANCH GIT_PRIVATE_KEY
+	OUT_DIR WORKING_DIR
+	VAULT_ROLE_ID VAULT_SECRET_ID VAULT_ADDR/;
 	push @undefined, "CACHE_DIR" if ($ENV{PREVIOUS_ENV} && ! $ENV{CACHE_DIR});
 	__bail_on_missing_pipeline_environment_variables(@undefined);
 
-        # we need a method of issue tokens with a temporary lifetime, so approle/secret is used
-        vault_auth(vault       => $ENV{VAULT_ADDR},
-                   skip_verify => envset("VAULT_SKIP_VERIFY"),
-                   role_id     => $ENV{VAULT_ROLE_ID},
-                   secret_id   => $ENV{VAULT_SECRET_ID});
+	# we need a method of issue tokens with a temporary lifetime, so approle/secret is used
+	vault_auth(vault       => $ENV{VAULT_ADDR},
+	           skip_verify => envset("VAULT_SKIP_VERIFY"),
+	           role_id     => $ENV{VAULT_ROLE_ID},
+	           secret_id   => $ENV{VAULT_SECRET_ID});
 
 	# write .saferc file so that safe commands execute properly
 	open my $OUT, ">", "$ENV{HOME}/.saferc"

--- a/bin/genesis
+++ b/bin/genesis
@@ -18,7 +18,7 @@ use JSON::PP qw/encode_json/;
 # dependencies have to be placed in lib/
 
 # core modules
-use Getopt::Long qw/GetOptionsFromArray :config no_ignore_case bundling/;
+use Getopt::Long qw/GetOptionsFromArray/;
 use File::Temp qw/tempdir tempfile/;
 use File::Basename qw/dirname basename/;
 use File::Path qw/rmtree/;
@@ -468,6 +468,7 @@ EOF
 sub options {
 	my ($args, $options, @spec) = @_;
 	$options->{color} = 1 unless exists $options->{color};
+	Getopt::Long::Configure(qw(no_pass_through permute auto_abbrev no_ignore_case bundling));
 	GetOptionsFromArray($args, $options,
 		(qw/
 			help|h

--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -69,7 +69,7 @@ sub load {
 	# reconstitute our kit via top
 	my $kit_name = $env->lookup('kit.name');
 	my $kit_version = $env->lookup('kit.version');
-	$env->{kit} = $env->{top}->find_kit($kit_name, $kit_version)
+	$env->{kit} = $env->{top}->local_kit_version($kit_name, $kit_version)
 			or bail "Unable to locate v$kit_version of `$kit_name` kit for '$env->{name}' environment.";
 
 	my $min_version = $env->lookup(['genesis.min_version','params.genesis_version_min'],'');
@@ -910,7 +910,7 @@ things like the `new` hook:
     my $env = Genesis::Env->create(
        top  => $top,
        name => 'us-west-1-preprod',
-       kit  => $top->find_kit('some-kit', 'latest'),
+       kit  => $top->local_kit_version('some-kit', 'latest'),
     );
 
 It can optionally take the `vault` and `secrets_path` option to specify the vault name

--- a/lib/Genesis/Kit/Compiled.pm
+++ b/lib/Genesis/Kit/Compiled.pm
@@ -9,9 +9,10 @@ use Genesis::Helpers;
 sub new {
 	my ($class, %opts) = @_;
 	bless({
-		name    => $opts{name},
-		version => $opts{version},
-		archive => $opts{archive},
+		name     => $opts{name},
+		version  => $opts{version},
+		archive  => $opts{archive},
+		provider => $opts{provider},
 	}, $class);
 }
 

--- a/lib/Genesis/Kit/Compiler.pm
+++ b/lib/Genesis/Kit/Compiler.pm
@@ -152,8 +152,8 @@ author:  $user <$email>
 docs:    https://github.com/cloudfoundry-community/$name-boshrelease
 code:    https://github.com/genesis-community/$name-genesis-kit
 
-# 2.6.0 was our last big feature bump
-genesis_version_min: 2.6.0
+# 2.7.0 was our last big feature bump
+genesis_version_min: 2.7.0
 DONE
 
 # }}}
@@ -268,17 +268,23 @@ set -eu
 # Genesis Kit `new' Hook
 #
 
-cat <<EOF >\$GENESIS_ROOT/\$GENESIS_ENVIRONMENT.yml
+(
+cat <<EOF
 kit:
   name:    \$GENESIS_KIT_NAME
   version: \$GENESIS_KIT_VERSION
   features:
     - (( replace ))
 
-params:
-  env:   \$GENESIS_ENVIRONMENT
-  vault: \$GENESIS_VAULT_PREFIX
 EOF
+
+genesis_config_block
+
+cat <<EOF
+params: {}
+EOF
+) >\$GENESIS_ROOT/\$GENESIS_ENVIRONMENT.yml
+
 exit 0
 DONE
 

--- a/lib/Genesis/Kit/Provider.pm
+++ b/lib/Genesis/Kit/Provider.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Genesis;
 use Genesis::Helpers;
-use Getopt::Long qw/GetOptionsFromArray :config pass_through no_auto_abbrev no_ignore_case bundling/;
+use Getopt::Long qw/GetOptionsFromArray/;
 
 ### Class Methods {{{
 
@@ -79,8 +79,13 @@ EOF
 # parse_opts - parses options based on the type of kit provider specified {{{
 sub parse_opts {
 	my ($class,$args,$kit_opts) = @_;
+  Getopt::Long::Configure(qw(pass_through permute no_auto_abbrev no_ignore_case bundling));
 
-	GetOptionsFromArray($args, $kit_opts, qw/kit-provider=s/);
+	# Make sure to stop once a '--' is encountered.
+	my $opt_args = [];
+	while (scalar(@$args) && $args->[0] ne '--') {push(@$opt_args, shift(@$args))};
+
+	GetOptionsFromArray($opt_args, $kit_opts, qw/kit-provider=s/);
 	my $type = $kit_opts->{'kit-provider'};
 
 	my @extra_opts = ();
@@ -94,7 +99,10 @@ sub parse_opts {
 		bail("Unknown kit provider type '$type'");
 	}
 
-	GetOptionsFromArray($args, $kit_opts, @extra_opts) if scalar(@extra_opts);
+	GetOptionsFromArray($opt_args, $kit_opts, @extra_opts) if scalar(@extra_opts);
+
+	# Shove the non-opts back into the args passed in
+	while (scalar(@$opt_args)) {unshift(@$args,pop(@$opt_args))};
 
 	return 1;
 }

--- a/lib/Genesis/Kit/Provider.pm
+++ b/lib/Genesis/Kit/Provider.pm
@@ -1,0 +1,307 @@
+package Genesis::Kit::Provider;
+use strict;
+use warnings;
+
+use Genesis;
+use Genesis::Helpers;
+use Getopt::Long qw/GetOptionsFromArray :config pass_through no_auto_abbrev no_ignore_case bundling/;
+
+### Class Methods {{{
+
+# new -  builder for creating new instance of derived class based on config {{{
+sub new {
+	my ($class,%config) = @_;
+	bug("%s->new is calling %s->new illegally",$class, __PACKAGE__)
+		if ($class ne __PACKAGE__);
+
+	if (!%config || !defined($config{type}) || $config{type} eq "genesis_community") {
+		use Genesis::Kit::Provider::GenesisCommunity;
+		return Genesis::Kit::Provider::GenesisCommunity->new(%config);
+	} elsif ($config{type} eq 'github') {
+		use Genesis::Kit::Provider::Github;
+		return Genesis::Kit::Provider::Github->new(%config);
+	} else {
+		bail("Unknown kit provider type '$config{type}'");
+	}
+}
+
+# }}}
+# init - builder for creating new instance based on options {{{
+sub init {
+	my ($class, %opts) = @_;
+	bug("%s->init is calling %s->init illegally",$class, __PACKAGE__)
+		if ($class ne __PACKAGE__);
+
+	if (!defined($opts{'kit-provider'}) || $opts{'kit-provider'} eq "genesis-community") {
+		use Genesis::Kit::Provider::GenesisCommunity;
+		return Genesis::Kit::Provider::GenesisCommunity->init(%opts);
+	} elsif ($opts{'kit-provider'} eq 'github') {
+		use Genesis::Kit::Provider::Github;
+		return Genesis::Kit::Provider::Github->init(%opts);
+	} else {
+		bail("Unknown kit provider type '$opts{'kit-provider'}'");
+	}
+}
+
+# }}}
+# opts -  list of options supported by init method {{{
+sub opts {
+	qw/
+		/;
+}
+
+# }}}
+# opts_help - specifies the new/update options understood by this provider {{{
+sub opts_help {
+	my ($class,%config) = @_;
+	bug("%s->new is calling %s->new illegally",$class, __PACKAGE__)
+		if ($class ne __PACKAGE__);
+	use Genesis::Kit::Provider::Github;
+
+	<<EOF
+KIT PROVIDERS
+
+By default, kits are available from the Genesis Community Github organizations,
+which requires no further options.  However, the following kit provider types
+are available.
+
+  General Kit Provider Options:
+
+    --kit-provider <type> (optional, defaults to "genesis-community")
+        The type of kit provider you want to use.  Each provider has further
+        options it accepts.
+
+${\Genesis::Kit::Provider::Github->opts_help()}
+EOF
+}
+
+# }}}
+# parse_opts - parses options based on the type of kit provider specified {{{
+sub parse_opts {
+	my ($class,$args,$kit_opts) = @_;
+
+	GetOptionsFromArray($args, $kit_opts, qw/kit-provider=s/);
+	my $type = $kit_opts->{'kit-provider'};
+
+	my @extra_opts = ();
+	if (!$type || $type eq 'genesis-community') {
+		use Genesis::Kit::Provider::GenesisCommunity;
+		@extra_opts = Genesis::Kit::Provider::GenesisCommunity->opts();
+	} elsif ($type eq 'github') {
+		use Genesis::Kit::Provider::Github;
+		@extra_opts =  Genesis::Kit::Provider::Github->opts();
+	} else {
+		bail("Unknown kit provider type '$type'");
+	}
+
+	GetOptionsFromArray($args, $kit_opts, @extra_opts) if scalar(@extra_opts);
+
+	return 1;
+}
+
+# }}}
+
+# }}}
+
+### Instance Methods {{{
+
+# config - provides the config hash used to specify this provider (abstract) {{{
+sub config {
+	my ($self) = @_;
+	bug("Abstract Method: Expecting %s class to define concrete '%' method", ref($self), 'config');
+	# Input expected:
+	#		No arguments>
+	#
+	# Output expected:
+	#   Hash of config items that would be expected to create an object of this
+	#   class as arguments to its new method
+	
+}
+# }}}
+# check - checks the availability of this provider (abstract) {{{
+sub check {
+	my ($self) = @_;
+	bug("Abstract Method: Expecting %s class to define concrete '%' method", ref($self), 'config');
+	# Input expected:
+	#		No arguments, but can allow alternate url>
+	#
+	# Output expected:
+	#   Error message if error encountered, otherwise undef or empty string
+}
+
+# }}}
+# kit_names - retrieves list of kit names available from this provider (abstract) {{{
+sub kit_names {
+	my ($self, $filter) = @_;
+	bug("Abstract Method: Expecting %s class to define concrete '%' method", ref($self), 'kits');
+	# Input expected:
+	#		$filter <regular expression to match kit names against>
+	#
+	# Output expected:
+	#   List of kit names as strings, not including the '-genesis-kit' suffix.
+	
+}
+
+# }}}
+# kit_releases - retrieves a list of releases for a kit (abstract) {{{
+sub kit_releases {
+	# TODO: This should create (and cache) a list of Genesis::Kit:<Provider-centric-remote-type>
+	my ($self, $name) = @_;
+	bug("Abstract Method: Expecting %s class to define concrete '%' method", ref($self), 'kit_releases');
+	# Input expected:
+	#		$name: <kit name>
+	#
+	# Output expected:
+	#   List of release objects, definition determined by provider class.
+}
+
+# }}}
+# kit_versions - retrieves a list of versions for the given kit name (abstract) {{{
+sub kit_versions {
+	my ($self, $name, %opts) = @_;
+	bug("Abstract Method: Expecting %s class to define concrete '%' method", ref($self), 'kit_versions');
+	# Input expected:
+	#		$name: <kit name>
+	#		%opts: Hash that must except at least:
+	#		  draft:      <boolean: include draft releases>
+	#		  prerelease: <boolean: include draft releases>
+	#		  latest:     <integer: number of versions to retrieve, decending order of version>
+	#
+	# Output expected:
+	#   [
+	#     {
+	#       version:    <semver>,
+	#       body:       <release notes>,
+	#       draft:      <boolean: version is a draft>,
+	#       prerelease: <boolean: version is a draft>,
+	#       date:       <date of release creation>,
+	#       url:        <optional: download url>
+	#     }, ...
+	#   ]
+}
+
+# }}}
+# fetch_kit_version - fetches a tarball for the named kit and version from this provide (abstract) {{{
+sub fetch_kit_version {
+	my ($self, $name, $version, $path) = @_;
+	bug("Abstract Method: Expecting %s class to define concrete '%' method", ref($self), 'fetch_kit_version');
+	# Input expected:
+	#		$name:    <kit name>
+	#		$version: <kit version, or 'latest'>
+	#		$path:    <directory to store kit tarball>
+	#
+	# Output expected:
+	#   ( <kit_name>, <actual_version>, <path/filename to where tarball was saved> )
+}
+# }}}
+# latest_version_of - The latest version number,  {{{
+sub latest_version_of {
+	my ($self, $name, %opts) = @_;
+	bail("Missing name for retrieving kit releases") unless $name;
+	my $version = ($self->kit_versions($name, latest => 1, %opts))[0];
+	return $version && $version->{version};
+}
+
+# }}}
+# kit_version_info - The version information for a specific version {{{
+sub kit_version_info {
+	my ($self, $name, $version) = @_;
+	bail("Missing name for retrieving kit releases") unless $name;
+	($self->kit_versions($name, version => $version))[0];
+}
+
+# }}}
+
+# }}}
+
+1;
+
+=head1 NAME
+
+Genesis::Kit::Provider
+
+=head1 DESCRIPTION
+
+This class represents a Genesis Kit Provider.  This provider knows how to list
+and fetch kits and their versions provided by that provider.
+
+=head1 CONSTRUCTORS
+
+=head2 new($path)
+
+Instantiates a new dev kit, using source files in C<$path>.
+
+=head2 downloadable($filter)
+
+Lists the known downloadable compiled kits on the Genesis Community Github
+organization.  If a filter is given, it will be used to limit the kit names to
+match that filter as a regular expression.
+
+An error will be thrown if it cannot reach the github api endpoint for
+genesis-community organization, if the response is not valid JSON, or for
+any other communication error.
+
+=head2 releases($name)
+
+Returns the list of releases for a given repository under the Genesis Community
+Github organization.  This is the full response from Github, converted from
+JSON, and includes all the information for all releases under the given
+repository.  This is primarily a low-level function for C<url> and C<versions>
+
+An error will be thrown if it cannot reach the github api endpoint for
+genesis-community organization, if the repository does not exist,  if the
+response is not valid JSON, or for any other communication error.
+
+=head2 versions($name)
+
+Returns a hash of tag,name,draft,prerelease,body and timestamp for each version
+for the named repository under the Genesis Community Github organization.
+
+An error will be thrown if it cannot reach the github api endpoint for
+genesis-community organization, if the repository does not exist,  if the
+response is not valid JSON, or for any other communication error.
+
+=head2 url($name, $version)
+
+Determines the download URL for this kit, by consulting Github.
+Right now, this is limited to just the C<genesis-community> organization.
+
+If you omit C<$version>, or set it to "latest", the most recent released
+version on Github will be used.  Otherwise, the URL for the given version
+will be used.
+
+An error will be thrown if the version in question does not exist on Github.
+
+
+=head1 METHODS
+
+=head2 id()
+
+Returns the identity of the dev kit, which is always C<(dev kit)>.  This is
+useful for error messages and reporting.
+
+=head2 name()
+
+Returns the name of the dev kit, which is always C<dev>.
+
+=head2 version()
+
+Returns the version of the dev kit, which is always C<latest>.
+
+=head2 kit_bug($fmt, ...)
+
+Prints an error to the screen, complete with details about how the problem
+at hand is a problem with the (local) development kit.
+
+=head2 extract()
+
+Copies the contents of the dev/ working directory to a temporary workspace,
+and installs the Genesis hooks helper script.  The copy is done to avoid
+accidental modifications to pristine dev kit sources, and to ensure that we
+can safely write the hooks helper.
+
+This method is memoized; subsequent calls to C<extract> will not re-copy the
+dev/ working directory to the temporary workspace.
+
+=cut
+# vim: fdm=marker:foldlevel=1:noet

--- a/lib/Genesis/Kit/Provider.pm
+++ b/lib/Genesis/Kit/Provider.pm
@@ -74,12 +74,14 @@ sub opts_help {
 	use Genesis::Kit::Provider::GenesisCommunity;
 	use Genesis::Kit::Provider::Github;
 
+	$config{type_default_msg} ||= '(optional, defaults to "genesis-community")';
+	$config{valid_types} ||= [qw(genesis-community github)];
+
 	<<EOF
 KIT PROVIDERS
 
-By default, kits are available from the Genesis Community Github organizations,
-which requires no further options.  However, the following kit provider types
-are available.
+While the Genesis Community Github organization is the primary source, kits are
+available from various kit providers, each requiring their specific options.
 
   General Kit Provider Options:
 
@@ -92,8 +94,9 @@ are available.
         specify an existing configuration to use, or an existing Genesis
         deployment repository.
 
-${\Genesis::Kit::Provider::GenesisCommunity->opts_help()}
-${\Genesis::Kit::Provider::Github->opts_help()}
+${\Genesis::Kit::Provider::GenesisCommunity->opts_help(%config)
+}${\Genesis::Kit::Provider::Github->opts_help(%config)
+}
 EOF
 }
 

--- a/lib/Genesis/Kit/Provider.pm
+++ b/lib/Genesis/Kit/Provider.pm
@@ -56,6 +56,7 @@ sub opts_help {
 	my ($class,%config) = @_;
 	bug("%s->new is calling %s->new illegally",$class, __PACKAGE__)
 		if ($class ne __PACKAGE__);
+	use Genesis::Kit::Provider::GenesisCommunity;
 	use Genesis::Kit::Provider::Github;
 
 	<<EOF
@@ -71,6 +72,7 @@ are available.
         The type of kit provider you want to use.  Each provider has further
         options it accepts.
 
+${\Genesis::Kit::Provider::GenesisCommunity->opts_help()}
 ${\Genesis::Kit::Provider::Github->opts_help()}
 EOF
 }

--- a/lib/Genesis/Kit/Provider/GenesisCommunity.pm
+++ b/lib/Genesis/Kit/Provider/GenesisCommunity.pm
@@ -1,0 +1,146 @@
+package Genesis::Kit::Provider::GenesisCommunity;
+use strict;
+use warnings;
+
+use base 'Genesis::Kit::Provider::Github';
+use Genesis;
+use Genesis::Helpers;
+
+### Class Methods {{{
+
+# init - creates a new provider on repo init or change {{{
+sub init {
+	$_[0]->new();
+}
+
+# }}}
+# new - create a default genesis-community kit provider {{{
+sub new {
+	my ($class, %config) = @_;
+	my $credentials;
+	if ($ENV{GITHUB_USER} && $ENV{GITHUB_AUTH_TOKEN}) {
+		$credentials = "$ENV{GITHUB_USER}:$ENV{GITHUB_AUTH_TOKEN}";
+	}
+	bless({
+		domain        => "github.com",
+		organization  => "genesis-community",
+		credentials   => $credentials,
+		label         => "Genesis Community organization on Github",
+		tls           => "yes"
+	}, $class);
+}
+
+# }}}
+# opts -  list of options supported by init method {{{
+sub opts {
+	qw//;
+}
+
+# }}}
+# opts_help - specifies the new/update options understood by this provider {{{
+sub opts_help {
+
+	<<EOF
+  GenesisCommunity Kit Provider Options:
+    This provider doesn't take any further options.
+EOF
+}
+# }}}
+
+### Instance Methods {{{
+
+# config - provides the config hash used to specify this provider {{{
+sub config {
+	my ($self) = @_;
+	my $config = {
+		type         => 'genesis-community',
+	};
+	return %$config;
+}
+# }}}
+# status - The human-understandable label for messages and errors {{{
+sub status {
+	my ($self,$verbose) = @_;
+	my %info = $self->SUPER::status($verbose);
+
+	my $new_info = {
+		type      => 'genesis-community',
+		extras     => ["Source"],
+		"Source"   => $self->{label},
+		status    => $info{status},
+		kits      => $info{kits}
+	};
+	return %$new_info;
+}
+
+# }}}
+
+# Rest inherited from Genesis::Kit::Provider::Github
+
+# }}}
+1;
+
+=head1 NAME
+
+Genesis::Kit::Provider::Default
+
+=head1 DESCRIPTION
+
+This class represents a compiled kit, and its distribution as a tarball
+archive.  Most operators use kits in this format.
+
+=head1 CONSTRUCTORS
+
+=head2 new(%opts)
+
+Instantiates a new Kit::Compiled object.
+
+The following options are recognized:
+
+=over
+
+=item name
+
+The name of the kit.  This option is B<required>.
+
+=item version
+
+The version of the kit.  This option is B<required>.
+
+=item archive
+
+The absolute path to the compiled kit tarball.  This option is B<required>.
+
+=back
+
+
+=head1 METHODS
+
+=head2 id()
+
+Returns the identity of the kit, in the form C<$name/$verison>.  This is
+useful for error messages and reporting.
+
+=head2 name()
+
+Returns the name of the kit.
+
+=head2 version()
+
+Returns the version of the kit.
+
+=head2 kit_bug($fmt, ...)
+
+Prints an error to the screen, complete with details about how the problem
+at hand is not the operator's fault, and that they should file a bug against
+the kit's Github page, or contact the authors.
+
+=head2 extract()
+
+Extracts the compiled kit tarball to a temporary workspace, and installs the
+Genesis hooks helper script.
+
+This method is memoized; subsequent calls to C<extract> will have no effect.
+
+=cut
+# vim: fdm=marker:foldlevel=1:noet

--- a/lib/Genesis/Kit/Provider/GenesisCommunity.pm
+++ b/lib/Genesis/Kit/Provider/GenesisCommunity.pm
@@ -41,8 +41,11 @@ sub opts {
 sub opts_help {
 
 	<<EOF
-  GenesisCommunity Kit Provider Options:
-    This provider doesn't take any further options.
+  Kit Provider `genesis-community`:
+
+    This is a singleton kit provider type that points to the Genesis Community
+    collection of kits hosted on github.com/genesis-community - it is the
+    default provider type and doesn't take any further options.
 EOF
 }
 # }}}

--- a/lib/Genesis/Kit/Provider/GenesisCommunity.pm
+++ b/lib/Genesis/Kit/Provider/GenesisCommunity.pm
@@ -39,6 +39,8 @@ sub opts {
 # }}}
 # opts_help - specifies the new/update options understood by this provider {{{
 sub opts_help {
+	my ($self,%config) = @_;
+	return '' unless grep {$_ eq 'genesis-community'} (@{$config{valid_types}});
 
 	<<EOF
   Kit Provider `genesis-community`:
@@ -46,6 +48,7 @@ sub opts_help {
     This is a singleton kit provider type that points to the Genesis Community
     collection of kits hosted on github.com/genesis-community - it is the
     default provider type and doesn't take any further options.
+
 EOF
 }
 # }}}

--- a/lib/Genesis/Kit/Provider/Github.pm
+++ b/lib/Genesis/Kit/Provider/Github.pm
@@ -35,7 +35,7 @@ sub init {
 }
 
 # }}}
-# new - create a default genesis-community kit provider {{{
+# new - create a default github kit provider {{{
 sub new {
 	my ($class, %config) = @_;
 	my $credentials;
@@ -59,12 +59,15 @@ sub opts {
 		kit-provider-domain=s
 		kit-provider-org=s
 		kit-provider-tls=s
+		kit-provider-access-token=s
 		/;
 }
 
 # }}}
 # opts_help - specifies the new/update options understood by this provider {{{
 sub opts_help {
+	my ($self,%config) = @_;
+	return '' unless grep {$_ eq 'github'} (@{$config{valid_types}});
 	<<EOF
   Kit Provider `github`:
 

--- a/lib/Genesis/Kit/Provider/Github.pm
+++ b/lib/Genesis/Kit/Provider/Github.pm
@@ -1,0 +1,430 @@
+package Genesis::Kit::Provider::Github;
+use strict;
+use warnings;
+
+use base 'Genesis::Kit::Provider';
+use Genesis;
+use Genesis::Helpers;
+
+use constant {
+	DEFAULT_DOMAIN => 'github.com',
+	DEFAULT_LABEL  => "Custom Github-based Kit Provider",
+	DEFAULT_TLS    => 'yes'
+};
+
+### Class Methods {{{
+
+# init - creates a new provider on repo init or change {{{
+sub init {
+	my ($class, %opts) = @_;
+	my $label = $opts{"kit-provider-name"} || DEFAULT_LABEL;
+
+	bail("$label kit provider requires specifying the organization using the --kit-provider-org option")
+		unless $opts{"kit-provider-org"};
+	
+	$opts{"kit-provider-tls"} ||= DEFAULT_TLS;
+	bail("Github kit provider option --kit-provider-tls only accepts: no, yes, and skip")
+		unless $opts{"kit-provider-tls"} =~ /^(no|yes|skip)$/;
+	$class->new(
+		type         => 'github',
+		label         => $label,
+		domain       => $opts{'kit-provider-domain'},
+		organization => $opts{'kit-provider-org'},
+		tls          => $opts{'kit-provider-tls'}
+	);
+}
+
+# }}}
+# new - create a default genesis-community kit provider {{{
+sub new {
+	my ($class, %config) = @_;
+	my $credentials;
+	if ($ENV{GITHUB_USER} && $ENV{GITHUB_AUTH_TOKEN}) {
+		$credentials = "$ENV{GITHUB_USER}:$ENV{GITHUB_AUTH_TOKEN}";
+	}
+	bless({
+		domain          => $config{domain} || DEFAULT_DOMAIN,
+		organization    => $config{organization},
+		credentials     => $credentials,
+		label           => $config{label} || DEFAULT_LABEL,
+		tls             => $config{tls} || DEFAULT_TLS,
+	}, $class);
+}
+
+# }}}
+# opts -  list of options supported by init method {{{
+sub opts {
+	qw/
+		kit-provider-name=s
+		kit-provider-domain=s
+		kit-provider-org=s
+		kit-provider-tls=s
+		/;
+}
+
+# }}}
+# opts_help - specifies the new/update options understood by this provider {{{
+sub opts_help {
+	<<EOF
+  Github Kit Provider `github` - supports the following options:
+
+    --kit-provider-name <value> (optional, defaults to "Custom Github-based kit provider")
+        Provide an understandable label that will be used to refer to this
+        provider in messages
+
+    --kit-provider-domain <value> (optional, defaults to "github.com")
+        If you are using Github Enterprise, specify your github domain, without
+        the www or api subdomain.
+
+    --kit-provider-org <value> (required)
+        The name of your github organization that owns the kit repositories.
+
+    --kit-provider-tls <value> (optional, defaults to 'yes')
+        Use this option to configure tls:
+          no   - uses http protocol.
+          yes  - uses https protocol and validates certificate.
+          skip - uses https protocol, but skips validation.
+EOF
+}
+
+# }}}
+# }}}
+
+### Instance Methods {{{
+
+# config - provides the config hash used to specify this provider {{{
+sub config {
+	my ($self) = @_;
+	my $config = {
+		type         => 'github',
+		organization => $self->{organization},
+	};
+	$config->{label}   = $self->{label} unless $self->{label} eq DEFAULT_LABEL;
+	$config->{tls}    = $self->{tls} unless $self->{tls} eq DEFAULT_TLS;
+	$config->{domain} = $self->{domain} unless $self->{domain} eq DEFAULT_DOMAIN;
+	return %$config;
+}
+# }}}
+# check - checks the availability of this provider {{{
+sub check {
+	my ($self, $url) = @_;
+	my $ref = $self->label();
+	my $status;
+	$url ||= $self->repos_url;
+	my ($code, $msg) = curl("HEAD", $url, undef, undef, 0, $self->{credentials});
+	if ($code == 404) {
+		$status =  "Could not find $ref; are you able to route to the Internet?\n";
+	} elsif ($code == 403) {
+		$status = "Access forbidden trying to reach $ref; throttling may be in effect.  Set your GITHUB_USER and GITHUB_AUTH_TOKEN to prevent throttling.\n";
+	} elsif ($code != 200) {
+		$status = "Could not read $ref at $url; returned ($code):\n ".$msg."\n";
+	}
+	return wantarray ? ($code,$status) : $status;
+}
+
+# }}}
+# kits - retrieves list of kit names available from this provider {{{
+sub kit_names {
+	my ($self, $filter) = @_;
+
+	unless (defined($self->{_kits})) {
+		my $status = $self->check;
+		bail $status."\n" if $status;
+
+		my ($code, $msg, $data) = curl("GET", $self->repos_url, undef, undef, 0, $self->{credentials});
+		my $results;
+		eval {
+			$results = load_json($data);
+			1
+		} or bail("Failed to read repository information from %s: %s", $self->label, $@);
+
+		$self->{_kits} = [
+			map  {(my $k = $_) =~ s/-genesis-kit$//; $k}
+			grep {$_ =~ qr/.*-genesis-kit$/}
+			map  {$_->{name}}
+			@$results
+		]
+	}
+	my @kits = @{$self->{_kits}};
+
+	@kits = grep {$_ =~ qr/$filter/} @kits if $filter;
+	return @kits if scalar(@kits);
+
+	my $err = "No genesis kit repositories found on $self->{label}";
+	$err .= "that match the pattern /$filter/" if $filter;
+	$err .= "\nYou will need to provide your credentials via GITHUB_USER and GITHUB_AUTH_TOKEN to see private repositories"
+		unless $self->{credentials};
+	bail $err."\n";
+}
+
+# }}}
+# releases - retrieves a list of releases for a kit {{{
+sub kit_releases {
+	my ($self, $name) = @_;
+
+	bail("Missing name for retrieving kit releases") unless $name;
+
+	$self->{_releases} ||= {};
+	unless (defined($self->{_releases}{$name})) {
+		my $url =	$self->releases_url($name);
+		my ($code, $status) = $self->check($url);
+		if ($code == 404) {
+			# Check if kit exists, for a better error message
+			my $kits = $self->kit_names;
+			if (! grep {$_ eq $name} ($self->kit_names)) {
+				$status = "No kit named #C{$name} exists under $self->{label}";
+			}
+		}
+		bail "$status"."\n" if $status;
+
+		my ($msg,$data);
+		($code, $msg, $data) = curl("GET", $url, undef, undef, 0, $self->{credentials});
+		bail("Could not find Genesis Kit %s release information; Github rsponded with a %s status:\n%s",$name,$code,$msg)
+		unless $code == 200;
+
+		my $results;
+		eval {
+			$results = load_json($data);
+			1 
+		} or bail("Failed to read releases information from Github: %s\n",$@);
+		$self->{_releases}{$name} = $results;
+	}
+
+	return @{$self->{_releases}{$name}};
+}
+
+# }}}
+# kit_versions - retrieves a list of versions for the given kit name {{{
+sub kit_versions {
+	my ($self, $name, %opts) = @_;
+
+	# If specific version is specified, normalize it, and don't filter out drafts
+	# or prereleases
+	if ($opts{version}) {
+		if ($opts{version} eq 'latest') {
+			$opts{latest} = 1;
+			$opts{version} = undef;
+		} else {
+			$opts{version} =~ s/^v//;
+			$opts{drafts} = $opts{prerelease} = 1;
+		}
+	}
+
+	my @releases =
+		grep {!$opts{version}   || $_->{tag_name} =~qr/^v?$opts{version}$/}
+		grep {!$_->{draft}      || $opts{'include_drafts'}}
+		grep {!$_->{prerelease} || $opts{'include_prereleases'}}
+		$self->kit_releases($name);
+
+	if (defined $opts{latest}) {
+		my $latest = $opts{latest} || 1;
+		my @versions = (reverse sort by_semver (map {$_->{tag_name}} @releases))[0..($latest-1)];
+		@releases = grep {my $v = $_->{tag_name}; grep {$_ eq $v} @versions} @releases;
+	}
+	return map {
+		my $r = $_;
+		(my $v = $r->{tag_name}) =~ s/^v//;
+		my $url = (map {$_->{browser_download_url}} grep {$_->{name} =~ /$name-$v\.t(ar\.)?gz/} @{$r->{assets}})[0];
+		scalar({
+			version => $v,
+			body => $r->{body},
+			draft=> !!$r->{draft},
+			prerelease => !!$r->{prerelease},
+			date => $r->{published_at} || $r->{created_at},
+			url => $url || ""
+		});
+	} @releases;
+}
+
+# }}}
+# fetch_kit_version - fetches a tarball for the named kit and version from this provide {{{
+sub fetch_kit_version {
+	my ($self, $name, $version, $path) = @_;
+
+	if (!defined($version) || $version eq 'latest') {
+		# Better to call `latest_version` prior to this, but this is a safety valve.
+		$version = $self->latest_version_of($name);
+		bail("No latest version of $name kit found with a downloadable release")
+			unless $version;
+	} else {
+		$version =~ s/^v//;
+	}
+
+	my $version_info = (
+		grep {$_->{version} eq $version}
+		grep {$_->{url}}
+		$self->kit_versions($name, include_drafts => 1, include_prereleases => 1)
+	)[0];
+	bail "Version $name/$version was not found" unless $version_info && ref($version_info) eq 'HASH';
+	
+	my $url = $version_info->{url};
+	bail "Version $name/$version does not have a downloadable release\n" unless $url;
+
+	my ($code, $msg, $data) = curl("GET", $url);
+	bail "Failed to download %s/%s from %s: returned a %s status code\n", $name, $version, $self->label, $code
+		unless $code == 200;
+
+	my $file = "$path/$name-$version.tar.gz";
+	mkfile_or_fail($file, 0400, $data);
+	debug("downloaded kit #M{%s}/#C{%s}: %s bytes", $name, $version, length($data));
+
+	return ($name,$version,$file);
+}
+# }}}
+# latest_kit_version - The human-understandable label for messages and errors {{{
+sub latest_version_of {
+	my ($self, $name, %opts) = @_;
+	bail("Missing name for retrieving kit releases") unless $name;
+	my $version = (
+		grep {$_->{url}}
+		$self->kit_versions($name, include_drafts => $opts{include_drafts}, include_prerelease => $opts{include_prereleases})
+	)[0];
+	return $version && $version->{version};
+}
+
+# }}}
+# status - The human-understandable label for messages and errors {{{
+sub status {
+	my ($self,$verbose) = @_;
+	my ($code,$msg) = $self->check();
+
+	# Reinterperete message for clearer status
+	if ($code == 404) {
+		($code,$msg) = $self->check($self->base_url);
+		if ($code == 404) {
+			$msg = "Cannot find API endpoint for $self->{domain}";
+		} else {
+			$msg = "Cannot find organization $self->{organization} on $self->{domain}";
+		}
+	} elsif ($code == 403 && !$self->{credentials}) {
+		$msg = "Unable to access - throttling may be effect, or you may not have permission to access this organization.  Credentials may need to be set in environment vars GITHUB_USER & GITHUB_AUTH_TOKEN";
+	} elsif ($code != 200) {
+		$msg =~ s/^.*:/HTTP Error $code while accessing:/;
+	}
+
+	my $kits;
+	if ($code == 200) {
+		# Get kit counts
+		my @kit_names = sort $self->kit_names;
+		if ($verbose) {
+			$kits = {};
+			for my $name (@kit_names) {
+				waiting_on('.');
+				my @releases = $self->kit_releases($name);
+				my $num_drafts = scalar(grep {$_->{draft}} @releases);
+				my $num_prereleases = scalar(grep {!$_->{draft} && $_->{prerelease}} @releases);
+				my $num_releases = scalar(@releases) - $num_prereleases - $num_drafts;
+				$kits->{$name}      = sprintf("#%s{%d release%s}", ($num_releases ? "G" : "R"), $num_releases, $num_releases == 1 ? "" : "s") .
+					($num_prereleases ? sprintf(", %d pre-release%s", $num_prereleases, $num_prereleases == 1 ? "" : "s") : '') .
+					($num_drafts      ? sprintf(", %d draft%s", $num_drafts, $num_drafts == 1 ? "" : "s") : '');
+			}
+		} else {
+			$kits = [@kit_names];
+		}
+	}
+
+	my $info = {
+		type      => 'github',
+		extras    => ["Name", "Domain", "Org", "Use TLS"],
+		"Name"    => $self->{label},
+		"Domain"  => $self->{domain},
+		"Org"     => $self->{organization},
+		"Use TLS" => $self->{tls},
+
+		status    => $msg || 'ok',
+		kits      => $kits
+	};
+	return %$info;
+}
+
+# }}}
+# label - The human-understandable label for messages and errors {{{
+sub label {
+	$_[0]->{label};
+}
+
+# }}}
+# repos_url - The url required to fetch the repos for this provider {{{
+sub repos_url {
+	sprintf("%s/users/%s/repos", $_[0]->base_url, $_[0]->{organization})
+}
+
+# }}}
+# releases_url - The url required to fetch the list of releases for a given kit on this provider {{{
+sub releases_url {
+	my ($self, $name) = @_;
+	sprintf("%s/repos/%s/%s-genesis-kit/releases",$self->base_url,$self->{organization},$name);
+}
+# }}}
+# base_url - the base url under which all requests are made {{{
+sub base_url {
+	my ($self) = @_;
+	sprintf("%s://api.%s", ($self->{tls} eq 'no' ? "http" : "https"), $self->{domain});
+}
+# }}}
+
+# }}}
+1;
+
+=head1 NAME
+
+Genesis::Kit::Provider::Github
+
+=head1 DESCRIPTION
+
+
+=head1 CONSTRUCTORS
+
+=head2 new(%opts)
+
+Instantiates a new Kit::Compiled object.
+
+The following options are recognized:
+
+=over
+
+=item name
+
+The name of the kit.  This option is B<required>.
+
+=item version
+
+The version of the kit.  This option is B<required>.
+
+=item archive
+
+The absolute path to the compiled kit tarball.  This option is B<required>.
+
+=back
+
+
+=head1 METHODS
+
+=head2 id()
+
+Returns the identity of the kit, in the form C<$name/$verison>.  This is
+useful for error messages and reporting.
+
+=head2 name()
+
+Returns the name of the kit.
+
+=head2 version()
+
+Returns the version of the kit.
+
+=head2 kit_bug($fmt, ...)
+
+Prints an error to the screen, complete with details about how the problem
+at hand is not the operator's fault, and that they should file a bug against
+the kit's Github page, or contact the authors.
+
+=head2 extract()
+
+Extracts the compiled kit tarball to a temporary workspace, and installs the
+Genesis hooks helper script.
+
+This method is memoized; subsequent calls to C<extract> will have no effect.
+
+=cut
+# vim: fdm=marker:foldlevel=1:noet

--- a/lib/Genesis/Kit/Provider/Github.pm
+++ b/lib/Genesis/Kit/Provider/Github.pm
@@ -66,7 +66,11 @@ sub opts {
 # opts_help - specifies the new/update options understood by this provider {{{
 sub opts_help {
 	<<EOF
-  Github Kit Provider `github` - supports the following options:
+  Kit Provider `github`:
+
+    This is a generic kit provider type for kits backed by Github or Github
+    Enterprise, allowing you to specify the domain url and organization to
+    target your specific provider location.  It supports the following options:
 
     --kit-provider-name <value> (optional, defaults to "Custom Github-based kit provider")
         Provide an understandable label that will be used to refer to this

--- a/lib/Genesis/Top.pm
+++ b/lib/Genesis/Top.pm
@@ -6,6 +6,7 @@ use Genesis;
 use Genesis::Env;
 use Genesis::Kit::Compiled;
 use Genesis::Kit::Dev;
+use Genesis::Kit::Provider;
 use Genesis::Vault;
 
 use Cwd ();
@@ -50,9 +51,14 @@ sub create {
 	eval { # to delete path if creation fails
 
 		# Write new configuration
-		$self->_write_config($name, $Genesis::VERSION, Genesis::Vault->target($opts{vault}));
+	$self->_write_config(
+		type         => $name,
+		version      => $Genesis::VERSION,
+		vault        => Genesis::Vault->target($opts{vault}),
+		kit_provider => Genesis::Kit::Provider->init(%opts)
+	);
 
-		$self->mkfile("README.md", # {{{
+	$self->mkfile("README.md", # {{{
 <<EOF);
 $name deployments
 ==============================
@@ -86,48 +92,58 @@ Quickstart
 
 To create a new environment (called us-east-prod-$name):
 
-    genesis new us-east-prod
+  genesis new us-east-prod
 
 To build the full BOSH manifest for an environment:
 
-    genesis manifest us-east-prod
+  genesis manifest us-east-prod
 
 ... and then deploy it:
 
-    genesis deploy us-east-prod
+  genesis deploy us-east-prod
 
 To rotate credentials for an environment:
 
-    genesis rotate-secrets us-east-prod
-    genesis deploy us-east-prod
+  genesis rotate-secrets us-east-prod
+  genesis deploy us-east-prod
 
 To change the secrets provider for the environments in this repo:
 
-    genesis secrets-provider --url https://example.com:8200 --insecure
+  genesis secrets-provider --url https://example.com:8200 --insecure
 
 ... or clear it to use safe's currently targeted vault:
 
-    genesis secrets-provider --clear
+  genesis secrets-provider --clear
+
+By default, the provider for kits is https://github.com/genesis-community, but
+you can set this to another provider url via the `genesis kit-provider`
+command:
+
+  genesis kit-provider https://github.mycorp.com/mygenesiskits
+
+This requires that url to provide releases in the same manner as github does.
+You can see the current kit provider by calling it with no argument, or revert
+back to default with the `--clear` option.
 
 To update the Concourse Pipeline for this repo:
 
-    genesis repipe
+  genesis repipe
 
 To check for updates for this kit:
 
-    genesis list-kits -u
+  genesis list-kits -u
 
 To download a new version of the kit, and deploy it:
 
-    genesis download $name [version] # omitting version downloads the latest
+  genesis download $name [version] # omitting version downloads the latest
 
-    # update the environment yaml to use the desired kit version,
-    # this might be in a different file if using CI to propagate
-    # deployment upgrades (perhaps us.yml)
-    vi us-east-prod.yml
+  # update the environment yaml to use the desired kit version,
+  # this might be in a different file if using CI to propagate
+  # deployment upgrades (perhaps us.yml)
+  vi us-east-prod.yml
 
-    genesis deploy us-east-prod.yml     # or commit + git push to have
-                                        # CI run through the upgrades
+  genesis deploy us-east-prod.yml     # or commit + git push to have
+                                      # CI run through the upgrades
 
 See the [Deployment Pipeline Documentation][3] for more
 information on getting set up with Concourse deployment pipelines.
@@ -171,14 +187,49 @@ EOF
 
 # }}}
 
-	};
-	if ($@) {
-		debug("removing incomplete Genesis deployments repository at #C{$path} due to failed creation");
-		rmtree $path;
-		die $@;
-	}
+};
+if ($@) {
+	debug("removing incomplete Genesis deployments repository at #C{$path} due to failed creation");
+	rmtree $path;
+	die $@;
+}
 
-	return $self;
+return $self;
+}
+
+sub kit_provider {
+
+	my ($self) = @_;
+	unless (exists($self->{_kit_provider})) {
+		$self->{_kit_provider} = Genesis::Kit::Provider->new(%{$self->config->{kit_provider} || {}});
+	}
+	return $self->{_kit_provider};
+}
+
+sub set_kit_provider {
+
+	my ($self, %opts) = @_;
+	my $new_provider;
+
+	# TODO: If needed, provide an interactive wizard to enter provider type and details
+	#	if ($opts{interactive}) {
+	#		$new_provider = Genesis::Kit::Provider->target(undef);
+	#	} else ...
+	eval {
+		waiting_on "\nSetting up new kit provider...";
+		$new_provider = Genesis::Kit::Provider->init(%opts);
+		explain "done.";
+		waiting_on "Writing configuration....";
+		$self->{_kit_provider} = $new_provider;
+		$self->_write_config(kit_provider => $new_provider);
+		explain "done.";
+	};
+	return $@;
+}
+
+sub kit_provider_info {
+	my $self = shift;
+	$self->kit_provider->status(@_);
 }
 
 sub vault {
@@ -226,7 +277,7 @@ sub set_vault {
 		bug "#R{[Error]} Invalid call to Genesis::Top->set_vault"
 	}
 	$self->{_vault} = $new_vault;
-	$self->_write_config($self->type,$self->version,$new_vault)
+	$self->_write_config(vault => $new_vault)
 		unless $opts{session_only};
 	return;
 }
@@ -285,25 +336,6 @@ sub embed {
 	return 1;
 }
 
-sub download_kit {
-	my ($self, $spec) = @_;
-
-	my ($name, $version) = $spec =~ m{(.*)/(.*)} ? ($1, $2)
-	                                             : ($spec, 'latest');
-
-	(my $url, $version) = Genesis::Kit->url($name, $version);
-
-	mkdir_or_fail($self->path(".genesis"));
-	mkdir_or_fail($self->path(".genesis/kits"));
-	my ($code, $msg, $data) = curl("GET", $url);
-	if ($code != 200) {
-		die "Failed to download $name/$version from $url: Github returned an HTTP ".$msg."\n";
-	}
-	mkfile_or_fail($self->path(".genesis/kits/$name-$version.tar.gz"), 0400, $data);
-	debug("downloaded kit #M{$name}/#C{$version}");
-
-	return ($name,$version);
-}
 
 sub path {
 	my ($self, $relative) = @_;
@@ -323,6 +355,7 @@ sub mkdir {
 
 sub config {
 	my ($self) = @_;
+	return {} unless -f $self->path(".genesis/config");
 	return $self->{_config} ||= load_yaml_file($self->path(".genesis/config"));
 }
 
@@ -369,35 +402,95 @@ sub create_env {
 	);
 }
 
-sub compiled_kits {
+sub local_kits {
 	my ($self) = @_;
 
 	my %kits;
 	for (glob("$self->{root}/.genesis/kits/*")) {
 		next unless m{/([^/]*)-(\d+(\.\d+(\.\d+([.-]rc[.-]?\d+)?)?)?).t(ar.)?gz$};
-		$kits{$1}{$2} = $_;
+		$kits{$1}{$2} = Genesis::Kit::Compiled->new(
+			name     => $1,
+			version  => $2,
+			archive  => $_,
+			provider => $self->kit_provider()
+		);
 	}
 
 	return \%kits;
 }
 
-sub _semver {
-	my ($v) = @_;
-	if ($v =~  m/^(\d+)(?:\.(\d+)(?:\.(\d+)(?:[.-]rc[.-]?(\d+))?)?)?$/) {
-		return  $1       * 1000000000
-		     + ($2 || 0) * 1000000
-		     + ($3 || 0) * 1000
-		     + ($4 || 0) * 1;
-	}
-	return 0;
+sub local_kit_version {
+	my ($self, $name, $version) = @_;
+
+	($name, $version) = ($1, $2)
+		if (!defined($version) && defined($name) && $name =~ m{(.*)/(.*)});
+
+	# local_kit_version('dev') or local_kit_version() with a dev kit present
+	return Genesis::Kit::Dev->new($self->path("dev"))
+		if ((!$name && !$version) || ($name && $name eq 'dev')) && $self->has_dev_kit;
+	return undef if ($name and $name eq 'dev');
+
+	#    local_kit_version() without a dev/ directory
+	# or local_kit_version($name, $version)
+	my $kits = $self->local_kits();
+
+	# we either need a $name, or only one kit type
+	# (i.e. we can autodetect $name for the caller)
+	$name = (keys %$kits)[0] if (!$name && keys(%$kits) == 1);
+	return undef unless $kits->{$name};
+
+	$version = (reverse sort by_semver keys %{$kits->{$name}})[0]
+		if (!defined($version) || $version eq 'latest');
+	return $kits->{$name}{$version};
 }
 
+sub remote_kit_names {
+	my $self = shift;
+	$self->kit_provider->kit_names(@_);
+}
+
+sub remote_kit_versions {
+	my $self = shift;
+	$self->kit_provider->kit_versions(@_);
+}
+
+sub remote_kit_version_info {
+	my ($self, $name, $version) = @_;
+	($name, $version) = ($1, $2)
+		if (!defined($version) && defined($name) && $name =~ m{(.*)/(.*)});
+	$version = $self->kit_provider->latest_version_of($name) unless $version && $version ne 'latest';
+  $self->kit_provider->kit_versions($name, version => $version);
+}
+
+sub download_kit {
+	my ($self, $name, $version) = @_;
+	($name, $version) = ($1, $2)
+		if (!defined($version) && defined($name) && $name =~ m{(.*)/(.*)});
+	$version = $self->kit_provider->latest_version_of($name) unless $version && $version ne 'latest';
+
+	mkdir_or_fail($self->path(".genesis"));
+	mkdir_or_fail($self->path(".genesis/kits"));
+
+	$self->kit_provider->fetch_kit_version($name,$version,$self->path(".genesis/kits"));
+}
+
+
 sub _write_config {
-	my ($self, $type, $version, $vault) = @_;
+	my ($self, %changes) = @_;
+	my $type         = $changes{type}         || $self->type;
+	my $version      = $changes{version}      || $self->version;
+	my $kit_provider = $changes{kit_provider} || $self->kit_provider;
+
 	my $vault_info = "";
-	if ($vault) {
-		my $vault_url = $vault->url;
-		my $vault_skip_validate: = $vault->verify ? "false" : "true";
+	my ($vault_url, $vault_skip_validate);
+	if ($changes{vault}) {
+		$vault_url = $changes{vault}->url;
+		$vault_skip_validate = $changes{vault}->verify ? "false" : "true";
+	} elsif ($self->config()->{secrets_provider}{url}) {
+		$vault_url = $self->config()->{secrets_provider}{url};
+		$vault_skip_validate = $self->config()->{secrets_provider}{insecure} ? "true" : "false";
+	}
+	if ($vault_url) {
 		$vault_info =
 		  <<EOF; # {{{
 
@@ -407,67 +500,36 @@ secrets_provider:
 EOF
 # }}}
 	}
+	my $kit_info = "";
+	if ($kit_provider && ref($kit_provider) ne "Genesis::Kit::Provider::GenesisCommunity") {
+		$kit_info =
+		  <<EOF; # {{{
+
+kit_provider: 
+EOF
+		my %kit_config = $kit_provider->config;
+		for (keys %kit_config) {
+			$kit_info .= qq(  ${_}: "$kit_config{$_}"\n);
+		}
+
+# }}}
+	}
+
 	$self->mkfile(".genesis/config",
 	  <<EOF); # {{{
 ---
 # This file is generated by Genesis - do not edit manually.
 
 deployment_type: $type
-genesis_version: $version$vault_info
+genesis_version: $version$vault_info$kit_info
 EOF
 # }}}
 
 	# reload config and vault
 	$self->{_config} = undef;
-	$self->{_vault} = $vault;
+	$self->{_vault} = $changes{vault};
+	$self->{_kit_provider} = $kit_provider;
 	$self->config;
-}
-
-sub find_kit {
-	my ($self, $name, $version) = @_;
-
-	# find_kit('dev')
-	if ($name and $name eq 'dev') {
-		return $self->has_dev_kit ? Genesis::Kit::Dev->new($self->path("dev"))
-		                          : undef;
-	}
-
-	# find_kit() with a dev/ directory
-	if (!$name and !$version and $self->has_dev_kit) {
-		return Genesis::Kit::Dev->new($self->path("dev"));
-	}
-
-	#    find_kit() without a dev/ directory
-	# or find_kit($name, $version)
-	my $kits = $self->compiled_kits();
-
-	# we either need a $name, or only one kit type
-	# (i.e. we can autodetect $name for the caller)
-	if (!$name) {
-		return undef unless (keys %$kits) == 1;
-		$name = (keys %$kits)[0];
-
-	} else {
-		return undef unless exists $kits->{$name};
-	}
-
-	if (defined $version and $version ne 'latest') {
-		return exists $kits->{$name}{$version}
-		     ? Genesis::Kit::Compiled->new(
-		         name    => $name,
-		         version => $version,
-		         archive => $kits->{$name}{$version})
-		     : undef;
-	}
-
-	my @versions = reverse sort { $a->[1] <=> $b->[1] }
-	                       map  { [$_, _semver($_)] }
-	                       keys %{$kits->{$name}};
-	$version = $versions[0][0];
-	return Genesis::Kit::Compiled->new(
-		name    => $name,
-		version => $version,
-		archive => $kits->{$name}{$version});
 }
 
 1;
@@ -577,7 +639,7 @@ their compiled tarball paths.  For example:
       },
     }
 
-=head2 find_kit([$name, [$version]])
+=head2 local_kit_version([$name || $spec, [$version]])
 
 Looks through the list of compiled kits and returns the correct Genesis::Kit
 object for the requested name/version combination.  Returns C<undef> if no
@@ -595,28 +657,31 @@ the named kit will be done to determine the latest version, per semver.
 Some examples may help to clarify:
 
     # find the 1.0 concourse kit:
-    $top->find_kit(concourse => '1.0');
+    $top->local_kit_version(concourse => '1.0');
 
     # find the latest concourse kit:
-    $top->find_kit(concourse => 'latest');
+    $top->local_kit_version(concourse => 'latest');
 
     # find the latest version of whatever kit we have
-    $top->find_kit(undef, 'latest');
+    $top->local_kit_version(undef, 'latest');
 
     # find version 2.0 of whatever kit we have
-    $top->find_kit(undef, '2.0');
+    $top->local_kit_version(undef, '2.0');
+
+    # find using kit spec string
+    $top->local_kit_version('concourse/1.0.3');
 
     # explicitly use the dev/ kit
-    $top->find_kit('dev');
+    $top->local_kit_version('dev');
 
     # use whatever makes the most sense.
-    $top->find_kit();
+    $top->local_kit_version();
 
 Note that if you omit C<$name>, there is a semantic difference between
 passing C<$version> as "latest" and not passing it (or passing it as
 C<undef>, explicitly).  In the former case (version = "latest"), the latest
 version of the singleton compiled kit is returned.  In the latter case,
-C<find_kit> will check for a dev/ directory and use that if available.
+C<local_kit_version> will check for a dev/ directory and use that if available.
 
 =head2 load_env($name)
 

--- a/lib/Genesis/Top.pm
+++ b/lib/Genesis/Top.pm
@@ -187,14 +187,14 @@ EOF
 
 # }}}
 
-};
-if ($@) {
-	debug("removing incomplete Genesis deployments repository at #C{$path} due to failed creation");
-	rmtree $path;
-	die $@;
-}
+	};
+	if ($@) {
+		debug("removing incomplete Genesis deployments repository at #C{$path} due to failed creation");
+		rmtree $path;
+		die $@;
+	}
 
-return $self;
+	return $self;
 }
 
 sub kit_provider {

--- a/t/10-top.t
+++ b/t/10-top.t
@@ -31,7 +31,7 @@ subtest 'kit location' => sub {
 		/);
 		mkfile_or_fail("$tmp/.genesis/config", <<EOF);
 ---
-genesis: 2.6.0
+genesis_version: 2.7.0
 deployment_type: foo
 EOF
 	};

--- a/t/10-top.t
+++ b/t/10-top.t
@@ -10,6 +10,7 @@ use Test::Output;
 use Cwd ();
 
 use_ok 'Genesis::Top';
+use_ok 'Genesis::Kit::Compiled';
 use Genesis;
 my $vault_target = vault_ok();
 
@@ -28,50 +29,100 @@ subtest 'kit location' => sub {
 			unversioned.tar.gz
 			unversioned.tgz
 		/);
+		mkfile_or_fail("$tmp/.genesis/config", <<EOF);
+---
+genesis: 2.6.0
+deployment_type: foo
+EOF
 	};
 	my $top = Genesis::Top->new($tmp);
 
 	$again->();
 	ok(!$top->has_dev_kit, "roots without dev/ should not report having a dev kit");
-	cmp_deeply($top->compiled_kits, {
+	cmp_deeply($top->local_kits, {
 			foo => {
-				'0.9.5' => $top->path(".genesis/kits/foo-0.9.5.tar.gz"),
-				'0.9.6' => $top->path(".genesis/kits/foo-0.9.6.tar.gz"),
-				'1.0.0' => $top->path(".genesis/kits/foo-1.0.0.tar.gz"),
-				'1.0.1' => $top->path(".genesis/kits/foo-1.0.1.tgz"),
+				'0.9.5' => bless({
+					'archive'  => $top->path(".genesis/kits/foo-0.9.5.tar.gz"),
+					'name'     => 'foo',
+					'version'  => '0.9.5',
+					'provider' => isa("Genesis::Kit::Provider")
+				}, "Genesis::Kit::Compiled"),
+				'0.9.6' => bless({
+					'archive'  => $top->path(".genesis/kits/foo-0.9.6.tar.gz"),
+					'name'     => 'foo',
+					'version'  => '0.9.6',
+					'provider' => isa("Genesis::Kit::Provider")
+				}, "Genesis::Kit::Compiled"),
+				'1.0.0' => bless({
+					'archive'  => $top->path(".genesis/kits/foo-1.0.0.tar.gz"),
+					'name'     => 'foo',
+					'version'  => '1.0.0',
+					'provider' => isa("Genesis::Kit::Provider")
+				}, "Genesis::Kit::Compiled"),
+				'1.0.1' => bless({
+					'archive'  => $top->path(".genesis/kits/foo-1.0.1.tgz"),
+					'name'     => 'foo',
+					'version'  => '1.0.1',
+					'provider' => isa("Genesis::Kit::Provider")
+				}, "Genesis::Kit::Compiled"),
 			},
 			bar => {
-				'3.4.5' => $top->path(".genesis/kits/bar-3.4.5.tar.gz"),
+				'3.4.5' => bless({
+					'archive'  => $top->path(".genesis/kits/bar-3.4.5.tar.gz"),
+					'name'     => 'bar',
+					'version'  => '3.4.5',
+					'provider' => isa("Genesis::Kit::Provider")
+				}, "Genesis::Kit::Compiled"),
 			},
 		}, "roots should list out all of their compiled kits");
 
 	$again->();
-	ok( defined $top->find_kit(foo => '1.0.0'), "test root dir should have foo-1.0.0 kit");
-	ok(!defined $top->find_kit(foo => '9.8.7'), "test root dir should not have foo-9.8.7 kit");
-	ok(!defined $top->find_kit(quxx => undef), "test root dir should not have any quux kit");
-	ok( defined $top->find_kit(foo => '1.0.1'), "roots should recognize .tgz kits");
-	ok( defined $top->find_kit(foo => 'latest'), "root should find latest kit versions");
-	is($top->find_kit(foo => 'latest')->{version}, '1.0.1', "the latest foo kit should be 1.0.1");
-	is($top->find_kit(foo => undef)->{version}, '1.0.1', "an undef version should count as 'latest'");
-	ok(!defined $top->find_kit(undef => 'latest'), "kit name should be required if more than one kit exists");
-	ok(!defined $top->find_kit(undef => '1.0.0'), "kit name should be requried if more than one kit exists, regardless of version uniqueness");
+	ok( defined $top->local_kit_version(foo => '1.0.0'), "test root dir should have foo-1.0.0 kit");
+	ok(!defined $top->local_kit_version(foo => '9.8.7'), "test root dir should not have foo-9.8.7 kit");
+	ok(!defined $top->local_kit_version(quxx => undef), "test root dir should not have any quux kit");
+	ok( defined $top->local_kit_version(foo => '1.0.1'), "roots should recognize .tgz kits");
+	ok( defined $top->local_kit_version(foo => 'latest'), "root should find latest kit versions");
+	is($top->local_kit_version(foo => 'latest')->{version}, '1.0.1', "the latest foo kit should be 1.0.1");
+	is($top->local_kit_version(foo => undef)->{version}, '1.0.1', "an undef version should count as 'latest'");
+	ok(!defined $top->local_kit_version(undef => 'latest'), "kit name should be required if more than one kit exists");
+	ok(!defined $top->local_kit_version(undef => '1.0.0'), "kit name should be requried if more than one kit exists, regardless of version uniqueness");
 
 	$again->();
 	system("rm -f $tmp/.genesis/kits/bar-*gz");
-	cmp_deeply($top->compiled_kits, {
+	cmp_deeply($top->local_kits, {
 			foo => {
-				'0.9.5' => $top->path(".genesis/kits/foo-0.9.5.tar.gz"),
-				'0.9.6' => $top->path(".genesis/kits/foo-0.9.6.tar.gz"),
-				'1.0.0' => $top->path(".genesis/kits/foo-1.0.0.tar.gz"),
-				'1.0.1' => $top->path(".genesis/kits/foo-1.0.1.tgz"),
+				'0.9.5' => bless({
+					'archive'  => $top->path(".genesis/kits/foo-0.9.5.tar.gz"),
+					'name'     => 'foo',
+					'version'  => '0.9.5',
+					'provider' => isa("Genesis::Kit::Provider")
+				}, "Genesis::Kit::Compiled"),
+				'0.9.6' => bless({
+					'archive'  => $top->path(".genesis/kits/foo-0.9.6.tar.gz"),
+					'name'     => 'foo',
+					'version'  => '0.9.6',
+					'provider' => isa("Genesis::Kit::Provider")
+				}, "Genesis::Kit::Compiled"),
+				'1.0.0' => bless({
+					'archive'  => $top->path(".genesis/kits/foo-1.0.0.tar.gz"),
+					'name'     => 'foo',
+					'version'  => '1.0.0',
+					'provider' => isa("Genesis::Kit::Provider")
+				}, "Genesis::Kit::Compiled"),
+				'1.0.1' => bless({
+					'archive'  => $top->path(".genesis/kits/foo-1.0.1.tgz"),
+					'name'     => 'foo',
+					'version'  => '1.0.1',
+					'provider' => isa("Genesis::Kit::Provider")
+				}, "Genesis::Kit::Compiled"),
 			},
 		}, "root should only have `foo' kit");
-	ok( defined $top->find_kit(undef, 'latest'), "root should find latest kit version of only kit");
-	ok( defined $top->find_kit(undef, '0.9.6'), "root should find 0.9.6 kit version of only kit");
-	is($top->find_kit(undef, 'latest')->{version}, '1.0.1', "the latest foo kit should be 1.0.1");
-	is($top->find_kit(undef, 'latest')->{name}, 'foo', "the only kit should be 'foo'");
-	is($top->find_kit(undef, '0.9.6')->{version}, '0.9.6', "specific version of the kit are returned");
-	is($top->find_kit(undef, '0.9.6')->{name}, 'foo', "the only kit should be 'foo' (0.9.6)");
+	ok( defined $top->local_kit_version(undef, 'latest'), "root should find latest kit version of only kit");
+	ok( defined $top->local_kit_version(undef, '0.9.6'), "root should find 0.9.6 kit version of only kit");
+	is($top->local_kit_version(undef, 'latest')->{version}, '1.0.1', "the latest foo kit should be 1.0.1");
+	is($top->local_kit_version(undef, 'latest')->{name}, 'foo', "the only kit should be 'foo'");
+	is($top->local_kit_version(undef, '0.9.6')->{version}, '0.9.6', "specific version of the kit are returned");
+	is($top->local_kit_version(undef, '0.9.6')->{name}, 'foo', "the only kit should be 'foo' (0.9.6)");
 };
 
 subtest 'init' => sub {
@@ -146,10 +197,10 @@ subtest 'downloading kits' => sub {
 	my $top = Genesis::Top->new($tmp);
 
 	$again->();
-	ok(!defined $top->find_kit('bosh'), "bosh kit shouldn't exist (before download)");
+	ok(!defined $top->local_kit_version('bosh'), "bosh kit shouldn't exist (before download)");
 	$top->download_kit("bosh/0.2.0");
-	ok( defined $top->find_kit('bosh'), "bosh kit should exist after we download");
-	ok( defined $top->find_kit('bosh', '0.2.0'), "top downloaded bosh-0.2.0 as requested");
+	ok( defined $top->local_kit_version('bosh'), "bosh kit should exist after we download");
+	ok( defined $top->local_kit_version('bosh', '0.2.0'), "top downloaded bosh-0.2.0 as requested");
 };
 
 subtest 'manage secrets provider' => sub {

--- a/t/20-kit.t
+++ b/t/20-kit.t
@@ -169,6 +169,29 @@ subtest 'legacy kit support' => sub {
 	           "legacy kits with subkits should return all relevant yaml files");
 };
 
+subtest 'genesis-community kit provider configuration' => sub {
+	my (%info);
+
+	my $kit_provider = Genesis::Kit::Provider::GenesisCommunity->init();
+	cmp_deeply({$kit_provider->config()}, {
+			type => 'genesis-community',
+		}, "GenesisCommunity kit provider has correct config");
+	lives_ok { %info = $kit_provider->status() } "GenesisCommunity kit provider is reachable";
+	cmp_deeply({%info}, {
+		'type'   => 'genesis-community',
+		'Source' => "Genesis Community organization on Github",
+		'extras' => ['Source'],
+		'kits'   => supersetof(qw/bosh cf jumpbox vault/),
+		'status' => "ok"
+	}, "GenesisCommunity kit provider contains correct provider status information");
+
+	$kit_provider = Genesis::Kit::Provider->init();
+	cmp_deeply({$kit_provider->config()}, {
+			type => 'genesis-community',
+		}, "Default kit provider is the GenesisCommunity kit provider");
+
+};
+
 subtest 'kit urls' => sub {
 	my ($kit, $url, $version);
 	my $provider = Genesis::Kit::Provider->init();

--- a/t/30-env.t
+++ b/t/30-env.t
@@ -758,7 +758,7 @@ subtest 'new env and check' => sub{
 
 	my $name = "far-fetched";
 	my $top = Genesis::Top->create(workdir, 'sample', vault=>$VAULT_URL);
-	my $kit = $top->link_dev_kit('t/src/creator')->find_kit('dev');
+	my $kit = $top->link_dev_kit('t/src/creator')->local_kit_version('dev');
 	mkfile_or_fail $top->path("pre-existing.yml"), "I'm already here";
 
 	# create the environment

--- a/t/subkits.t
+++ b/t/subkits.t
@@ -25,7 +25,7 @@ properties:
       secret: haha
     type: s3
 EOF
-eq_or_diff get_file("$tmp/manifest-errors"), <<EOF, "errors from manifest generated with webdav subkit";
+eq_or_diff get_file("$tmp/manifest-errors"), <<EOF, "errors from manifest generated with use-s3 subkit";
 EOF
 
 runs_ok "genesis manifest -c cloud.yml use-webdav 2>$tmp/manifest-errors >$tmp/manifest.yml";


### PR DESCRIPTION
# New Feature: Kit Providers

Until now, you could only use the kits that were provided by the
`genesis_community` organization on GitHub, or by creating dev kits yourself.
This release allows you to specify any GitHub org as a kit provider.

## Creating a new repo with an alternative kit provider:

```
genesis init --kit-provider        github \
             --kit-provider-org    myproject \
             --kit-provider-domain github.mycorp.com \
             --kit-provider-tls    skip \
             --kit-provider-name   "Our Custom Kit Provider" \
             --kit                 my-awesome-kit
```

There are further options, which can be shown using --help.

## Showing current kit provider:

```
genesis kit-provider

Collecting information on current kit provider for concourse deployment at ./work/concourse-deployments ...done.

         Type: github

         Name: Our Custom Kit Provider
       Domain: github.mycorp.com
          Org: myproject
      Use TLS: skip

       Status: ok

         Kits: my-awesome-kit
               another-kit

```

If the `-v|--verbose` option is specifies, this will also show what versions of the kits are available under the current kit provider.

## Changing kit provider on existing repo:

```
genesis kit-provider --default
genesis kit-provider --kit-provider genesis-community
```

Either of these will set the kit provider to the default Genesis Community kit
provider.

```
genesis kit-provider --kit-provider github [... rest of github-specific options]
```

You can also change it to another github org as its kit provider using the
above.

_Note:_  You can't just change one option to have it update just that property
-- you must set all the provider-specific options to update the provider
information.  Refer to the help output (-h|--help) for details on what options
are expected.

### Kit Provider Configuration file

Alternative to specifying individual configuration options, you can point to a configuration file that contains the correct information for a specific provider when setting the kit provider for the repository.

``` 
genesis kit-provider --kit-provider-config <file>
```

This file is a yaml file that contains the configuration options.  While hand-editable, using the `--export-config` option for an existing repository provides an easy way to share the config:

```
genesis init some-kit --kit-provider-config <(genesis kit-provider -C some-other-kit-deployments --export-config)
```
