### PR TITLE
Improve debugging logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: sanity-test test test-quick test-secrets test-ci release dev-release clean coverage
 
 sanity-test:
-	perl -Ilib -c bin/genesis && perl -Ilib -- bin/genesis -D ping
+	perl -Ilib -c bin/genesis && perl -Ilib -- bin/genesis -D ping 2>&1| grep "DEBUG"
 
 coverage:
 	SKIP_SECRETS_TESTS=yes cover -t -ignore_re '(/Legacy.pm|/UI.pm|^t/|/JSON/)'

--- a/bin/genesis
+++ b/bin/genesis
@@ -566,7 +566,14 @@ our $GLOBAL_USAGE = <<EOF;
                     Genesis is doing, to standard error.
 
   -T, --trace       Even more debugging, including debugging inside called
-                    tools (like spruce and bosh).
+                    tools (like spruce and bosh).  Any trace commands within
+                    the Genesis codebase will be printed, along with identifying
+                    the line they were encountered.
+
+  -S, --show-stack  Will show stack trace when displaying fatal error due to
+                    runtime conditions or bugs.  When -T|--trace is also
+                    specified, each trace will contain the full stack of where
+                    it was encountered.
 
   -C, --cwd         Effective working directory.  You can also specify the
                     environment YAML file to use, in which case the working
