### PR TITLE
Add support for bosh variables

### DIFF
--- a/lib/Genesis/BOSH.pm
+++ b/lib/Genesis/BOSH.pm
@@ -118,10 +118,13 @@ sub create_env {
 	bug("Missing 'state' option in call to create_env()!!")
 		unless $opts{state};
 
+	$opts{flags} ||= [];
+	push(@{$opts{flags}}, '--state', $opts{state});
+	push(@{$opts{flags}}, '-l', $opts{vars_file}) if ($opts{vars_file});
+
 	return _bosh({ interactive => 1, passfail => 1 },
-		'bosh', 'create-env', '--state', $opts{state},
-		$ENV{BOSH_NON_INTERACTIVE} ? '-n' : (),
-		$manifest);
+		'bosh', $ENV{BOSH_NON_INTERACTIVE} ? '-n' : (),
+		'create-env',  @{$opts{flags}}, $manifest);
 }
 
 sub download_cloud_config {
@@ -144,13 +147,13 @@ sub deploy {
 		bug("Missing '$o' option in call to deploy()!!")
 			unless $opts{$o};
 	}
-
+	$opts{flags} ||= [];
+	push(@{$opts{flags}}, "-l", $opts{vars_file}) if ($opts{vars_file});
 
 	return _bosh({ interactive => 1, passfail => 1 },
 		'bosh', '-e', $env, '-d', $opts{deployment},
 		$ENV{BOSH_NON_INTERACTIVE} ? '-n' : (),
-		'deploy', $opts{manifest}, @{ $opts{flags} || [] });
-
+		'deploy', @{$opts{flags}}, $opts{manifest});
 }
 
 sub alias {

--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -6,6 +6,7 @@ use Genesis;
 use Genesis::Legacy; # but we'd rather not
 use Genesis::BOSH;
 use Genesis::UI;
+use Genesis::IO qw/DumpYAML/;
 use Genesis::Vault;
 
 use POSIX qw/strftime/;
@@ -426,6 +427,26 @@ sub cached_manifest_info {
 	return (wantarray ? ($mpath, $exists, $sha1) : $mpath);
 }
 
+sub vars_file {
+	my ($self, $file) = @_;
+
+	# Check if manifest currently has params.variable-values hash, and if so,
+	# build a variables.yml file in temp directory and return a path to it
+	# (return undef otherwise)
+
+	return $self->{_vars_file} if ($self->{_vars_file} && -f $self->{_vars_file});
+
+	my $vars = $self->manifest_lookup('params.bosh-variables');
+	if ($vars && ref($vars) eq "HASH" && scalar(keys %$vars) > 0) {
+		my $vars_file = "$self->{__tmp}/bosh-vars.yml";
+		DumpYAML($vars_file,$vars);
+		dump_var "BOSH Variables File" => $vars_file, "Contents" => slurp($vars_file);
+		return $self->{_vars_file} = $vars_file;
+	} else {
+		return undef
+	}
+}
+
 sub _yaml_files {
 	my ($self) = @_;
 	my $vault_path = $self->vault_path;
@@ -635,6 +656,7 @@ sub deploy {
 		debug("deploying this environment via `bosh create-env`, locally");
 		$ok = Genesis::BOSH->create_env(
 			"$self->{__tmp}/manifest.yml",
+			vars_file => $self->vars_file,
 			state => $self->path(".genesis/manifests/$self->{name}-state.yml"));
 
 	} else {
@@ -650,6 +672,7 @@ sub deploy {
 		debug("deploying this environment to our BOSH director");
 		$ok = Genesis::BOSH->deploy(
 			$self->bosh_target,
+			vars_file => $self->vars_file,
 			manifest   => "$self->{__tmp}/manifest.yml",
 			deployment => $self->deployment,
 			flags      => \@bosh_opts);

--- a/lib/Genesis/IO.pm
+++ b/lib/Genesis/IO.pm
@@ -2,7 +2,7 @@ package Genesis::IO;
 
 use base 'Exporter';
 our @EXPORT = qw/
-	DumpJSON LoadFile Load
+	DumpJSON DumpYAML LoadFile Load
 /;
 
 use JSON::PP qw/decode_json encode_json/;
@@ -13,6 +13,14 @@ sub DumpJSON {
 	open my $fh, ">", $file or die "Unable to write to $file: $!\n";
 	print $fh encode_json($data);
 	close $fh;
+}
+
+sub DumpYAML {
+	my ($file, $data) = @_;
+	my $i=1; while (-f "$file.$i.json") {$i++};
+	my $tmpfile = "$file.$i.json";
+	DumpJSON($tmpfile,$data);
+	run('cat "$1" | spruce merge - > $2; rm "$1"', $tmpfile, $file);
 }
 
 sub LoadFile {

--- a/t/compiled.t
+++ b/t/compiled.t
@@ -16,13 +16,13 @@ bosh2_cli_ok;
 
 runs_ok "genesis manifest -c cloud.yml test-env >$tmp/manifest.yml";
 eq_or_diff get_file("$tmp/manifest.yml"), <<EOF, "manifest generated based on compile kit";
-name: env-compiled-kit-test
+name: test-env-compiled-kit-test
 version: 0.0.1
 EOF
 
 runs_ok "genesis manifest -c cloud.yml test-env-upgrade >$tmp/manifest.yml";
 eq_or_diff get_file("$tmp/manifest.yml"), <<EOF, "manifest generated based on compile kit";
-name: env-compiled-kit-test
+name: test-env-upgrade-compiled-kit-test
 properties:
   added: stuff
 version: 0.0.2


### PR DESCRIPTION
In order to fill in variables referenced in double-parentheses, users
can add them under `params.bosh-variables` in their env files, instead
of having to have them in separate files.  Kits can also specify default
values for these variables, something that is not supported by BOSH
directly.