### PR TITLE
V2.7.8 rc

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -1370,8 +1370,10 @@ Can specify one of the follow three:
                          doesn't change anything.
 
       --recreate         Recreate all VMs instead of just applying changes to them.
+                         This requires the VMs to be responsive; use --fix if they
+                         are not.
 
-      --fix              Only recreate VMs that are unresponsive.
+      --fix              Recreate unresponsive VMs instead of raising an error.
 
 EOF
 sub {

--- a/bin/genesis
+++ b/bin/genesis
@@ -1619,7 +1619,7 @@ $GLOBAL_USAGE
   -v, --verbose     List each item as it is processed, not just failures and warnings.
   -I, --invalid     Rotate secrets that are invalid (expired, missing, or don't
                     match the kit specification)
-  -P, --probematic  Rotate secrets that are either invalid, or valid for
+  -P, --problematic Rotate secrets that are either invalid, or valid for
                     deployment, but are not in compliance with the kit
                     specification or may soon expire.
   -y, --no-prompt   Don't prompt for confirmation

--- a/bin/genesis
+++ b/bin/genesis
@@ -458,7 +458,7 @@ sub check_environment {
 
 	if (!exists($opts{check_secrets}) || $opts{check_secrets}) {
 		explain "\n[#M{%s}] running secrets checks...", $env->name;
-		my %check_opts=(indent => '  ', validate => 1);
+		my %check_opts=(indent => '  ', validate => ! envset("GENESIS_TESTING_CHECK_SECRETS_PRESENCE_ONLY"));
 		$env->check_secrets(%check_opts) or $ok = 0;
 	}
 

--- a/bin/genesis
+++ b/bin/genesis
@@ -40,7 +40,6 @@ our $USER_AGENT_STRING = "genesis/$Genesis::VERSION";
 use FindBin;
 $ENV{GENESIS_CALLBACK_BIN} ||= $FindBin::Bin.'/'.$FindBin::Script;
 $ENV{GENESIS_LIB} ||= $FindBin::Bin.'/lib';
-$ENV{HTTPS_PROXY}=$ENV{BOSH_ALL_PROXY} if ($ENV{BOSH_ALL_PROXY});
 
 my ($COMMAND, %RUN, %USAGE, %PROPS);
 

--- a/bin/genesis
+++ b/bin/genesis
@@ -350,7 +350,11 @@ sub check_bosh_version {
 		my ($version, undef) = run("$boshcmd -v 2>&1 | grep version | head -n1");
 		if ($version =~ /version (\S+?)-.*/) {
 			if (new_enough($1, $min)) {
-				$ENV{GENESIS_BOSH_COMMAND} = $boshcmd;
+				# Try to get the full path if possible
+				$ENV{GENESIS_BOSH_COMMAND} = `command -v $boshcmd`;
+				$ENV{GENESIS_BOSH_COMMAND} = `which $boshcmd` if $? > 0;
+				$ENV{GENESIS_BOSH_COMMAND} = "\\$boshcmd" if $? > 0;
+				chomp $ENV{GENESIS_BOSH_COMMAND};
 				debug("#G{Version $1} of #C{$boshcmd} meets or exceeds minimum of #W{$min}");
 				return ();
 			}

--- a/bin/genesis
+++ b/bin/genesis
@@ -351,11 +351,11 @@ sub check_bosh_version {
 		if ($version =~ /version (\S+?)-.*/) {
 			if (new_enough($1, $min)) {
 				# Try to get the full path if possible
-				$ENV{GENESIS_BOSH_COMMAND} = `command -v $boshcmd`;
-				$ENV{GENESIS_BOSH_COMMAND} = `which $boshcmd` if $? > 0;
-				$ENV{GENESIS_BOSH_COMMAND} = "\\$boshcmd" if $? > 0;
+				$ENV{GENESIS_BOSH_COMMAND} = `/usr/bin/env bash -c 'command -v $boshcmd 2>/dev/null' 2>/dev/null`;
+				$ENV{GENESIS_BOSH_COMMAND} = `which $boshcmd 2>/dev/null` if $? != 0;
+				$ENV{GENESIS_BOSH_COMMAND} = "\\$boshcmd" if $? != 0;
 				chomp $ENV{GENESIS_BOSH_COMMAND};
-				debug("#G{Version $1} of #C{$boshcmd} meets or exceeds minimum of #W{$min}");
+				debug("#G{Version $1} of #C{$ENV{GENESIS_BOSH_COMMAND}} meets or exceeds minimum of #W{$min}");
 				return ();
 			}
 			$best = $1 if new_enough($1, $best); # Track the best we've found for error message

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,3 +1,19 @@
+# Breaking Changes
+
+* No longer set $HTTPS_PROXY to $BOSH_ALL_PROXY
+
+  This broke under two conditions:
+
+  1) If you wanted to use BOSH via a proxy, but your vault was on your
+     home network
+
+  2) If you used a protocol of ssh+socks5, which is not supported by
+     HTTPS_PROXY.
+
+  Instead, if you are setting BOSH_ALL_PROXY, you must set HTTPS_PROXY or
+  alternatively SAFE_ALL_PROXY instead of relying on Genesis to do that
+  for you.
+
 # Improvements
 
 * Now supports extraction of bosh variables and credhub secrets into exodus
@@ -29,3 +45,20 @@
   script, via spruce, to perform actions such as:
   `(( vault $GENESIS_EXODUS_MOUNT params.cf_deployment_name ":admin_password" ))`
 
+* Add features hook
+
+  While blueprint hook has the ability to make decisions on when a feature
+  is NOT present, or on specific combinations of features, that ability is
+  beyond other interactions.
+
+  We used to have a subkit hook which would allow you to create derived
+  features so that default features and not-features could show up as
+  explicit features, which allows things like secrets management to
+  determine dependencies for these. (ie lack of a features can result in a
+  `not-feature` derived feature to add secrets for a default state)
+
+  This has been re-realized as a `features` hook, which given a list of
+  features in the `$GENESIS_REQUESTED_FEATURES` value, can provide a
+  derived list of features, which will be used by internal genesis for the
+  environment's features list, which in turn will be used to populate
+  `$GENESIS_REQUESTED_FEATURES` for other hooks.

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,23 @@
+# Improvements
+
+* Now supports extraction of bosh variables and credhub secrets into exodus
+  data for cross-kit integration and addon support.
+
+* When testing availability of the vault, it specifies the alias and url of
+  the vault instead of specifying "selected vault"
+
+# Bug Fixes
+
+* Universal support for timeout detection when attempting to connect to remote
+  BOSH and Vault, with better feedback in case of timeout (Fixes #412)
+
+* Adds support for multiline provided secrets rotation and addition (Fixes #413)
+
+* Fix typo in rotate-secrets help (Fixes #414)
+
+* Deployments using legacy mode for secrets providers now get the vault
+  connection validated prior to using it
+
+* Fixed bug where non-standard secrets mount would report the vault was
+  uninitialized.
+

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -6,6 +6,8 @@
 * When testing availability of the vault, it specifies the alias and url of
   the vault instead of specifying "selected vault"
 
+* Clarify usage of --recreate and --fix options for deploy
+
 # Bug Fixes
 
 * Universal support for timeout detection when attempting to connect to remote
@@ -20,4 +22,10 @@
 
 * Fixed bug where non-standard secrets mount would report the vault was
   uninitialized.
+
+# Kit Authoring Improvements
+
+* Kit manifests can now use the same environment variables used by the hooks
+  script, via spruce, to perform actions such as:
+  `(( vault $GENESIS_EXODUS_MOUNT params.cf_deployment_name ":admin_password" ))`
 

--- a/lib/Genesis.pm
+++ b/lib/Genesis.pm
@@ -446,7 +446,7 @@ sub run {
 
 	local %ENV = %ENV; # To get local scope for duration of this call
 	for (keys %{$opts{env} || {}}) {
-		$ENV{$_} = $opts{env}{$_};
+		$ENV{$_} = $opts{env}{$_}||"";
 		trace("#M{Setting: }#B{$_}='#C{$ENV{$_}}'");
 	}
 	my $shell = $opts{shell} || '/bin/bash';

--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -1042,7 +1042,7 @@ sub deploy {
 	$ok = $self->vault->query(
 		{ onfailure => "#R{Failed to export $self->{name} metadata.}\n".
 		               "Deployment was still successful, but metadata used by addons and other kits is outdated.\n".
-		               "This may be resolved by deploying again, or it maybe a permissions issue while trying to\n".
+		               "This may be resolved by deploying again, or it may be a permissions issue while trying to\n".
 		               "write to vault path '".$self->exodus_base."'\n"
 		},
 		'rm',  $self->exodus_base, "-f",

--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -432,7 +432,7 @@ sub features {
 	my $ref = $_[0]->_memoize('__features', sub {
 		my $self = shift;
 		my $features = scalar($self->lookup(['kit.features', 'kit.subkits'], []));
-		$features = $self->kit->run_hook('features',features => $features)
+		$features = [$self->kit->run_hook('features',features => $features)]
 			if $self->kit->has_hook('features');
 		$features;
 	});

--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -589,6 +589,7 @@ sub _manifest {
 		} else {
 			debug("running spruce merge of all files, with evaluation, to generate a manifest");
 		}
+		setup_hook_env_vars; # For merging genesis environment variables
 		my $out = run({
 				onfailure => "Unable to merge $self->{name} manifest",
 				stderr => "&1",

--- a/lib/Genesis/Helpers.pm
+++ b/lib/Genesis/Helpers.pm
@@ -456,8 +456,8 @@ export -f valid_features
 validate_features() {
   local __bad
   if ! valid_features "$@"; then
-    __bail "$GENESIS_KIT_NAME/$GENESIS_KIT_VERSION does not understand the following feature flags:" \
-      "$(for __bad in $(invalid_features "$@"); do echo " - $__bad"; done)"
+    __bail "#R{[ERROR]} $GENESIS_KIT_ID does not understand the following feature flags:" \
+      "$(for __bad in $(invalid_features "$@"); do echo " - $__bad"; done; echo)"
   fi
 }
 export -f validate_features

--- a/lib/Genesis/Helpers.pm
+++ b/lib/Genesis/Helpers.pm
@@ -219,6 +219,10 @@ export -f bosh
 
 bosh_cpi() {
   local __have_env
+	if [[ -n "${GENESIS_TESTING_BOSH_CPI:-}" ]] ; then
+		echo "$GENESIS_TESTING_BOSH_CPI"
+		return 0
+	fi
   __have_env="$(bosh env --json | jq -r '.Tables[0].Rows[0].cpi')"
   [[ "$?" != "0" ]] && \
     __bail "Cannot determine CPI from BOSH director - failed to communicate with BOSH director:" \

--- a/lib/Genesis/Kit.pm
+++ b/lib/Genesis/Kit.pm
@@ -82,7 +82,7 @@ sub run_hook {
 
 	die "Unrecognized hook '$hook'\n"
 		unless grep { $_ eq $hook } qw/new blueprint secrets info addon check pre-deploy post-deploy
-		                               prereqs subkit/;
+		                               prereqs features subkit/;
 
 	if (grep { $_ eq $hook } qw/new secrets info addon check prereqs blueprint pre-deploy post-deploy/) {
 
@@ -96,7 +96,7 @@ sub run_hook {
 		$ENV{$_} = $env_vars{$_} for (keys %env_vars);
 		trace ('got env info');
 
-	} elsif ($hook eq 'subkit') {
+	} elsif (grep { $_ eq $hook}  qw/features subkit/) {
 		bug("The 'features' option to run_hook is required for the '$hook' hook!!")
 			unless $opts{features};
 		$ENV{GENESIS_TARGET_VAULT} = $ENV{SAFE_TARGET} = (Genesis::Vault->current || Genesis::Vault->default)->ref; #for legacy
@@ -129,6 +129,9 @@ sub run_hook {
 		my $fn = $opts{env}->tmppath("data");
 		mkfile_or_fail($fn, $opts{data}) if ($opts{data});
 		$ENV{GENESIS_PREDEPLOY_DATAFILE} = $fn;
+
+	} elsif ($hook eq 'features') {
+		$ENV{GENESIS_REQUESTED_FEATURES} = join(" ", @{ $opts{features} });
 
 	##### LEGACY HOOKS
 	} elsif ($hook eq 'subkit') {

--- a/lib/Genesis/Kit.pm
+++ b/lib/Genesis/Kit.pm
@@ -92,7 +92,8 @@ sub run_hook {
 
 		trace ('getting env info');
 		bug("The 'env' option to run_hook is required for the '$hook' hook!!") unless $opts{env};
-		$opts{env}->setup_hook_env_vars($hook);
+		my %env_vars = $opts{env}->get_environment_variables($hook);
+		$ENV{$_} = $env_vars{$_} for (keys %env_vars);
 		trace ('got env info');
 
 	} elsif ($hook eq 'subkit') {

--- a/lib/Genesis/Legacy.pm
+++ b/lib/Genesis/Legacy.pm
@@ -256,7 +256,9 @@ sub run_param_hook {
 
 sub new_environment {
 	my ($self) = @_;
-	$self->setup_hook_env_vars('new');
+	local %ENV = %ENV;
+	my %env = $self->get_environment_variables('new');
+	$ENV{$_} = $env{$_} for (keys %env);
 
 	my ($k, $kit, $version) = ($self->{kit}, $self->{kit}->name, $self->{kit}->version);
 	my $meta = $k->metadata;

--- a/lib/Genesis/Top.pm
+++ b/lib/Genesis/Top.pm
@@ -244,7 +244,7 @@ sub vault {
 			);
 		} else {
 			if ($self->{_vault} = Genesis::Vault::default) {
-				$self->{_vault}->set_as_current()->ref_by_name();
+				$self->{_vault}->connect_and_validate()->ref_by_name();
 			}
 		}
 	}

--- a/lib/Genesis/Vault.pm
+++ b/lib/Genesis/Vault.pm
@@ -218,13 +218,15 @@ sub tls     { $_[0]->{url} =~ "^https://"; }
 sub connect_and_validate {
 	my ($self) = @_;
 	unless ($self->is_current) {
-		printf STDERR csprintf("\n#yi{Verifying availability of selected vault...}")
+		printf STDERR csprintf("\n#yi{Verifying availability of vault '%s' (%s)...}", $self->name, $self->url)
 			unless in_callback || under_test;
 		my $status = $self->status;
 		error("#%s{%s}\n", $status eq "ok"?"G":"R", $status)
 			unless in_callback || under_test;
 		debug "Vault status: $status";
-		bail("#R{[ERROR]} Could not connect to vault: status is $status") unless $status eq "ok";
+		bail("#R{[ERROR]} Could not connect to vault%s",
+			(in_callback || under_test) ? sprintf(" '%s' (%s): status is %s)", $self->name, $self->url,$status):""
+		) unless $status eq "ok";
 	}
 	return $self->set_as_current;
 }

--- a/lib/Genesis/Vault.pm
+++ b/lib/Genesis/Vault.pm
@@ -354,7 +354,8 @@ sub status {
 		bail("Invalid vault target URL #C{%s}: expecting http(s)://ip-or-domain(:port)", $self->url);
 	my $ip = $2;
 	my $port = $3 || ($1 eq "s" ? 443 : 80);
-	return "unreachable" unless tcp_listening($ip,$port);
+	my $status = tcp_listening($ip,$port);
+	return "unreachable - $status" unless $status eq 'ok';
 
 	return "unauthenticated" if $self->token eq "";
 	my ($out,$rc) = $self->query({stderr => "&1"}, "vault", "status");

--- a/lib/Genesis/Vault.pm
+++ b/lib/Genesis/Vault.pm
@@ -366,7 +366,7 @@ sub status {
 		return "sealed" if $1 == 2;
 		return "unreachable";
 	}
-	return "uninitialized" unless $self->has($secrets_mount.'handshake');
+	return "uninitialized" unless $self->has($secrets_mount.'handshake') || $self->has('/secret/handshake');
 	return "ok"
 }
 

--- a/t/20-kit.t
+++ b/t/20-kit.t
@@ -35,17 +35,18 @@ sub lookup { "a-value" }
 sub bosh_target { 'a-bosh'; }
 sub path { "some/path/some/where".($_[1]?"/$_[1]":""); }
 sub vault { $_[0]->{vault} }
-sub setup_hook_env_vars {
+sub get_environment_variables {
 	my $self = shift;
-	$ENV{GENESIS_ROOT}         = $self->path;
-	$ENV{GENESIS_ENVIRONMENT}  = $self->name;
-	$ENV{GENESIS_TYPE}         = $self->type;
-	$ENV{GENESIS_TARGET_VAULT} = $ENV{SAFE_TARGET} = $self->vault->ref;
-	$ENV{GENESIS_VERIFY_VAULT} = $self->vault->verify || "";
+	my %env;
+	$env{GENESIS_ROOT}         = $self->path;
+	$env{GENESIS_ENVIRONMENT}  = $self->name;
+	$env{GENESIS_TYPE}         = $self->type;
+	$env{GENESIS_TARGET_VAULT} = $env{SAFE_TARGET} = $self->vault->ref;
+	$env{GENESIS_VERIFY_VAULT} = $self->vault->verify || "";
 
-	$ENV{HOOK_ENV_VARS}='setup';
-	$ENV{GENESIS_VAULT_PREFIX} = $ENV{GENESIS_SECRETS_PATH} = secrets_path;
-	1;
+	$env{HOOK_ENV_VARS}='setup';
+	$env{GENESIS_VAULT_PREFIX} = $env{GENESIS_SECRETS_PATH} = secrets_path;
+	return %env;
 }
 
 package main;

--- a/t/21-hooks.t
+++ b/t/21-hooks.t
@@ -229,13 +229,14 @@ params:
 EOF
 		"[fancy] the 'new' hook should populate the env yaml file properly";
 
-
 	{
 		local $ENV{HOOK_SHOULD_FAIL} = 'yes';
-		my $env =  Genesis::Env->new(top => $top, name => 'env-should-fail', vault => $vault);
-		$env->{__params} = {
-			genesis => {env => $env->name} # compensate for not using Genesis::Env#create
-		};
+		my $name = 'env-should-fail';
+		my $env =  Genesis::Env->new(
+			top => $top, name => $name,
+			kit => $fancy, vault => $vault,
+			__params => {genesis => {env => $name}} # compensate for not using Genesis::Env#create
+		);
 		
 		throws_ok {
 			$fancy->run_hook('new', env => $env);
@@ -247,10 +248,12 @@ EOF
 
 	{
 		local $ENV{HOOK_SHOULD_CREATE_ENV_FILE} = 'no';
-		my $env = Genesis::Env->new(top => $top, name => 'env-should-fail', vault => $vault);
-		$env->{__params} = {
-			genesis => {env => $env->name} # compensate for not using Genesis::Env#create
-		};
+		my $name = 'env-should-fail';
+		my $env = Genesis::Env->new(
+			top => $top, name => $name,
+			kit => $fancy, vault => $vault,
+			__params => {genesis => {env => $name}} # compensate for not using Genesis::Env#create
+		);
 		throws_ok {
 			$fancy->run_hook('new', env => $env );
 		} qr/could not create/i;

--- a/t/30-env.t
+++ b/t/30-env.t
@@ -745,6 +745,10 @@ standalone-thing
 deploy
 --no-redact
 $env->{__tmp}/manifest.yml
+
+Deployment successful.  Preparing metadata for export...
+Done.
+
 EOF
 		"Deploy should call BOSH with the correct options");
 
@@ -861,6 +865,10 @@ deploy
 -l
 $varsfile
 $env->{__tmp}/manifest.yml
+
+Deployment successful.  Preparing metadata for export...
+Done.
+
 EOF
 
 	eq_or_diff get_file($env->vars_file), <<EOF, "download_cloud_config calls BOSH correctly";

--- a/t/secrets.t
+++ b/t/secrets.t
@@ -274,7 +274,7 @@ EOF
 			secret/genesis-2.7.0/deployments/dev/azure/us1/passwords:alt
 			secret/genesis-2.7.0/deployments/dev/azure/us1/passwords:alt-base64
 			secret/genesis-2.7.0/deployments/dev/azure/us1/passwords:uncrypted
-			secret/genesis-2.7.0/deployments/dev/azure/us1/passwords:crypted), 
+			secret/genesis-2.7.0/deployments/dev/azure/us1/passwords:crypted),
 
 			# This following crl and serial seem to be bumped by safe when something they signed is rotated.
 		qw(

--- a/t/secrets.t
+++ b/t/secrets.t
@@ -44,7 +44,7 @@ subtest 'secrets-v2.7.0' => sub {
 	expect_ok $cmd, [ "What is your base domain?", sub { $_[0]->send("demo.genesisproject.io\n"); }];
 	expect_exit $cmd, 0, "genesis creates a new environment and auto-generates certificates - set secrets stuff to non-standard";
 
-	my ($pass,$rc,$out) = runs_ok("genesis lookup $env_name .");
+	my ($pass,$rc,$out) = runs_ok("genesis lookup $env_name . 2>/dev/null");
 	my $properties;
 	lives_ok {$properties = decode_json($out)} "genesis lookup on environment returns parsable json";
 

--- a/t/src/fancy/hooks/features-disabled
+++ b/t/src/fancy/hooks/features-disabled
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [[ ${HOOK_SHOULD_FAIL:-no} = "yes" ]]; then
+	set -u
+	echo "$garblerflaven"
+  exit 42;
+fi
+
+if [[ ${HOOK_NO_FEATURES:-no} = "yes" ]]; then
+	exit 0
+fi
+
+(
+if want_feature always-first; then
+	echo "always-first"
+fi
+for feature in $GENESIS_REQUESTED_FEATURES; do
+	[[ "$feature" == "always-first" ]] || echo "$feature"
+done
+if ! want_feature shazzam; then
+	echo no-shazzam
+fi
+
+) | uniq


### PR DESCRIPTION
# Improvements

* Now supports extraction of bosh variables and credhub secrets into exodus
  data for cross-kit integration and addon support.

* When testing availability of the vault, it specifies the alias and url of
  the vault instead of specifying "selected vault"

# Bug Fixes

* Universal support for timeout detection when attempting to connect to remote
  BOSH and Vault, with better feedback in case of timeout (Fixes #412)

* Adds support for multiline provided secrets rotation and addition (Fixes #413)

* Fix typo in rotate-secrets help (Fixes #414)

* Deployments using legacy mode for secrets providers now get the vault
  connection validated prior to using it

* Fixed bug where non-standard secrets mount would report the vault was
  uninitialized.