### PR TITLE
Genesis update

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -1206,12 +1206,12 @@ sub {
 		exit 0
 	}
 
-	waiting_on("\nCollecting information on %s kit provider for #C{%s} deployment at #M{%s} ...", $kit_provider_lookup, $top->type, humanize_path($top->path));
+	explain("\nCollecting information on %s kit provider for #C{%s} deployment at #M{%s}", $kit_provider_lookup, $top->type, humanize_path($top->path));
 	my %info;
 	eval {
 		%info = $top->kit_provider_info($verbose);
 	};
-	explain("done.\n");
+	explain("Complete.\n");
 	bail "#R{[ERROR]} $@\n" if $@;
 
 	explain("         Type: #M{%s}\n", $info{type});

--- a/bin/genesis
+++ b/bin/genesis
@@ -559,8 +559,12 @@ sub deprecated {
 }
 
 
-our $GLOBAL_USAGE = <<EOF;
+our $BASE_USAGE = <<EOF;
   -h, --help        Show this help screen.
+
+      --[no]-color  Enable [or disable] color output
+
+  -q, --quiet       Suppress informative output (errors will still be displayed)
 
   -D, --debug       Enable debugging, printing helpful message about what
                     Genesis is doing, to standard error.
@@ -574,12 +578,16 @@ our $GLOBAL_USAGE = <<EOF;
                     runtime conditions or bugs.  When -T|--trace is also
                     specified, each trace will contain the full stack of where
                     it was encountered.
-
+EOF
+our $REPO_USAGE = <<EOF;
+$BASE_USAGE
   -C, --cwd         Effective working directory.  You can also specify the
                     environment YAML file to use, in which case the working
                     directory is the one containing the specified file.
                     Defaults to '.'
-
+EOF
+our $GLOBAL_USAGE = <<EOF;
+$REPO_USAGE
   -e, --bosh-env    Which BOSH environment (aka director) to use.  If not
                     specified, it will use the value in genesis.bosh or
                     genesis.env in that order.  Can also be provided using
@@ -617,24 +625,31 @@ our $GLOBAL_USAGE = <<EOF;
 EOF
 sub options {
 	my ($args, $options, @spec) = @_;
+	my $base_opt_type = (defined($spec[0]) && $spec[0] =~ /_USAGE$/) ? shift(@spec) : '';
+	my @global_spec = (qw/
+		help|h
+		debug|D+
+		trace|T+
+		show-stack|S
+		color!
+		quiet|q/);
+
+	if ($base_opt_type ne 'BASE_USAGE') {
+		push(@global_spec, (qw/
+			cwd|C=s/));
+
+		if ($base_opt_type ne 'REPO_USAGE') {
+			push(@global_spec, (qw/
+				environment|bosh-env|e=s
+				config|c=s@
+				cloud-config|cc=s
+				runtime-config|rc=s/));
+		}
+	}
+
 	$options->{color} = 1 unless exists $options->{color};
 	Getopt::Long::Configure(qw(no_pass_through permute auto_abbrev no_ignore_case bundling));
-	GetOptionsFromArray($args, $options,
-		(qw/
-			help|h
-			debug|D+
-			trace|T+
-			show-stack|S
-			quiet|q
-			cwd|C=s
-			environment|bosh-env|e=s
-			color!
-			config|c=s@
-			cloud-config|cc=s
-			runtime-config|rc=s
-		/,
-		@spec))
-			or usage(1);
+	GetOptionsFromArray($args, $options,(@global_spec,@spec)) or usage(1);
 
 	usage(0) if $options->{help};
 
@@ -800,7 +815,9 @@ genesis v$Genesis::VERSION$Genesis::BUILD
 USAGE: genesis [OPTIONS] COMMAND [MORE OPTIONS]
 
 OPTIONS
-$GLOBAL_USAGE
+$BASE_USAGE
+#Ki{Each command may support further options.}
+
 #U{BASIC ENVIRONMENT MANAGEMENT COMMANDS:}
   #C{init}              Initialize a new Genesis deployment.
   #G{new}               Create a new Genesis deployment environment.

--- a/bin/genesis
+++ b/bin/genesis
@@ -831,6 +831,8 @@ $BASE_USAGE
   #G{manifest}          Generate a redacted BOSH deployment manifest for an environment.
   #G{deploy}            Generate a real manifest using Vault + Cloud Config, and deploy it to BOSH.
   #G{do}                Run an addon script provided by the Kit.  Try `do list`
+  embed             Embed this version of Genesis into the current Genesis deployment repository.
+  #C{update}            Downloads a newer version of Genesis or checks if one is available.
 
 #U{INFORMATIVE COMMANDS:}
   #C{ping}              See if the genesis binary is a real thing.
@@ -971,6 +973,153 @@ sub {
 	# FIXME: update .genesis/config with new version info
 	Genesis::Top->new('.')->embed($ENV{GENESIS_CALLBACK_BIN} || $0);
 });
