### PR TITLE
Makes genesis check -h output consistent with flags that genesis check takes

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -1369,7 +1369,7 @@ performed as per the options below.  Run with the -q|--quiet flag will result
 in no output except exit-code 0 on success, 1 otherwise.
 
 OPTIONS
-  --no-cloud-config Do not run cloud config tests.
+  --no-config Do not run cloud config tests.
   --[no-]secrets    Determines if the secrets checks are run.
                     Runs by default.
   --[no-]manifest   Determines if the secrets checks are run.


### PR DESCRIPTION
`genesis check -h` lists --no-cloud-config as a flag, while the code itself errors if --no-cloud-config is provided because it is actually expecting --no-config. In this PR I'm changing the help to match the code, though thoughts on instead changing the genesis code to expect --no-cloud-config welcome.

resolves #433 