### PR TITLE
Bumps CLI version requirement for jq from 1.5 to 1.6

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -476,7 +476,7 @@ sub check_prereqs {
 		["safe",    "1.5.9", "safe -v        2>&1 >/dev/null",        qr(safe v(\S+)),          "https://github.com/starkandwayne/safe/releases"],
 		["vault",   "0.9.0", "vault -v       2>/dev/null",            qr(.*vault v(\S+).*)i,    "https://www.vaultproject.io/downloads.html"],
 		["git",     "1.8.0", "git --version  2>/dev/null",            qr(.*version\s+(\S+).*)],
-		["jq",        "1.5", "jq --version   2>/dev/null",            qr(^jq-([\.0-9]+)),       "https://stedolan.github.io/jq/download/"],
+		["jq",        "1.6", "jq --version   2>/dev/null",            qr(^jq-([\.0-9]+)),       "https://stedolan.github.io/jq/download/"],
 		["curl",   "7.30.0", "curl --version 2>/dev/null | head -n1", qr(^curl\s+(\S+))],
 		["perl",   "5.10.0", "/usr/bin/perl -v 2>/dev/null | head -n2 | grep version", qr/\(v([0-9\.]+)\)/],
 	];


### PR DESCRIPTION
According to #443, jq v1.5 errors when genesis tries to use it on Debian 10. Updating to jq v1.6 (latest version) fixes the issue. 

Resolves #443  