+
+# }}}
+# genesis update - update the current version of Genesis {{{
+command("update", {alias => 'upgrade'}, <<EOF,
+genesis v$Genesis::VERSION$Genesis::BUILD
+USAGE: genesis update [-c|--check] [-v|--version VERSION] [-d|--details] [-f|--force]
+
+OPTIONS
+$BASE_USAGE
+  -c, --check       Check if a newer version (or the specified version) is
+                    available.
+
+  -v, --version <x> Install the specified version instead of the latest
+
+  -d, --details     Print the release notes of the versions between the current
+                    version and the latest (or the release notes of the
+                    specified version)
+
+  -f, --force       Replace the current genesis executable.  Otherwise,
+                    confirmation will be requested.
+
+EOF
+sub {
+	my %options;
+	options(\@_, \%options, qw/
+		BASE_USAGE
+		check|c
+		version|v=s
+		details|d
+		force|f
+	/);
+	usage(1) if @_;
+
+	use Genesis::Github;
+	my $gh = Genesis::Github->new();
+
+	my ($err,$label,@versions);
+	if ($options{version}) {
+		@versions = $gh->versions('genesis', version => $options{version});
+		if (! @versions) {
+			$err = csprintf("Genesis #C{v%s} does not exist", $options{version});
+		} elsif (! $versions[0]->{url}) {
+			$err = csprintf(
+				"Genesis #C{v%s} found, but the executable is no longer available",
+				$options{version}
+			)
+		} else {
+			$label = csprintf("Version #C{v%s}",$options{version});
+		}
+	} else {
+		@versions = grep {by_semver($_->{version}, $Genesis::VERSION) == 1} $gh->versions('genesis');
+		shift @versions while (@versions && ! defined($versions[0]->{url}));
+		if (@versions) {
+			$label = csprintf("A newer version (#C{v%s})", $versions[0]->{version});
+		} else {
+			$err = csprintf(
+				"No newer version of Genesis (currently #C{v%s}) is available",
+				$Genesis::VERSION
+			)
+		}
+	}
+
+	if ($err) {
+		if ($options{check}) {
+			explain "\n$err.\n";
+			exit 1
+		}
+		bail "#R{[ERROR]} $err - cannot update.";
+	}
+
+	my $extra_versions = scalar(@versions)-1;
+	explain "\n%s is available%s!\n",
+		$label,
+		($extra_versions > 0)
+			? sprintf(" (with %d preceeding release%s)",$extra_versions, ($extra_versions > 2 ? 's' : ''))
+			: '';
+
+	if ($options{details}) {
+		for my $version (@versions) {
+			my $c = ($version->{version} =~ /[\.-]rc[\.-]?(\d+)$/) ? "Y" : ($version->{prerelease} ? "y" : "G");
+			my $d = "";
+			if ($version->{date}) {
+				$d = "Published ".$version->{date};
+				$d .= " - \e[3mPre-release\e[0m"
+				if $version->{prerelease};
+				$d = " ($d)";
+			}
+			explain "  #%s{v%s%s}", $c, $version->{version}, $d;
+			if ($version->{body} && $options{details}) {
+				explain "    Release Notes:";
+				explain "      $_" for split $/, $version->{body};
+				explain "";
+			}
+		}
+	}
+	return 0 if $options{check};
+
+	my $tmpdir = workdir();
+	my $target = $ENV{GENESIS_CALLBACK_BIN};
+	my $version = $versions[0]->{version};
+
+	if (!$options{force}) {
+		die_unless_controlling_terminal;
+		my $overwrite = prompt_for_boolean(
+			csprintf(
+				"[AYour Genesis version is currently #C{v%s}, located at #M{%s}.\nDo you want to overwrite this file with #C{v%s}? [y|n]",
+				$Genesis::VERSION, $target, $version
+			),0);
+		bail "Aborted!\n" unless $overwrite;
+	}
+
+	explain "";
+	my (undef,undef,$file) = $gh->fetch_release('genesis',$version,$tmpdir);
+	my (undef,undef,$fmode,undef,$fuid, $fgid) = stat($target);
+
+	if (-w $target && $fuid == $> && $fgid == $)) {
+		copy_or_fail $file, $target;
+		chmod_or_fail($fmode,$file);
+	} else {
+		mkfile_or_fail($tmpdir."/update_genesis", 0777, <<EOF);
+#!/usr/bin/env bash
+cp "$file" "$target"
+chmod ${\(sprintf("%04o",$fmode))} "$target"
+chown $fuid:$fgid "$target"
+EOF
+		my (undef,$rc) = run({stderr => '/dev/null'}, 'sudo','-n','true');
+		explain(
+			"\n#Yi{Notice:} You will need to enter your password for sudo, as the Genesis\n".
+		  "executable is not in a location the current user has write-access to."
+		) if ($rc);
+		run({
+			onfailure => "#R{[ERROR]} Could not overwrite existing Genesis with #C{v$version}",
+			interactive =>1
+		}, 'sudo', "$tmpdir/update_genesis");
+	}
+
+	# Clean up tempdir before exec-ing to another process (if safe)
+	my @unexpected_contents = grep {
+		$_ !~ /^(genesis|install_genesis)$/
+	} lines(scalar(run('ls -1 "$1"',$tmpdir)));
+	run('rm', '-rf', $tmpdir) unless scalar(@unexpected_contents);
+
+	explain "Verifying new version of Genesis...";
+	exec {$target} $target, 'version';
+
+});
+
 # }}}
 # genesis init - initialize a new Genesis repository {{{
 

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,27 @@
+# New Feature
+
+* Add `update` genesis command to get new version
+
+  Usage: genesis update [-c|--check] [-v|--version VERSION] [-d|--details] [-f|--force]
+
+    -c, --check       Check if a newer version (or the specified version) is
+                      available.
+
+    -v, --version <x> Install the specified version instead of the latest
+
+    -d, --details     Print the release notes of the versions between the current
+                      version and the latest (or the release notes of the
+                      specified version)
+
+    -f, --force       Replace the current genesis executable.  Otherwise,
+                      confirmation will be requested.
+
+# Bug Fixes
+
+* Fix getting non-production github release version
+
+  If user specified version by name, it should include draft and
+  prereleases when looking for it.  This was the initial intent, but the
+  wrong options were set when attempting it.
+
+* Improve `genesis kit-provider -v` status output

