### PR TITLE
Extend -C option to allow specifying yaml file

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -502,7 +502,24 @@ sub options {
 
 	$ENV{GENESIS_BOSH_ENVIRONMENT} = delete($options->{environment})
 		if $options->{environment};
-	chdir_or_fail(delete($options->{cwd})) if $options->{cwd};
+
+	if ($options->{cwd}) {
+		my $cwd = abs_path(delete($options->{cwd}));
+		if ( -f $cwd ) {
+			unshift(@$args, basename($cwd));
+			$cwd = dirname($cwd);
+		}
+		if (-d $cwd) {
+			while (! -d $cwd."/.genesis") {
+				$cwd = dirname($cwd);
+				bail "Cannot find genesis deployment repo base directory under $options->{cwd}"
+				  if $cwd eq "/";
+			}
+			chdir_or_fail($cwd)
+		} else {
+			bail "Cannot locate directory '$cwd' specified by -C option"
+		}
+	}
 }
 
 sub command {


### PR DESCRIPTION
The -C option allows users to specify an alternative directory as the
base genesis directory instead of the current directory.  As a convenience,
this change allows users to specify the actual environment YAML file
instead of the base directory.  The base directory will then be whatever
ancestor directory above that file that contains the .genesis directory.