### PR TITLE
Timestamps and better debugging on bugs

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -470,7 +470,7 @@ sub options {
 	GetOptionsFromArray($args, $options,
 		(qw/
 			help|h
-			debug|D
+			debug|D+
 			trace|T+
 			quiet|q
 			cwd|C=s
@@ -490,6 +490,7 @@ sub options {
 
 	$ENV{GENESIS_DEBUG}  = 'y' if $debug || envset "DEBUG";
 	$ENV{GENESIS_TRACE}  = 'y' if $trace;
+	$ENV{GENESIS_TSTAMP} = 'y' if $debug > 1;
 
 	# spruce debugging
 	$ENV{DEBUG}          = 'y' if $trace > 1;


### PR DESCRIPTION
Timestamps were added for two situations:

* The `run` subroutine, and by extention anything that wraps it, gets a
duration added to the logs.

* The log entries will get a time-of-day timestamp when -D option is
  specified more than once.  To get the timestamps when using trace (-T),
  you still need to specify the -DD as well.

Improved debugging for genesis bugs:

* Get a stack trace, template and argument dump when calling csprintf
  results in a missing or extra argument error

* Get a stack trace when a bug is encountered (via the bug routine)