### PR TITLE
add kit commands to kit dev paragraph

### DIFF
--- a/docs/AUTHORING-KITS.md
+++ b/docs/AUTHORING-KITS.md
@@ -120,6 +120,9 @@ doesn't use `dev/`.  These are the ground rules:
 
 In dev-mode, the `kit.version` parameter is ignored.
 
+Genesis comes with `compile-kit` and `decompile-kit` commands 
+which further enhance kit developer experience.
+
 Structure of a Kit
 ------------------
 

--- a/docs/AUTHORING-KITS.md
+++ b/docs/AUTHORING-KITS.md
@@ -120,8 +120,8 @@ doesn't use `dev/`.  These are the ground rules:
 
 In dev-mode, the `kit.version` parameter is ignored.
 
-Genesis comes with `compile-kit` and `decompile-kit` commands 
-which further enhance kit developer experience.
+Genesis comes with `create-kit`, `compile-kit` and `decompile-kit` 
+commands which further enhance kit developer experience.
 
 Structure of a Kit
 ------------------


### PR DESCRIPTION
Added `create-kit`, `compile-kit` and `decompile-kit` commands to kit development instructions.