### PR TITLE
Enhance fetch kit behaviour

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -429,6 +429,16 @@ sub check_environment {
 	return $ok;
 }
 
+sub extract_kit_to_dev {
+	my ($top,$file) = @_;
+	my ($out,$rc) = run("tar -ztf \"\$1\" | awk '{print \$NF}' | cut -d'/' -f1 | uniq", $file);
+	bail("#R{ERROR} #C{%s} does not look like a valid compiled kit", $file)
+		unless $rc == 0 && scalar(split $/, $out) == 1;
+	run(
+		'rm -rf "$2" && mkdir "$2" && tar -xzf "$1" --strip-components=1 -C "$2"',
+		$file, $top->path('dev')
+	);
+}
 
 ###########################################################################
 
@@ -1637,13 +1647,7 @@ sub {
 	}
 
 	explain "Uncompressing compiled kit archive #G{$file} into #C{dev/}";
-
-	# Test the kit
-	my ($out,$rc) = run("tar -ztf \$1 |cut -d'/' -f1 | uniq", $file);
-	bail "#R{[ERROR]} #C{$file} does not look like a valid compiled kit"
-		unless $rc == 0 && scalar(split $/, $out) == 1;
-	run('rm -rf ./dev && mkdir ./dev && tar -xzf "$1" --strip-components=1 -C ./dev/',
-		$file);
+	extract_kit_to_dev($top,$file);
 });
 
 # }}}
@@ -2087,15 +2091,7 @@ sub {
 		($name,$version,my $target) = $top->download_kit($kitsig,%options)
 			or bail "Failed to download Genesis Kit #C{$kitsig}";
 
-		if ($options{'as-dev'}) {
-			my ($out,$rc) = run("tar -ztf \$1 |cut -d'/' -f1 | uniq", $target);
-			bail("#R{ERROR} #C{%s} does not look like a valid compiled kit", $target)
-				unless $rc == 0 && scalar(split $/, $out) == 1;
-			run(
-				'rm -rf "$2" && mkdir "$2" && tar -xzf "$1" --strip-components=1 -C "$2"',
-				$target, $top->path('dev')
-			);
-		}
+		extract_kit_to_dev($top,$target) if ($options{'as-dev'});
 
 		my $target_str = $options{to} ? " to ".humanize_path($target) : '';
 		$target_str .= " and decompiled it into ".humanize_path($top->path('dev'))

--- a/bin/genesis
+++ b/bin/genesis
@@ -2080,7 +2080,7 @@ sub {
 		explain("Attempting to retrieve Genesis kit #M{$name (%s)}...", $version ? "v$version" : "latest version" );
 		($name,$version) = $top->download_kit($kitsig)
 			or bail "Failed to download Genesis Kit #C{$kitsig}";
-		explain "Downloaded version #C{$version} of the #C{$name} kit";
+		explain "Downloaded version #C{$version} of the #C{$name} kit\n";
 	}
 });
 

