### PR TITLE
Fixes bad error when calling man on kit that doesn't exist

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -907,6 +907,11 @@ sub {
 		$kit = $top->local_kit_version($name, $version);
 	}
 
+	if(!(defined $kit)) {
+		error "Kit not found: #C{%s}", $name;
+		exit 1;
+	}
+
 	error "Displaying manual for kit #C{%s}...", $kit->id;
 
 	my $man = $kit->path('MANUAL.md');


### PR DESCRIPTION
Fixes issue #454 

Command: `genesis man cf/1.10.5`

Output: ```Kit not found: cf/1.10.5```