### PR TITLE
Check genesis version against kit min version

### DIFF
--- a/lib/Genesis.pm
+++ b/lib/Genesis.pm
@@ -257,7 +257,7 @@ sub _log {
 
 sub error {
 	my @err = @_;
-	binmode(STDOUT, "encoding(UTF-8)");
+	binmode(STDERR, "encoding(UTF-8)");
 	unshift @err, "%s" if $#err == 0;
 	print STDERR csprintf(@err) . "$/";
 }

--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -70,7 +70,9 @@ sub load {
 	my $kit_name = $env->lookup('kit.name');
 	my $kit_version = $env->lookup('kit.version');
 	$env->{kit} = $env->{top}->local_kit_version($kit_name, $kit_version)
-			or bail "Unable to locate v$kit_version of `$kit_name` kit for '$env->{name}' environment.";
+		or bail "Unable to locate v$kit_version of `$kit_name` kit for '$env->{name}' environment.";
+	$env->{kit}->check_prereqs()
+		or bail "Cannot use the selected kit.\n";
 
 	my $min_version = $env->lookup(['genesis.min_version','params.genesis_version_min'],'');
 	$min_version =~ s/^v//i;

--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -71,7 +71,7 @@ sub load {
 	my $kit_version = $env->lookup('kit.version');
 	$env->{kit} = $env->{top}->local_kit_version($kit_name, $kit_version)
 		or bail "Unable to locate v$kit_version of `$kit_name` kit for '$env->{name}' environment.";
-	$env->{kit}->check_prereqs()
+	$env->kit->check_prereqs()
 		or bail "Cannot use the selected kit.\n";
 
 	my $min_version = $env->lookup(['genesis.min_version','params.genesis_version_min'],'');

--- a/lib/Genesis/Kit.pm
+++ b/lib/Genesis/Kit.pm
@@ -268,9 +268,11 @@ sub check_prereqs {
 	return 1 unless $min && semver($min);
 
 	if (!semver($Genesis::VERSION)) {
-		error("#Y{WARNING:} Using a development version of Genesis.");
-		error("Cannot determine if it meets or exceeds the minimum version");
-		error("requirement (v$min) for $id.");
+		unless (under_test && !envset 'GENESIS_TESTING_DEV_VERSION_DETECTION') {
+			error("#Y{WARNING:} Using a development version of Genesis.");
+			error("Cannot determine if it meets or exceeds the minimum version");
+			error("requirement (v$min) for $id.");
+		}
 		return 1;
 	}
 

--- a/lib/Genesis/Kit.pm
+++ b/lib/Genesis/Kit.pm
@@ -232,7 +232,14 @@ sub run_hook {
 # metadata - {{{
 sub metadata {
 	my ($self) = @_;
-	return $self->{__metadata} ||= load_yaml_file($self->path('kit.yml'));
+	if (! $self->{__metadata}) {
+		if (! -f $self->path('kit.yml')) {
+			debug "#Y[WARNING] Kit %s is missing it's kit.yml file -- cannot load metadata", $self->name;
+			return {}
+		}
+		$self->{__metadata} = load_yaml_file($self->path('kit.yml'));
+	}
+	return $self->{__metadata};
 }
 
 # }}}

--- a/t/prereqs.t
+++ b/t/prereqs.t
@@ -29,6 +29,7 @@ ok ! -f "failed-env.yml",
 	"environment file should not be created, when prereqs fails";
 
 $ENV{SHOULD_FAIL} = '';
+$ENV{GENESIS_TESTING_DEV_VERSION_DETECTION} = 'y';
 reprovision kit =>'version-prereq', compiled => 1;
 ($pass, $rc, $msg) = runs_ok "genesis new using-dev-genesis";
 matches $msg, qr{


### PR DESCRIPTION
Currently the genesis_version_min specified in a kit is only checked
when new environment files are generated, but not when other genesis
functions are evoked.  This is problematic when kits are upgraded and
rely on features not found in prior genesis versions.

This ensures the kit is viable for the active version of genesis and vice-versa.

Also included in this PR are fixes needed due to enabling this prereq check universally.