### PR TITLE
add fix-releases option to the bosh deploy stage

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -1649,6 +1649,9 @@ Can specify one of the follow three:
 
       --fix              Recreate unresponsive VMs instead of raising an error.
 
+	  --fix-releases     Reupload releases in manifest and replace corrupt
+	                     or missing jobs/packages
+
 EOF
 sub {
 	my %options = (redact => ! -t STDOUT);
@@ -1656,6 +1659,7 @@ sub {
 		yes|y
 		redact!
 		fix
+		fix-releases
 		recreate
 		dry-run
 		skip-drain=s@
@@ -2215,7 +2219,7 @@ sub {
 	# very commonly needed in this situation.
 	my @args = @_;
 	# If not in repo, and haven't provided -C or -r flags:
-	if(!in_repo_dir && 
+	if(!in_repo_dir &&
 	   !(
 	      grep( /^-r$/, @args )
 	      || grep( /^--remote$/, @args )

--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -1377,7 +1377,7 @@ sub deploy {
 
 	} else {
 		my @bosh_opts;
-		push @bosh_opts, "--$_"             for grep { $opts{$_} } qw/fix recreate dry-run/;
+		push @bosh_opts, "--$_"             for grep { $opts{$_} } qw/fix fix-releases recreate dry-run/;
 		push @bosh_opts, "--no-redact"      if  !$opts{redact};
 		push @bosh_opts, "--skip-drain=$_"  for @{$opts{'skip-drain'} || []};
 		push @bosh_opts, "--$_=$opts{$_}"   for grep { defined $opts{$_} } qw/canaries max-in-flight/;
@@ -2289,6 +2289,10 @@ Do (or don't) redact the output of the C<bosh deploy> command.
 =item fix
 
 Sets the C<--fix> flag in the call to C<bosh deploy>.
+
+=item fix-releases
+
+Sets the C<--fix-releases> flag in the call to C<bosh deploy>.
 
 =item recreate
 


### PR DESCRIPTION
add the `bosh deploy --fix-release` option

this will than solve issues if you have compiled releases that are not compatible with your new stemcell.

for example when encountering the following error

```
Task 3611765 | 08:19:19 | Error: 
Can't use release 'credhub/2.9.0'. It references packages without source code and are not compiled against stemcell 'bosh-vsphere-esxi-ubuntu-bionic-go_agent/1.25':
 - 'credhub/52e658833bb47489daac9f5813a41398cd713854'
 - 'openjdk_1.8.0/d24f5d50f7fb877b454655fa1d7039b6c0be69f5'
 ```

you could then add `genesis deploy --fix-releases MANIFEST.yml`