### PR TITLE
Fix #424: list-kits now mentions -r flag when run from not in a repo

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -2191,6 +2191,24 @@ Remote and updates supports further options
                         Defaults to show for --updated, not show for others.
 EOF
 sub {
+
+	# Custom "not in a directory" error for list-kits because
+	# we want to be able to mention the subcommand's -r flag, which is
+	# very commonly needed in this situation.
+	my @args = @_;
+	if(!in_repo_dir
+		&& !(
+			grep( /^-r$/, @args )
+			|| grep( /^--remote$/, @args )
+			|| grep( /^-C$/, @args )
+			|| grep( /^--cwd$/, @args )
+		)) {
+		error "#R{GENESIS PRE-REQUISITES CHECKS FAILED!!}";
+		error "The '#B{genesis list-kits}' command needs to be run from a Genesis deployment\n".
+			"repo, or specify one using -C <dir> option. \nAlternatively, specify the -r flag to list available remote kits.";
+		exit 1;
+	}
+
 	my %options;
 	options(\@_, \%options, qw/
 		updates|u

--- a/bin/genesis
+++ b/bin/genesis
@@ -2196,13 +2196,15 @@ sub {
 	# we want to be able to mention the subcommand's -r flag, which is
 	# very commonly needed in this situation.
 	my @args = @_;
-	if(!in_repo_dir
-		&& !(
-			grep( /^-r$/, @args )
-			|| grep( /^--remote$/, @args )
-			|| grep( /^-C$/, @args )
-			|| grep( /^--cwd$/, @args )
-		)) {
+	# If not in repo, and haven't provided -C or -r flags:
+	if(!in_repo_dir && 
+	   !(
+	      grep( /^-r$/, @args )
+	      || grep( /^--remote$/, @args )
+	      || grep( /^-C$/, @args )
+	      || grep( /^--cwd$/, @args )
+	     )
+	 ) {
 		error "#R{GENESIS PRE-REQUISITES CHECKS FAILED!!}";
 		error "The '#B{genesis list-kits}' command needs to be run from a Genesis deployment\n".
 			"repo, or specify one using -C <dir> option. \nAlternatively, specify the -r flag to list available remote kits.";


### PR DESCRIPTION
`genesis list-kits`

outputs:

```
GENESIS PRE-REQUISITES CHECKS FAILED!!
The 'genesis list-kits' command needs to be run from a Genesis deployment
repo, or specify one using -C <dir> option.
Alternatively, specify the -r flag to list available remote kits.
```