### PR TITLE
Bump safe and spruce versions

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -372,8 +372,8 @@ sub check_prereqs {
 	my $bosh_min_version = "2.0.1";
 	my $reqs = [
 		# Name,     Version, Command,                                 Pattern                   Source
-		["spruce", "1.20.0", "spruce -v      2>/dev/null",            qr(.*version\s+(\S+).*)i, "https://github.com/geofffranks/spruce/releases"],
-		["safe",    "1.1.0", "safe -v        2>&1 >/dev/null",        qr(safe v(\S+)),          "https://github.com/starkandwayne/safe/releases"],
+		["spruce", "1.25.2", "spruce -v      2>/dev/null",            qr(.*version\s+(\S+).*)i, "https://github.com/geofffranks/spruce/releases"],
+		["safe",    "1.5.4", "safe -v        2>&1 >/dev/null",        qr(safe v(\S+)),          "https://github.com/starkandwayne/safe/releases"],
 		["vault",   "0.9.0", "vault -v       2>/dev/null",            qr(.*vault v(\S+).*)i,    "https://www.vaultproject.io/downloads.html"],
 		["git",     "1.8.0", "git --version  2>/dev/null",            qr(.*version\s+(\S+).*)],
 		["jq",        "1.5", "jq --version   2>/dev/null",            qr(^jq-([\.0-9]+)),       "https://stedolan.github.io/jq/download/"],


### PR DESCRIPTION
- safe picks up better cert validation through subject and authority key
  identifiers, needed for v2.7.0
- spruce is bumped up to latest version for bug fixes