### PR TITLE
Move `name` set to final merge

### DIFF
--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -449,7 +449,6 @@ meta:
 exodus:  {}
 genesis: {}
 params:  {}
-name:    (( concat genesis.env "-$type" ))
 EOF
 	} else {
 		mkfile_or_fail("$self->{__tmp}/init.yml", 0644, <<EOF);
@@ -461,13 +460,13 @@ genesis: {}
 params:
   env:  (( grab genesis.env ))
   name: (( concat genesis.env || params.env "-$type" ))
-name: (( grab params.name ))
 EOF
 	}
 
 	my $now = strftime("%Y-%m-%d %H:%M:%S +0000", gmtime());
 	mkfile_or_fail("$self->{__tmp}/fin.yml", 0644, <<EOF);
 ---
+name: (( concat genesis.env || params.env "-$type" ))
 exodus:
   version:     $Genesis::VERSION
   dated:       $now


### PR DESCRIPTION
Genesis sets the `name` key in the first file merged, which allows it to
be overwritten by any following file, even the user's environment file.
However, bosh expects the `name` key to match the manifest, so there is no
point in allowing it to be overwritten.