--- a/lib/Genesis/Github.pm
+++ b/lib/Genesis/Github.pm
@@ -1,0 +1,298 @@
+package Genesis::Github;
+use strict;
+use warnings;
+
+use Genesis;
+use Genesis::UI;
+
+use Digest::SHA qw/sha1_hex/;
+
+use constant {
+	DEFAULT_DOMAIN => 'github.com',
+	DEFAULT_ORG    => 'genesis-community',
+	DEFAULT_TLS    => 'yes'
+};
+### Class Methods {{{
+
+# new - create a default github kit provider {{{
+sub new {
+	my ($class, %config) = @_;
+	my $tls = $config{tls} || DEFAULT_TLS;
+	$tls = "skip" unless $tls =~ /^(no|yes|skip)$/;
+	
+	my $creds;
+	if ($ENV{GITHUB_USER} && $ENV{GITHUB_AUTH_TOKEN}) {
+		$creds = "$ENV{GITHUB_USER}:$ENV{GITHUB_AUTH_TOKEN}";
+	}
+	bless({
+		domain => $config{domain} || DEFAULT_DOMAIN,
+		org    => $config{org}    || DEFAULT_ORG,
+		creds  => $creds,
+		tls    => $tls,
+		label  => $config{label}
+	}, $class);
+}
+
+# }}}
+# }}}
+
+### Instance Methods {{{
+
+# check - checks the availability of this provider {{{
+sub check {
+	my ($self, $url, $ref) = @_;
+	my $status;
+	$url ||= $self->repos_url;
+	$ref ||= $url;
+	my ($code, $msg) = curl("HEAD", $url, undef, undef, 0, $self->{creds});
+	if ($code == 404) {
+		$status =  "Could not find $ref; are you able to route to the Internet?\n";
+	} elsif ($code == 403) {
+		$status = "Access forbidden trying to reach $ref; throttling may be in effect.  Set your GITHUB_USER and GITHUB_AUTH_TOKEN to prevent throttling.\n";
+	} elsif ($code != 200) {
+		$status = "Could not read $ref at $url; returned ($code):\n ".$msg."\n";
+	}
+	return wantarray ? ($code,$status) : $status;
+}
+
+# }}}
+# label - description of the current github connection, defaults to domain/org {{{
+sub label {
+	return $_[0]->{label} || $_[0]->{domain}."/".$_[0]->{org};
+}
+
+# }}}
+# repos_url - The url required to fetch the repos for this provider {{{
+sub repos_url {
+	my ($self, $page) = @_;
+	my $url = sprintf("%s/users/%s/repos", $self->base_url, $self->{org});
+	$url .= "?page=$page" if $page;
+	return $url;
+}
+
+# }}}
+# releases_url - The url required to fetch the list of releases for a given kit on this provider {{{
+sub releases_url {
+	my ($self, $name, $page) = @_;
+	my $url = sprintf("%s/repos/%s/%s/releases",$self->base_url,$self->{org},$name);
+	$url .= "?page=$page" if $page;
+	return $url;
+}
+# }}}
+# base_url - the base url under which all requests are made {{{
+sub base_url {
+	my ($self) = @_;
+	sprintf("%s://api.%s", ($self->{tls} eq 'no' ? "http" : "https"), $self->{domain});
+}
+
+# }}}
+# repos - contents of the github orgs repos {{{
+sub repos {
+	my ($self,$refresh) = @_;
+	unless (defined($self->{_repos}) && !$refresh) {
+		my $status = $self->check;
+		bail $status."\n" if $status;
+
+		$self->{_repos} = [];
+		my $page = 1;
+		while (1) {
+			my ($code, $msg, $data) = curl("GET", $self->repos_url($page), undef, undef, 0, $self->{creds});
+			my $results;
+			eval {
+				$results = load_json($data);
+				1
+			} or bail("#R{error!}\nFailed to read repository information from #M{%s} org: %s", $self->label, $@);
+			last unless ref($results) eq "ARRAY" && scalar(@$results) > 0;
+			push @{$self->{_repos}}, @$results;
+			$page++;
+		}
+	}
+	return $self->{_repos};
+}
+
+# }}}
+# repo_names - return a list of repositories under the organization {{{
+sub repo_names {
+	my ($self, $filter) = @_;
+	$filter ||= qr/.*/;
+	return [
+		grep {$_ =~ $filter}
+		map  {$_->{name}}
+		@{$self->repos}
+	];
+}
+
+# }}}
+# releases - retrieves a list of releases for a repository {{{
+sub releases {
+	my ($self, $name) = @_;
+
+	bail("Missing repository name") unless $name;
+
+	$self->{_releases} ||= {};
+	unless (defined($self->{_releases}{$name})) {
+		my $url = $self->releases_url($name);
+		my ($code, $status) = $self->check($url);
+		if ($code == 404) {
+			# Check if kit exists, for a better error message
+			bail("No repository named #C{%s} exists under #M{%s}", $name, $self->label)
+				if (! grep {$_ eq $name} ($self->repo_names));
+		}
+		bail "$status"."\n" if $status;
+		trace "About to get releases from Github";
+
+		waiting_on STDERR "Retrieving list of available releases for #M{%s} kit on #C{%s} ...",$name,$self->label;
+		$self->{_releases}{$name} = $self->get_release_info($name);
+		explain STDERR "#G{ done.}";
+	}
+
+	return @{$self->{_releases}{$name}};
+}
+
+# }}}
+# get_release_info - fetch all release information for the given repository {{{
+sub get_release_info {
+	my ($self, $name, $label) = @_;
+	$label ||= "repository #C{$name}";
+	my ($code,$msg,$data,$headers,@results);
+	my $url = $self->releases_url($name);
+	while (1) {
+		($code, $msg, $data, $headers) = curl("GET", $url, undef, undef, 0, $self->{creds});
+		bail("#R{error!}\nCould not find  %s release information; Github rsponded with a %s status:\n%s",$label,$code,$msg)
+			unless $code == 200;
+
+		my $results;
+		eval {
+			$results = load_json($data);
+			1;
+		} or bail("Failed to read releases information from Github: %s\n",$@);
+		push(@results, @{$results});
+
+		my ($links) = grep {$_ =~ s/^Link: //i} split(/[\r\n]+/, $headers);
+		last unless $links;
+		$url = (grep {$_ =~ s/^<(.*)>; rel="next"/$1/} split(', ', $links))[0];
+		last unless $url;
+		waiting_on STDERR '.';
+	}
+	return \@results;
+}
+
+# }}}
+# versions - retrieves a list of versions for the given repository name{{{
+sub versions {
+	my ($self, $name, %opts) = @_;
+
+	# If specific version is specified, normalize it, and don't filter out drafts
+	# or prereleases
+	if ($opts{version}) {
+		if ($opts{version} eq 'latest') {
+			$opts{latest} = 1;
+			$opts{version} = undef;
+		} else {
+			$opts{version} =~ s/^v//;
+			$opts{drafts} = $opts{prerelease} = 1;
+		}
+	}
+
+	my @releases =
+		grep {!$opts{version}   || $_->{tag_name} =~qr/^v?$opts{version}$/}
+		grep {!$_->{draft}      || $opts{'include_drafts'}}
+		grep {!$_->{prerelease} || $opts{'include_prereleases'}}
+		$self->releases($name);
+
+	if (defined $opts{latest}) {
+		my $latest = $opts{latest} || 1;
+		my @versions = (reverse sort by_semver (map {$_->{tag_name}} @releases))[0..($latest-1)];
+		@releases = grep {my $v = $_->{tag_name}; grep {$_ eq $v} @versions} @releases;
+	}
+	my $asset_filter=$opts{"asset_filter"} || qr/^$name$/;
+	return map {
+		my $r = $_;
+		(my $v = $r->{tag_name}) =~ s/^v//;
+		(my $af = $asset_filter) =~ s/\[#version#\]/$v/;
+		my $asset = (grep {$_->{name} =~ $af} @{$r->{assets}})[0];
+		scalar({
+			version    => $v,
+			body       => $r->{body},
+			draft      => !!$r->{draft},
+			prerelease => !!$r->{prerelease},
+			date       => $r->{published_at} || $r->{created_at},
+			url        => $asset->{browser_download_url} || "",
+			filename   => $asset->{name} || ""
+		});
+	} @releases;
+}
+# fetch_release - fetches the release tarball for the specified version of the given repository {{{
+sub fetch_release {
+	my ($self, $name, $version, $path, $force) = @_;
+
+	if (!defined($version) || $version eq 'latest') {
+		# Better to call `latest_version` prior to this, but this is a safety valve.
+		$version = $self->latest_version_of($name);
+		bail("No latest version of $name repository found with a downloadable release")
+			unless $version;
+	} else {
+		$version =~ s/^v//;
+	}
+
+	my $version_info = (
+		grep {$_->{version} eq $version}
+		$self->versions($name, include_drafts => 1, include_prereleases => 1)
+	)[0];
+	bail(
+		"\n#R{[ERROR]} Release %s/%s was not found\n",
+		$name, $version
+	) unless $version_info && ref($version_info) eq 'HASH';
+
+	my $url = $version_info->{url};
+	bail(
+		"\n#R{[ERROR]} Release %s/%s was found but is missing its resource url.".
+		"\n        It may have been revoked (see release notes below):\n\n%s\n",
+		$name, $version, $version_info->{body}
+	) unless $url;
+
+	waiting_on "Downloading v%s of #M{%s} from #C{%s} ... ",$version,$name,$self->label;
+	my ($code, $msg, $data) = curl("GET", $url);
+	bail "\n#R{error!}\nFailed to download %s/%s from %s: returned a %s status code\n", $name, $version, $self->label, $code
+		unless $code == 200;
+	explain "#G{done.}";
+
+	my $file = "$path/$version_info->{filename}";
+	if (-f $file) {
+		if (! $force) {
+			my $old_data = slurp($file);
+			if (sha1_hex($data) eq sha1_hex($old_data)) {
+				bail "#Y{[WARNING]} Exact same release already exists under #C{%s} - no change.\n", humanize_path($path);
+			} else {
+				error "#R{[ERROR]} Release $name/$version already exists, but is different!";
+				die_unless_controlling_terminal;
+				my $overwrite = prompt_for_boolean("Do you want to overwrite the existing file with the content downloaded from\n$self->{label}",0);
+				bail "Aborted!\n" unless $overwrite;
+			}
+		}
+		chmod_or_fail(0600, $file);
+	}
+	mkfile_or_fail($file, 0400, $data);
+
+	# TODO: Add to gt
+	debug("downloaded release #M{%s}/#C{%s}: %s bytes", $name, $version, length($data));
+
+	return ($name,$version,$file);
+}
+# }}}
+# latest_version_of - The actual version for the latest release of the given repository {{{
+sub latest_version_of {
+	my ($self, $name, %opts) = @_;
+	bail("Missing name for retrieving release") unless $name;
+	my $version = (
+		grep {$_->{url}}
+		$self->versions($name, latest => 1, include_drafts => $opts{include_drafts}, include_prerelease => $opts{include_prereleases})
+	)[0];
+	return $version && $version->{version};
+}
+
+# }}}
+# }}}
+
+1;
+# vim: fdm=marker:foldlevel=1:noet

--- a/lib/Genesis/Github.pm
+++ b/lib/Genesis/Github.pm
@@ -190,7 +190,7 @@ sub versions {
 			$opts{version} = undef;
 		} else {
 			$opts{version} =~ s/^v//;
-			$opts{drafts} = $opts{prerelease} = 1;
+			$opts{include_drafts} = $opts{include_prereleases} = 1;
 		}
 	}
 

--- a/lib/Genesis/Kit/Provider/GenesisCommunity.pm
+++ b/lib/Genesis/Kit/Provider/GenesisCommunity.pm
@@ -16,17 +16,14 @@ sub init {
 # }}}
 # new - create a default genesis-community kit provider {{{
 sub new {
-	my ($class, %config) = @_;
-	my $credentials;
-	if ($ENV{GITHUB_USER} && $ENV{GITHUB_AUTH_TOKEN}) {
-		$credentials = "$ENV{GITHUB_USER}:$ENV{GITHUB_AUTH_TOKEN}";
-	}
+	my ($class) = @_;
 	bless({
-		domain        => "github.com",
-		organization  => "genesis-community",
-		credentials   => $credentials,
-		label         => "Genesis Community organization on Github",
-		tls           => "yes"
+		label  => "Genesis Community organization on Github",
+		remote => Genesis::Github->new(
+								domain => "github.com",
+								org    => "genesis-community",
+								tls    => "yes"
+							)
 	}, $class);
 }
 
@@ -72,7 +69,7 @@ sub status {
 	my $new_info = {
 		type      => 'genesis-community',
 		extras     => ["Source"],
-		"Source"   => $self->{label},
+		"Source"   => $self->label,
 		status    => $info{status},
 		kits      => $info{kits}
 	};

--- a/lib/Genesis/Kit/Provider/Github.pm
+++ b/lib/Genesis/Kit/Provider/Github.pm
@@ -277,8 +277,9 @@ sub status {
 		my @kit_names = sort $self->kit_names;
 		if ($verbose) {
 			$kits = {};
+			waiting_on STDERR "\n";
 			for my $name (@kit_names) {
-				waiting_on('.');
+				waiting_on STDERR "  - ";
 				my @releases = $self->kit_releases($name);
 				my $num_drafts = scalar(grep {$_->{draft}} @releases);
 				my $num_prereleases = scalar(grep {!$_->{draft} && $_->{prerelease}} @releases);

--- a/lib/Genesis/Kit/Provider/Github.pm
+++ b/lib/Genesis/Kit/Provider/Github.pm
@@ -6,6 +6,7 @@ use base 'Genesis::Kit::Provider';
 use Genesis;
 use Genesis::UI;
 use Genesis::Helpers;
+use Genesis::Github;
 
 use Digest::SHA qw/sha1_hex/;
 
@@ -30,7 +31,7 @@ sub init {
 		unless $opts{"kit-provider-tls"} =~ /^(no|yes|skip)$/;
 	$class->new(
 		type         => 'github',
-		label         => $label,
+		label        => $label,
 		domain       => $opts{'kit-provider-domain'},
 		organization => $opts{'kit-provider-org'},
 		tls          => $opts{'kit-provider-tls'}
@@ -41,16 +42,13 @@ sub init {
 # new - create a default github kit provider {{{
 sub new {
 	my ($class, %config) = @_;
-	my $credentials;
-	if ($ENV{GITHUB_USER} && $ENV{GITHUB_AUTH_TOKEN}) {
-		$credentials = "$ENV{GITHUB_USER}:$ENV{GITHUB_AUTH_TOKEN}";
-	}
 	bless({
-		domain          => $config{domain} || DEFAULT_DOMAIN,
-		organization    => $config{organization},
-		credentials     => $credentials,
-		label           => $config{label} || DEFAULT_LABEL,
-		tls             => $config{tls} || DEFAULT_TLS,
+		label  => $config{label} || DEFAULT_LABEL,
+		remote => Genesis::Github->new(
+		            domain => $config{domain} || DEFAULT_DOMAIN,
+		            org    => $config{organization},
+		            tls    => $config{tls} || DEFAULT_TLS
+		          )
 	}, $class);
 }
 
@@ -102,38 +100,29 @@ EOF
 
 ### Instance Methods {{{
 
+# Delegation to remote object
+sub label        {$_[0]->{label};}
+sub remote       {$_[0]->{remote};}
+sub domain       {$_[0]->{remote}{domain};}
+sub organization {$_[0]->{remote}{org};}
+sub credentials  {$_[0]->{remote}{creds};}
+sub tls          {$_[0]->{remote}{tls};}
+sub check        {$_[0]->remote->check($_[1], $_[0]->label);}
+
 # config - provides the config hash used to specify this provider {{{
 sub config {
 	my ($self) = @_;
 	my $config = {
 		type         => 'github',
-		organization => $self->{organization},
+		organization => $self->organization,
 	};
-	$config->{label}   = $self->{label} unless $self->{label} eq DEFAULT_LABEL;
-	$config->{tls}    = $self->{tls} unless $self->{tls} eq DEFAULT_TLS;
-	$config->{domain} = $self->{domain} unless $self->{domain} eq DEFAULT_DOMAIN;
+	$config->{label}  = $self->label  unless $self->label  eq DEFAULT_LABEL;
+	$config->{tls}    = $self->tls    unless $self->tls    eq DEFAULT_TLS;
+	$config->{domain} = $self->domain unless $self->domain eq DEFAULT_DOMAIN;
 	return %$config;
 }
 # }}}
-# check - checks the availability of this provider {{{
-sub check {
-	my ($self, $url) = @_;
-	my $ref = $self->label();
-	my $status;
-	$url ||= $self->repos_url;
-	my ($code, $msg) = curl("HEAD", $url, undef, undef, 0, $self->{credentials});
-	if ($code == 404) {
-		$status =  "Could not find $ref; are you able to route to the Internet?\n";
-	} elsif ($code == 403) {
-		$status = "Access forbidden trying to reach $ref; throttling may be in effect.  Set your GITHUB_USER and GITHUB_AUTH_TOKEN to prevent throttling.\n";
-	} elsif ($code != 200) {
-		$status = "Could not read $ref at $url; returned ($code):\n ".$msg."\n";
-	}
-	return wantarray ? ($code,$status) : $status;
-}
-
-# }}}
-# kits - retrieves list of kit names available from this provider {{{
+# kit_names - retrieves list of kit names available from this provider {{{
 sub kit_names {
 	my ($self, $filter) = @_;
 
@@ -142,27 +131,16 @@ sub kit_names {
 		bail $status."\n" if $status;
 
 		waiting_on "Retrieving list of available kits from #C{%s} ... ",$self->label;
-		my ($code, $msg, $data) = curl("GET", $self->repos_url, undef, undef, 0, $self->{credentials});
-		my $results;
-		eval {
-			$results = load_json($data);
-			1
-		} or bail("#R{error!}\nFailed to read repository information from %s: %s", $self->label, $@);
-		explain '#G{done.}';
-
 		$self->{_kits} = [
 			map  {(my $k = $_) =~ s/-genesis-kit$//; $k}
-			grep {$_ =~ qr/.*-genesis-kit$/}
-			map  {$_->{name}}
-			@$results
+			@{$self->remote->repo_names(qr/.*-genesis-kit$/)}
 		]
 	}
 	my @kits = @{$self->{_kits}};
-
 	@kits = grep {$_ =~ qr/$filter/} @kits if $filter;
 	return @kits if scalar(@kits);
 
-	my $err = "No genesis kit repositories found on $self->{label}";
+	my $err = "No genesis kit repositories found on $self->label";
 	$err .= "that match the pattern /$filter/" if $filter;
 	$err .= "\nYou will need to provide your credentials via GITHUB_USER and GITHUB_AUTH_TOKEN to see private repositories"
 		unless $self->{credentials};
@@ -178,40 +156,19 @@ sub kit_releases {
 
 	$self->{_releases} ||= {};
 	unless (defined($self->{_releases}{$name})) {
-		my $url =	$self->releases_url($name);
-		my ($code, $status) = $self->check($url);
+		my $url = $self->remote->releases_url($name."-genesis-kit");
+		my ($code, $status) = $self->check($url,$self->label);
 		if ($code == 404) {
 			# Check if kit exists, for a better error message
-			my $kits = $self->kit_names;
-			if (! grep {$_ eq $name} ($self->kit_names)) {
-				$status = "No kit named #C{$name} exists under $self->{label}";
-			}
+			bail("No kit named #C{%s} exists under %s", $name, $self->label)
+				if (! grep {$_ eq $name} ($self->kit_names));
 		}
 		bail "$status"."\n" if $status;
 		trace "About to get releases from Github";
 
-		my ($msg,$data,$headers,@results);
 		waiting_on STDERR "Retrieving list of available releases for #M{%s} kit on #C{%s} ...",$name,$self->label;
-		while (1) {
-			($code, $msg, $data, $headers) = curl("GET", $url, undef, undef, 0, $self->{credentials});
-			bail("#R{error!}\nCould not find Genesis Kit %s release information; Github rsponded with a %s status:\n%s",$name,$code,$msg)
-				unless $code == 200;
-
-			my $results;
-			eval {
-				$results = load_json($data);
-				1;
-			} or bail("Failed to read releases information from Github: %s\n",$@);
-			push(@results, @{$results});
-
-			my ($links) = grep {$_ =~ s/^Link: //i} split(/[\r\n]+/, $headers);
-			last unless $links;
-			$url = (grep {$_ =~ s/^<(.*)>; rel="next"/$1/} split(', ', $links))[0];
-			last unless $url;
-			waiting_on STDERR '.';
-		}
+		$self->{_releases}{$name} = $self->remote->get_release_info($name."-genesis-kit", "Genesis Kit $name");
 		explain STDERR "#G{ done.}";
-		$self->{_releases}{$name} = \@results;
 	}
 
 	return @{$self->{_releases}{$name}};
@@ -221,47 +178,12 @@ sub kit_releases {
 # kit_versions - retrieves a list of versions for the given kit name {{{
 sub kit_versions {
 	my ($self, $name, %opts) = @_;
-
-	# If specific version is specified, normalize it, and don't filter out drafts
-	# or prereleases
-	if ($opts{version}) {
-		if ($opts{version} eq 'latest') {
-			$opts{latest} = 1;
-			$opts{version} = undef;
-		} else {
-			$opts{version} =~ s/^v//;
-			$opts{drafts} = $opts{prerelease} = 1;
-		}
-	}
-
-	my @releases =
-		grep {!$opts{version}   || $_->{tag_name} =~qr/^v?$opts{version}$/}
-		grep {!$_->{draft}      || $opts{'include_drafts'}}
-		grep {!$_->{prerelease} || $opts{'include_prereleases'}}
-		$self->kit_releases($name);
-
-	if (defined $opts{latest}) {
-		my $latest = $opts{latest} || 1;
-		my @versions = (reverse sort by_semver (map {$_->{tag_name}} @releases))[0..($latest-1)];
-		@releases = grep {my $v = $_->{tag_name}; grep {$_ eq $v} @versions} @releases;
-	}
-	return map {
-		my $r = $_;
-		(my $v = $r->{tag_name}) =~ s/^v//;
-		my $url = (map {$_->{browser_download_url}} grep {$_->{name} =~ /$name-$v\.t(ar\.)?gz/} @{$r->{assets}})[0];
-		scalar({
-			version => $v,
-			body => $r->{body},
-			draft=> !!$r->{draft},
-			prerelease => !!$r->{prerelease},
-			date => $r->{published_at} || $r->{created_at},
-			url => $url || ""
-		});
-	} @releases;
+	$opts{asset_filter} = qr/$name-[#version#]\.t(ar\.)?gz/;
+	return $self->remote->versions($name."-genesis-kit", %opts);
 }
 
 # }}}
-# fetch_kit_version - fetches a tarball for the named kit and version from this provide {{{
+# fetch_kit_version - fetches a tarball for the named kit and version from this provider {{{
 sub fetch_kit_version {
 	my ($self, $name, $version, $path, $force) = @_;
 
@@ -318,7 +240,7 @@ sub fetch_kit_version {
 	return ($name,$version,$file);
 }
 # }}}
-# latest_kit_version - The human-understandable label for messages and errors {{{
+# latest_version_of - The actual version for the latest release of the given kit name {{{
 sub latest_version_of {
 	my ($self, $name, %opts) = @_;
 	bail("Missing name for retrieving kit releases") unless $name;
@@ -339,11 +261,11 @@ sub status {
 	if ($code == 404) {
 		($code,$msg) = $self->check($self->base_url);
 		if ($code == 404) {
-			$msg = "Cannot find API endpoint for $self->{domain}";
+			$msg = "Cannot find API endpoint for ".$self->domain;
 		} else {
-			$msg = "Cannot find organization $self->{organization} on $self->{domain}";
+			$msg = sprintf("Cannot find organization %s on %s", $self->organization, $self->domain);
 		}
-	} elsif ($code == 403 && !$self->{credentials}) {
+	} elsif ($code == 403 && !$self->credentials) {
 		$msg = "Unable to access - throttling may be effect, or you may not have permission to access this organization.  Credentials may need to be set in environment vars GITHUB_USER & GITHUB_AUTH_TOKEN";
 	} elsif ($code != 200) {
 		$msg =~ s/^.*:/HTTP Error $code while accessing:/;
@@ -373,10 +295,10 @@ sub status {
 	my $info = {
 		type      => 'github',
 		extras    => ["Name", "Domain", "Org", "Use TLS"],
-		"Name"    => $self->{label},
-		"Domain"  => $self->{domain},
-		"Org"     => $self->{organization},
-		"Use TLS" => $self->{tls},
+		"Name"    => $self->label,
+		"Domain"  => $self->domain,
+		"Org"     => $self->organization,
+		"Use TLS" => $self->tls,
 
 		status    => $msg || 'ok',
 		kits      => $kits
@@ -384,32 +306,6 @@ sub status {
 	return %$info;
 }
 
-# }}}
-# label - The human-understandable label for messages and errors {{{
-sub label {
-	$_[0]->{label};
-}
-
-# }}}
-# repos_url - The url required to fetch the repos for this provider {{{
-sub repos_url {
-	sprintf("%s/users/%s/repos", $_[0]->base_url, $_[0]->{organization})
-}
-
-# }}}
-# releases_url - The url required to fetch the list of releases for a given kit on this provider {{{
-sub releases_url {
-	my ($self, $name, $page) = @_;
-	my $url = sprintf("%s/repos/%s/%s-genesis-kit/releases",$self->base_url,$self->{organization},$name);
-	$url .= "?page=$page" if $page;
-	return $url;
-}
-# }}}
-# base_url - the base url under which all requests are made {{{
-sub base_url {
-	my ($self) = @_;
-	sprintf("%s://api.%s", ($self->{tls} eq 'no' ? "http" : "https"), $self->{domain});
-}
 # }}}
 
 # }}}

--- a/t/20-kit.t
+++ b/t/20-kit.t
@@ -266,7 +266,8 @@ subtest 'kit versions' => sub {
 	              draft      => re('^1?$'),
 	              prerelease => re('^1?$'),
 	              version    => re('^(\d+)(?:\.(\d+)(?:\.(\d+)(?:[\.-]rc[\.-]?(\d+))?)?)?'),
-	              url        => re('https://github.com/genesis-community/jumpbox-genesis-kit/releases/download/[^/]*/jumpbox-[^/]*.tar.gz')
+	              url        => re('https://github.com/genesis-community/jumpbox-genesis-kit/releases/download/[^/]*/jumpbox-[^/]*.tar.gz'),
+	              filename   => re('jumpbox-[^/]*.tar.gz')
 	             );
 	cmp_deeply( [@version_info], array_each(\%struct), "Each version contains desired details");
 


### PR DESCRIPTION
# New Feature

* Add `update` genesis command to get new version

```
  Usage: genesis update [-c|--check] [-v|--version VERSION] [-d|--details] [-f|--force]

    -c, --check       Check if a newer version (or the specified version) is
                      available.

    -v, --version <x> Install the specified version instead of the latest

    -d, --details     Print the release notes of the versions between the current
                      version and the latest (or the release notes of the
                      specified version)

    -f, --force       Replace the current genesis executable.  Otherwise,
                      confirmation will be requested.
```

# Bug Fixes

* Fix getting non-production github release version

  If user specified version by name, it should include draft and
  prereleases when looking for it.  This was the initial intent, but the
  wrong options were set when attempting it.

* Improve `genesis kit-provider -v` status output