### PR TITLE
Refactor lookup routines, added uniq for stable sort uniqueness

### DIFF
--- a/lib/Genesis.pm
+++ b/lib/Genesis.pm
@@ -59,6 +59,7 @@ our @EXPORT = qw/
 	pushd popd
 
 	struct_lookup
+	uniq
 
 	tcp_listening
 /;
@@ -715,6 +716,13 @@ sub struct_lookup {
 	return wantarray ? ($value,$key) : $value;
 }
 
+sub uniq {
+	my (@items,%check);
+	for (@_) {
+		push @items, $_ unless $check{$_}++;
+	}
+	@items
+}
 
 
 # Because x FH args... translates to FH->x args, it is required to monkey-patch


### PR DESCRIPTION
Moved lookup to Genesis base library to share
- Both Env and Kit::Compiler need to be able to lookup values from a
  structure for an upcoming change.

Added uniq utility for stable sort uniqueness