@@ -617,6 +624,7 @@ sub options {
 			help|h
 			debug|D+
 			trace|T+
+			show-stack|S
 			quiet|q
 			cwd|C=s
 			environment|bosh-env|e=s
@@ -639,6 +647,7 @@ sub options {
 	$ENV{GENESIS_DEBUG}  = 'y' if $debug || envset "DEBUG";
 	$ENV{GENESIS_TRACE}  = 'y' if $trace;
 	$ENV{GENESIS_TSTAMP} = 'y' if $debug > 1;
+	$ENV{GENESIS_STACK_TRACE} = "y" if delete($options->{'show-stack'});
 
 	# spruce debugging
 	$ENV{DEBUG}          = 'y' if $trace > 1;

--- a/lib/Genesis.pm
+++ b/lib/Genesis.pm
@@ -7,7 +7,7 @@ use utf8;
 our $VERSION = "(development)";
 our $BUILD   = "";
 
-our $GITHUB  = "https://github.com/starkandwayne/genesis";
+our $GITHUB  = "https://github.com/genesis-community/genesis";
 
 use Data::Dumper;
 use File::Basename qw/basename dirname/;
@@ -282,7 +282,7 @@ sub _get_scope {
 	my ($scope) = @_;
 	my $out = "";
 	for (_get_stack($scope+1)) {
-		$out .= csprintf("#K\@{^-}#Ki{%s:L%d (in %s)\n}", $_->{file}, $_->{line}, $_->{sub});
+		$out .= csprintf("#K\@{^-}#Ki{ %s:L%d (in %s)\n}", $_->{file}, $_->{line}, $_->{sub});
 		last unless envset ("GENESIS_STACK_TRACE");
 	}
 	chomp $out;
@@ -295,7 +295,7 @@ sub _get_stack {
 	my ($file,$line,$sub,@stack,@info);
   while (@info = caller($scope++)) {
 		$sub = $info[3];
-		push @stack, {line => $line, sub => $sub, file => $file} if ($file);
+		push @stack, {line => $line, sub => $sub, file => humanize_path($file)} if ($file);
 		(undef, $file, $line) = @info;
 	}
 	return @stack;
@@ -320,18 +320,19 @@ sub bail {
 
 sub bug {
 	my (@msg) = @_;
-	local %ENV;
-	$ENV{GENESIS_STACK_TRACE} = 1;
-	_log("FATAL", "Genesis defect encountered - please file a defect report with the following stack info", "Wr");
-	_log("FATAL", _get_scope(1));
 
 	my $msg = csprintf(@msg)."\n\n";
 	$msg .= csprintf("#R{This is most likely a bug in Genesis itself.}\n");
+	$msg .= csprintf("\nPlease file an issue on #Bu{%s/issues/new}\nwith the following stack info:\n", $GITHUB);
+	$msg .= csprintf("  #Ki{%s:L%d (in %s)\n}", $_->{file}, $_->{line}, $_->{sub}) for (_get_stack(1));
+
 	if ($Genesis::VERSION =~ /dev/) {
-		$msg .= csprintf("$_\n") for (
-			"#Y{NOTE: This is a development build of Genesis, not an official release.}",
+		$msg .= csprintf("#Y{%s}\n", $_) for (
+			"",
+			"NOTE: This is a development build of Genesis, not an official release.",
 			"      Please try to reproduce this behavior with an officially-released",
-			"      version before submitting issues to the Genesis Github repository.\n"
+			"      version before submitting issues to the Genesis Github repository.",
+			""
 		);
 	}
 	$! = 2; die csprintf($msg);

--- a/lib/Genesis.pm
+++ b/lib/Genesis.pm
@@ -293,7 +293,7 @@ sub _get_stack {
 	my ($scope) = @_;
 
 	my ($file,$line,$sub,@stack,@info);
-  while (@info = caller($scope++)) {
+	while (@info = caller($scope++)) {
 		$sub = $info[3];
 		push @stack, {line => $line, sub => $sub, file => humanize_path($file)} if ($file);
 		(undef, $file, $line) = @info;
@@ -377,7 +377,7 @@ sub new_enough {
 
 sub strfuzzytime {
 	my ($datestring,$output_format, $input_format) = @_;
-  $input_format ||= "%Y-%m-%d %H:%M:%S %z";
+	$input_format ||= "%Y-%m-%d %H:%M:%S %z";
 
 	my $time = Time::Piece->strptime($datestring,$input_format);
 	my $delta = Time::Piece->new() - $time;

--- a/t/00-utils.t
+++ b/t/00-utils.t
@@ -108,7 +108,7 @@ subtest 'output utilities' => sub {
 			  error("this is an error");
 			}, "DEBUG> this is debugging\n".
 			   "TRACE> this is trace (debugging's debugging)\n".
-			   "       ⬑ t/00-utils.t:L107 (in main::__ANON__)\n".
+			   "       ⬑  t/00-utils.t:L107 (in main::__ANON__)\n".
 			   "this is an error\n", "with GENESIS_TRACE, you get trace to standard error");
 	}
 };

--- a/t/00-utils.t
+++ b/t/00-utils.t
@@ -17,11 +17,12 @@ use Cwd ();
 my $start_dir = Cwd::getcwd;
 subtest 'bug reporting utilities' => sub {
 	local $Genesis::VERSION = '2.6.0';
-	throws_ok { bug("an example bug"); } qr{
-			an \s+ example \s+ bug.*
-			a \s+ bug \s+ in \s+ genesis.*
-			file \s+ an \s+ issue .* https://github\.com/starkandwayne/genesis/issues
-		}six, "bug() reports all the necessary details";
+	quietly {
+		throws_ok { bug("an example bug"); } qr{
+				an \s+ example \s+ bug.*
+				a \s+ bug \s+ in \s+ Genesis.*
+			}six, "bug() reports all the necessary details";
+	};
 };
 
 subtest 'environment variable utilities' => sub {
@@ -107,7 +108,7 @@ subtest 'output utilities' => sub {
 			  error("this is an error");
 			}, "DEBUG> this is debugging\n".
 			   "TRACE> this is trace (debugging's debugging)\n".
-			   "       ⬑ t/00-utils.t:L106 (in main::__ANON__)\n".
+			   "       ⬑ t/00-utils.t:L107 (in main::__ANON__)\n".
 			   "this is an error\n", "with GENESIS_TRACE, you get trace to standard error");
 	}
 };

--- a/t/00-utils.t
+++ b/t/00-utils.t
@@ -107,6 +107,7 @@ subtest 'output utilities' => sub {
 			  error("this is an error");
 			}, "DEBUG> this is debugging\n".
 			   "TRACE> this is trace (debugging's debugging)\n".
+			   "       ⬑ t/00-utils.t:L106 (in main::__ANON__)\n".
 			   "this is an error\n", "with GENESIS_TRACE, you get trace to standard error");
 	}
 };

--- a/t/05-bosh.t
+++ b/t/05-bosh.t
@@ -43,11 +43,15 @@ subtest 'bosh create-env' => sub {
 	ok Genesis::BOSH->create_env("manifest.yml", state => "state.json"),
 		"create_env with state file should work";
 
-	throws_ok { Genesis::BOSH->create_env() }
-		qr/missing deployment manifest/i;
+	quietly {
+		throws_ok { Genesis::BOSH->create_env() }
+			qr/missing deployment manifest/i;
+  };
 
-	throws_ok { Genesis::BOSH->create_env("manifest.yml") }
-		qr/missing 'state' option/i;
+	quietly {
+		throws_ok { Genesis::BOSH->create_env("manifest.yml") }
+			qr/missing 'state' option/i;
+	};
 
 	bosh_runs_as("create-env --state state.json -l path/to/vars-file.yml manifest.yml");
 	ok Genesis::BOSH->create_env("manifest.yml", state => "state.json", vars_file => "path/to/vars-file.yml"),
@@ -68,9 +72,11 @@ subtest 'bosh cloud-config' => sub {
 		"download_cloud_config should work";
 
 	bosh_outputs_json('-e "some-env" config --type cloud --name default --json',"");
-	throws_ok { Genesis::BOSH->download_cloud_config('some-env', "$out/cloud.yml") }
-		qr/no cloud-config defined/i,
-		"without cloud-config output, download_cloud_config should fail";
+	quietly {
+		throws_ok { Genesis::BOSH->download_cloud_config('some-env', "$out/cloud.yml") }
+			qr/no cloud-config defined/i,
+			"without cloud-config output, download_cloud_config should fail";
+	};
 };
 
 subtest 'bosh deploy' => sub {
@@ -88,11 +94,15 @@ subtest 'bosh deploy' => sub {
 	                                           flags      => ['--some', '--flags']); }
 		"deploy should pass through vars-file, options and flags properly";
 
-	throws_ok { Genesis::BOSH->deploy } qr/missing bosh environment name/i;
-	throws_ok { Genesis::BOSH->deploy("an-env") }
-		qr/missing 'manifest' option/i;
-	throws_ok { Genesis::BOSH->deploy("an-env", manifest => 'manifest.yml') }
-		qr/missing 'deployment' option/i;
+	quietly { throws_ok { Genesis::BOSH->deploy } qr/missing bosh environment name/i; };
+	quietly {
+		throws_ok { Genesis::BOSH->deploy("an-env") }
+			qr/missing 'manifest' option/i;
+	};
+	quietly {
+		throws_ok { Genesis::BOSH->deploy("an-env", manifest => 'manifest.yml') }
+			qr/missing 'deployment' option/i;
+	};
 };
 
 subtest 'bosh alias' => sub {
@@ -108,11 +118,15 @@ subtest 'bosh run_errand' => sub {
 	                                               errand     => "smoke-tests") }
 		"run_errand works with env, deploytment, and errand name set";
 
-	throws_ok { Genesis::BOSH->run_errand } qr/missing bosh environment name/i;
-	throws_ok { Genesis::BOSH->run_errand("an-env") }
-		qr/missing 'deployment' option/i;
-	throws_ok { Genesis::BOSH->run_errand("an-env", deployment => 'my-dep') }
-		qr/missing 'errand' option/i;
+	quietly { throws_ok { Genesis::BOSH->run_errand } qr/missing bosh environment name/i; };
+	quietly {
+		throws_ok { Genesis::BOSH->run_errand("an-env") }
+			qr/missing 'deployment' option/i;
+	};
+	quietly {
+		throws_ok { Genesis::BOSH->run_errand("an-env", deployment => 'my-dep') }
+			qr/missing 'errand' option/i;
+	};
 };
 
 subtest 'environment variable management' => sub {

--- a/t/20-kit.t
+++ b/t/20-kit.t
@@ -105,20 +105,22 @@ sub decompile_kit {
 
 subtest 'kit utilities' => sub {
 	my $kit = kit('test', '1.0.0');
-	throws_ok { $kit->kit_bug('buggy behavior') }
+	quietly { throws_ok { $kit->kit_bug('buggy behavior') }
 		qr{
 			buggy \s+ behavior.*
 			a \s+ bug \s+ in \s+ the \s+ test/1\.0\.0 \s+ kit.*
 			file \s+ an \s+ issue \s+ at .* https://github\.com/.*/issues
 		}six, "kit_bug() reports the pertinent details for a compiled kit";
+	};
 
 	my $dev = decompile_kit('test', '1.0.0');
-	throws_ok { $dev->kit_bug('buggy behavior') }
+	quietly { throws_ok { $dev->kit_bug('buggy behavior') }
 		qr{
 			buggy \s+ behavior.*
 			a \s+ bug \s+ in \s+ your \s+ dev/ \s+ kit.*
 			contact .* author .* you
 		}six, "kit_bug() reports the pertinent details for a dev kit";
+	};
 };
 
 subtest 'compiled kits' => sub {
@@ -280,7 +282,7 @@ subtest 'version requirements' => sub {
 	local $Genesis::VERSION;
 
 	$Genesis::VERSION = '0.0.1';
-	ok !$kit->check_prereqs, 'v0.0.1 is too old for the t/src/simple kit prereq of 2.6.0';
+	quietly {ok !$kit->check_prereqs, 'v0.0.1 is too old for the t/src/simple kit prereq of 2.6.0';};
 
 	$Genesis::VERSION = '9.9.9';
 	ok $kit->check_prereqs, 'v9.9.9 is new enough for the t/src/simple kit prereq of 2.6.0';


### PR DESCRIPTION
Adds the -S|--show-stack debug option, and gives better context of traces
and errors.

Behaviour Changes:

- internal `trace` output will show the location in the code were it was
  called. If --show-stack option specified, it will show the full stack
  instead of just the location.

- internal `dump_vars` output will now show the full stack instead of
  just the calling location if --show-stack specified (along with
  --trace or --debug)

- internal `bail` will show calling location if --trace or --debug is
  specified, or the full stack if --show-stack is specified (with or
  without --debug or --trace).  This allows you to see where genesis
  terminates without wading through all the trace output.

- internal `bug` will always full stack where the bug was encountered.
  This allows the user to paste the stack into a defect report against
  the genesis project.