--- a/bin/genesis
+++ b/bin/genesis
@@ -1626,24 +1626,21 @@ sub {
 	check_prereqs;
 
 	my $top = Genesis::Top->new('.');
-	if ($top->has_dev_kit && !$options{force}) {
-		die "dev/ directory already exists (and --force not specified).  Bailing out.\n";
-	}
+	bail "#R{[ERROR]} dev/ directory already exists (and --force not specified).  Bailing out.\n"
+		if ($top->has_dev_kit && !$options{force});
 
 	my $file = $_[0];
 	if (! -f $file) {
 		(my $stem = $file) =~ s|/|-|;
 		$file = $top->path(".genesis/kits/$stem.tar.gz");
-	}
-	if (! -f $file) {
-		die "Unable to find Kit archive $_[0]\n";
+		bail("#R{[ERROR]} Unable to find Kit archive %s\n", $_[0]) if (! -f $file);
 	}
 
 	explain "Uncompressing compiled kit archive #G{$file} into #C{dev/}";
 
 	# Test the kit
 	my ($out,$rc) = run("tar -ztf \$1 |cut -d'/' -f1 | uniq", $file);
-	bail "#R{ERROR} #C{$file} does not look like a valid compiled kit"
+	bail "#R{[ERROR]} #C{$file} does not look like a valid compiled kit"
 		unless $rc == 0 && scalar(split $/, $out) == 1;
 	run('rm -rf ./dev && mkdir ./dev && tar -xzf "$1" --strip-components=1 -C ./dev/',
 		$file);
@@ -2051,6 +2048,9 @@ EOF
 sub {
 	my %options;
 	options(\@_, \%options, qw/
+		force|f
+		to=s
+		as-dev
 	/);
 	check_prereqs;
 
@@ -2064,6 +2064,9 @@ sub {
 		@kits = @possible_kits;
 	}
 
+	bail("#R{[ERROR]} Cannot specify multiple kits to fetch with --as-dev option")
+		if (@kits > 1 && $options{'as-dev'});
+
 	for (@kits) {
 		my ($name,$version) = $_ =~ m/^([^\/]*)(?:\/(.*))?$/;
 		if (!$version && semver($name)) {
@@ -2076,12 +2079,32 @@ sub {
 			$name = $possible_kits[0];
 		}
 
+		bail "#R{[ERROR]} dev/ directory already exists (and --force not specified).  Bailing out.\n"
+			 if ($top->has_dev_kit && $options{'as-dev'} && !$options{force});
+
 		my $kitsig = join('/', grep {$_} ($name, $version));
 		explain("Attempting to retrieve Genesis kit #M{$name (%s)}...", $version ? "v$version" : "latest version" );
-		($name,$version) = $top->download_kit($kitsig)
+		($name,$version,my $target) = $top->download_kit($kitsig,%options)
 			or bail "Failed to download Genesis Kit #C{$kitsig}";
-		explain "Downloaded version #C{$version} of the #C{$name} kit\n";
+
+		if ($options{'as-dev'}) {
+			my ($out,$rc) = run("tar -ztf \$1 |cut -d'/' -f1 | uniq", $target);
+			bail("#R{ERROR} #C{%s} does not look like a valid compiled kit", $target)
+				unless $rc == 0 && scalar(split $/, $out) == 1;
+			run(
+				'rm -rf "$2" && mkdir "$2" && tar -xzf "$1" --strip-components=1 -C "$2"',
+				$target, $top->path('dev')
+			);
+		}
+
+		my $target_str = $options{to} ? " to ".humanize_path($target) : '';
+		$target_str .= " and decompiled it into ".humanize_path($top->path('dev'))
+			if $options{'as-dev'};
+		explain "Downloaded version #C{$version} of the #C{$name} kit%s\n",$target_str;
 	}
+
+
+	# Test the kit
 });
 
 command("download", <<EOF,

--- a/lib/Genesis/Kit/Provider.pm
+++ b/lib/Genesis/Kit/Provider.pm
@@ -221,7 +221,7 @@ sub kit_versions {
 # }}}
 # fetch_kit_version - fetches a tarball for the named kit and version from this provide (abstract) {{{
 sub fetch_kit_version {
-	my ($self, $name, $version, $path) = @_;
+	my ($self, $name, $version, $path, $force) = @_;
 	bug("Abstract Method: Expecting %s class to define concrete '%' method", ref($self), 'fetch_kit_version');
 	# Input expected:
 	#		$name:    <kit name>

--- a/lib/Genesis/Kit/Provider.pm
+++ b/lib/Genesis/Kit/Provider.pm
@@ -138,6 +138,11 @@ sub parse_opts {
 
 ### Instance Methods {{{
 
+# label - unified access for identifying name for this provider in human-readable form {{{
+sub label {
+	$_[0]->{label};
+}
+# }}}
 # config - provides the config hash used to specify this provider (abstract) {{{
 sub config {
 	my ($self) = @_;

--- a/lib/Genesis/Kit/Provider/Github.pm
+++ b/lib/Genesis/Kit/Provider/Github.pm
@@ -7,7 +7,7 @@ use Genesis;
 use Genesis::UI;
 use Genesis::Helpers;
 
-use Digest::SHA1 qw/sha1_hex/;
+use Digest::SHA qw/sha1_hex/;
 
 use constant {
 	DEFAULT_DOMAIN => 'github.com',

--- a/lib/Genesis/Top.pm
+++ b/lib/Genesis/Top.pm
@@ -463,15 +463,23 @@ sub remote_kit_version_info {
 }
 
 sub download_kit {
-	my ($self, $name, $version) = @_;
-	($name, $version) = ($1, $2)
-		if (!defined($version) && defined($name) && $name =~ m{(.*)/(.*)});
+	my ($self, $id, %opts) = @_;
+	my ($name, $version) = ($1, $2) if $id =~ m/([^\/]+)(?:\/(.*))?/;
 	$version = $self->kit_provider->latest_version_of($name) unless $version && $version ne 'latest';
 
-	mkdir_or_fail($self->path(".genesis"));
-	mkdir_or_fail($self->path(".genesis/kits"));
+	my $target;
+	if ($opts{to}) {
+		$target = $opts{to};
+		bail("#R{[ERROR]} #C{%s} is not a directory", $opts{to}) unless -d $opts{to};
+		bail "#R{[ERROR]} #C{%s} is not writable", $opts{to} unless -w $opts{to};
+	} elsif ($opts{'as-dev'}) {
+		$target = workdir;
+	} else {
+		$target = $self->path(".genesis/kits");
+		mkdir_or_fail($target);
+	}
 
-	$self->kit_provider->fetch_kit_version($name,$version,$self->path(".genesis/kits"));
+	$self->kit_provider->fetch_kit_version($name,$version,$target,$opts{force});
 }
 
 


### PR DESCRIPTION
Added the following ability to `genesis fetch-kit`:

* Gets the highest available version instead of the latest created version (fixes #366)

* Checks if the fetched file already exists, and if so, compares its contents.  If identical, warns as such and aborts, but if different, will ask if it should be replaced -- will abort if not in a controlling terminal.

* -f|--force option to overwrite existing file when fetching kit version (useful when not in a controlling terminal)

* --to option to download a copy of the specific kit version to a
  specified directory instead of the embedded genesis kit directory

* --as-dev option to download the specific kit version and decompile it
  into the ./dev directory without putting it in the embedded genesis
  kit directory