### PR TITLE
Use spruce in ci-show-changes

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -2644,8 +2644,8 @@ current_variables="$(bosh int <(bosh curl "/deployments/${deployment}/variables"
                    | jq 'map("\(.name)@\(.id)") | {credhub_variables: .}'))"
 
 bosh diff-config --json \
-     --from-content <(bosh int <(printf "%s\n%s\n%s" "${current_configs}" "${current_manifest}" "${current_variables}")) \
-     --to-content <(bosh int <(printf "%s\n%s\n%s" "${new_configs}" "${new_manifest}" "${new_variables}") -l ${vars_file}) \
+     --from-content <(bosh int <(spruce merge --fallback-append <(echo "${current_configs}") <(echo "${current_manifest}") <(echo "${current_variables}"))) \
+     --to-content <(bosh int <(spruce merge --fallback-append <(echo "${new_configs}") <(echo "${new_manifest}") <(echo "${new_variables}")) -l ${vars_file}) \
      | jq -r '.Tables[0].Rows[0] | if (.diff == "" ) then "[32;1mNo differences found.[0m" else .diff end'
 EOF
 


### PR DESCRIPTION
Use spruce to merge the variables, configs and manifests in
`ci-show-changes` when comparing the before and after states.  This
replaces the use of concatenation, which caused problems when the same
fields exist in multiple files.

[//]: # (category:Bug Fixes)