### PR TITLE
Add credhub support

### DIFF
--- a/lib/Genesis/Helpers.pm
+++ b/lib/Genesis/Helpers.pm
@@ -578,7 +578,7 @@ credhub() {
 	HOME="$__tmpdir"
 	output="$(command credhub "$@")"
 	rc="$?"
-	[[ $rc -eq 0 ]] || __bail --rc $rc "Failed to execute #M{credhub $@}: $output"
+	[[ $rc -eq 0 ]] || __bail --rc $rc "Failed to execute #M{credhub $*}: $output"
 	HOME=$__old_home
 	echo "$output"
 }

--- a/lib/Genesis/Kit.pm
+++ b/lib/Genesis/Kit.pm
@@ -257,7 +257,7 @@ sub metadata {
 # uses_credhub - does this kit use credhub instead of vault {{{
 sub uses_credhub {
 	my ($self) = @_;
-	return defined($self->metadata->{secret_store}) && $self->metadata->{uses_credhub} eq "credhub";
+	return defined($self->metadata->{secret_store}) && $self->metadata->{secret_store} eq "credhub";
 }
 
 # }}}

--- a/lib/Genesis/Kit/Compiler.pm
+++ b/lib/Genesis/Kit/Compiler.pm
@@ -72,7 +72,7 @@ sub validate {
 		if ($meta->{secrets_store}) {
 			if ($meta->{secrets_store} eq "credhub") {
 				#no-op: valid, no further keys
-			} elsif ($meta->{secrets_store} eq "credhub") {
+			} elsif ($meta->{secrets_store} eq "vault") {
 				push @valid_keys, "credentials", "certificates"
 			} else {
 				error "Kit Metadata specifies invalid secrets_store: expecting one of 'vault' or 'credhub'";

--- a/lib/Genesis/Kit/Compiler.pm
+++ b/lib/Genesis/Kit/Compiler.pm
@@ -68,7 +68,18 @@ sub validate {
 		}
 
 		# check for errant top-level keys - params, subkits and features have been discontinued.
-		my @valid_keys = qw/name version description code docs author authors genesis_version_min certificates credentials/;
+		my @valid_keys = qw/name version description code docs author authors genesis_version_min secrets_store/;
+		if ($meta->{secrets_store}) {
+			if ($meta->{secrets_store} eq "credhub") {
+				#no-op: valid, no further keys
+			} elsif ($meta->{secrets_store} eq "credhub") {
+				push @valid_keys, "credentials", "certificates"
+			} else {
+				error "Kit Metadata specifies invalid secrets_store: expecting one of 'vault' or 'credhub'";
+			}
+		} else {
+			push @valid_keys, "credentials", "certificates"
+		}
 		my @errant_keys = ();
 		for my $key (sort keys %$meta) {
 			push(@errant_keys, $key) unless grep {$_ eq $key} @valid_keys;

--- a/t/04-compiling.t
+++ b/t/04-compiling.t
@@ -268,7 +268,7 @@ EOF
 stderr_like {
 		ok(!$cc->validate, "validation should fail when there are unknown top-level keys")
 	}
-	qr/.*Kit Metadata file kit.yml contains invalid top-level keys: by, descriptoin, github, homepage, params, secrets, subkits\n  Valid keys are: name, version, description, code, docs, author, authors, genesis_version_min, certificates, credentials\n/sm,
+	qr/.*Kit Metadata file kit.yml contains invalid top-level keys: by, descriptoin, github, homepage, params, secrets, subkits\n  Valid keys are: name, version, description, code, docs, author, authors, genesis_version_min, secrets_store, credentials, certificates\n/sm,
 	"invalid top-level keys should be reported";
 ok($cc->compile("test", "1.2.3", $tmp, force => 1), "compiling an invalid kit should be allowed with force option");
 

--- a/t/20-kit.t
+++ b/t/20-kit.t
@@ -30,6 +30,7 @@ sub type { "mock-type"; }
 sub secrets_path { "mock/env"; }
 sub needs_bosh_create_env { 0; }
 sub lookup_bosh_target { wantarray ? ('a-bosh', 'params.bosh') : 'a-bosh'; }
+sub lookup { "a-value" }
 sub bosh_target { 'a-bosh'; }
 sub path { "some/path/some/where".($_[1]?"/$_[1]":""); }
 sub vault { $_[0]->{vault} }


### PR DESCRIPTION
Adds a credhub bash helper function for hooks, and the ability to specify that an environment uses credhub (so don't do the vault validations).

The credhub helper requires an environment that provides the connection information via exodus data.  The latest BOSH genesis kit contains these values.  By default, the bosh environment name will be used, but can be overrode by using `genesis.credhub-exodus-env`