### PR TITLE
Use /usr/bin/env for shebangs

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # vim:ft=perl:noet:ts=2:sts=2:sw=2:fdm=marker:fdl=0
 use strict;
 use warnings;
@@ -327,7 +327,7 @@ EOF
 	if ($ENV{GIT_USERNAME}) {
 		mkdir_or_fail( "$env_dir/home", 0700);
 		mkfile_or_fail("$env_dir/home/credential-helper.sh", 0755, <<'EOF');
-#!/bin/bash
+#!/usr/bin/env bash
 echo username=$GIT_USERNAME
 echo password=$GIT_PASSWORD
 EOF
@@ -448,7 +448,7 @@ sub check_prereqs {
 	my $bosh_min_version = "6.4.4";
 	my $reqs = [
 		# Name,     Version, Command,                                 Pattern                   Source
-		["perl",   "5.10.0", "/usr/bin/perl -v 2>/dev/null | head -n2 | grep version", qr/\(v([0-9\.]+)\)/],
+		["perl",   "5.10.0", "/usr/bin/env perl -v 2>/dev/null | head -n2 | grep version", qr/\(v([0-9\.]+)\)/],
 		["curl",   "7.30.0", "curl --version 2>/dev/null | head -n1",                  qr(^curl\s+(\S+))],
 		["git",     "1.8.0", "git --version  2>/dev/null",                             qr(.*version\s+(\S+).*)],
 		["jq",        "1.6", "jq --version   2>/dev/null",                             qr(^jq-([\.0-9]+)),       "https://stedolan.github.io/jq/download/"],
@@ -3142,7 +3142,7 @@ sub {
 	DumpYAML($vars_file,$vars);
 
 	mkfile_or_fail "dry-run.sh", 0755, <<'EOF';
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 deployment="${1}-${2}"
 new_manifest="$(cat ${3})"
@@ -3481,7 +3481,7 @@ USAGE: genesis env-shell <options> env-name[.yml]
 OPTIONS
 $GLOBAL_USAGE
 
-  -s, --shell <shell>  Use the provided shell (default: /bin/bash)
+  -s, --shell <shell>  Use the provided shell (default: /usr/bin/env bash)
       --no-bosh        Don't connect to bosh
       --no-vault       Don't connect to vault
   -h, --hook <hook>    Pretend to be the specified hook for generating script

--- a/bin/pipey
+++ b/bin/pipey
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # pipey - a small proof-of-concept of pipeline caching
 # USAGE: ./pipey from-environment.yml to-environment.yml

--- a/ci/repipe
+++ b/ci/repipe
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ci/repipe
 #

--- a/ci/scripts/build
+++ b/ci/scripts/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 # Resource Directories

--- a/ci/scripts/bump-docker-image
+++ b/ci/scripts/bump-docker-image
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # ci/scripts/shipit

--- a/ci/scripts/release
+++ b/ci/scripts/release
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ci/scripts/release
 #

--- a/ci/scripts/test
+++ b/ci/scripts/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 export REPO_ROOT=git

--- a/docs/writing-a-hooks-new.md
+++ b/docs/writing-a-hooks-new.md
@@ -18,7 +18,7 @@ representing that environment.
 Let's look at a simple `new` hook:
 
 ```sh
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 root=$1      # absolute path to deployments directory
@@ -58,7 +58,7 @@ TLS certificates to be used, instead of generated certs.
 Here's the first draft of the `new` hook, supporting the Vault HA:
 
 ```sh
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 root=$1

--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -1105,7 +1105,7 @@ EOF
     source:
       filename: run
       body: |
-        #!/bin/bash
+        #!/usr/bin/env bash
         mkdir -p email
         rm -rf email/*
         echo "X-Concourse-Site-Env: ${CI_SITE_ENV}" >>email/header

--- a/lib/Genesis/Helpers.pm
+++ b/lib/Genesis/Helpers.pm
@@ -56,12 +56,12 @@ genesis() {
 export -f genesis
 
 describe() {
-  /usr/bin/perl -I$GENESIS_LIB -MGenesis -e 'binmode STDOUT, ":encoding(UTF-8)"; explain("%s",$_) for @ARGV' "$@"
+  /usr/bin/env perl -I$GENESIS_LIB -MGenesis -e 'binmode STDOUT, ":encoding(UTF-8)"; explain("%s",$_) for @ARGV' "$@"
 }
 export -f describe
 
 humanize_path() {
-  /usr/bin/perl -I$GENESIS_LIB -MGenesis -e 'binmode STDOUT, ":encoding(UTF-8)"; print humanize_path("$ARGV[0]")' "$1"
+  /usr/bin/env perl -I$GENESIS_LIB -MGenesis -e 'binmode STDOUT, ":encoding(UTF-8)"; print humanize_path("$ARGV[0]")' "$1"
 }
 export -f humanize_path
 
@@ -229,7 +229,7 @@ bosh() {
       }
       EOF
       )"
-      eval "$(/usr/bin/perl -I$GENESIS_LIB -MGenesis::BOSH::Director -e "$perl_script")"
+      eval "$(/usr/bin/env perl -I$GENESIS_LIB -MGenesis::BOSH::Director -e "$perl_script")"
     fi
     [[ -z "${BOSH_ENVIRONMENT:-}" || -z "${BOSH_CA_CERT:-}" ]] && \
       __bail "" "#R{[ERROR]} Environment not found for BOSH Director -- please ensure you've configured your BOSH alias used by this environment"
@@ -237,7 +237,7 @@ bosh() {
 
   if [[ -z "${GENESIS_BOSH_VERIFIED:-}" || "$GENESIS_BOSH_VERIFIED" != "${BOSH_ALIAS:-}" ]] ; then
     # Genesis has not yet validate the BOSH director's availability, so we need to
-    if /usr/bin/perl -I$GENESIS_LIB -MGenesis::BOSH::Director -e 'exit(Genesis::BOSH::Director->from_environment()->connect_and_validate()?0:1)' ; then
+    if /usr/bin/env perl -I$GENESIS_LIB -MGenesis::BOSH::Director -e 'exit(Genesis::BOSH::Director->from_environment()->connect_and_validate()?0:1)' ; then
       GENESIS_BOSH_VERIFIED="$BOSH_ALIAS"
     else
       __bail "" "#R{[ERROR]} Could not connect to BOSH director '#M{$BOSH_ALIAS}' (#M{$BOSH_ENVIRONMENT})"

--- a/lib/Genesis/Kit.pm
+++ b/lib/Genesis/Kit.pm
@@ -137,7 +137,7 @@ sub run_hook {
 	if ($is_shell) {
 		@args = ();
 		$hook_exec =
-		$hook_name = $opts{shell} || '/bin/bash';
+		$hook_name = $opts{shell} || '/usr/bin/env bash';
 	} else {
 		$hook_exec = $self->path("hooks/$hook");
 		$hook_name = $hook;

--- a/lib/Genesis/Kit/Compiler.pm
+++ b/lib/Genesis/Kit/Compiler.pm
@@ -349,7 +349,7 @@ DONE
 	mkdir_or_fail "$self->{root}/hooks";
 # hooks/new {{{
 	mkfile_or_fail "$self->{root}/hooks/new", <<DONE;
-#!/bin/bash
+#!/usr/bin/env bash
 shopt -s nullglob
 set -eu
 
@@ -381,7 +381,7 @@ DONE
 	chmod_or_fail 0755, "$self->{root}/hooks/new";
 # hooks/blueprint {{{
 	mkfile_or_fail "$self->{root}/hooks/blueprint", <<DONE;
-#!/bin/bash
+#!/usr/bin/env bash
 shopt -s nullglob
 set -eu
 

--- a/pack
+++ b/pack
@@ -9,7 +9,7 @@ use POSIX qw(strftime);
 
 ######################################################################
 
-system "perl -c -Ilib bin/genesis";
+system "perl -c -Ilib $(pwd)/bin/genesis";
 die "Perl compilation failed, not packing\n" if $?;
 
 # ---

--- a/pack
+++ b/pack
@@ -9,7 +9,7 @@ use POSIX qw(strftime);
 
 ######################################################################
 
-system "perl -c -Ilib $(pwd)/bin/genesis";
+system "perl -c -Ilib /bin/genesis";
 die "Perl compilation failed, not packing\n" if $?;
 
 # ---

--- a/pack
+++ b/pack
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # vim:ft=perl:ts=4:sts=4:sw=4
 use strict;
 use warnings;
@@ -113,7 +113,7 @@ print "packaged v$VERSION $BUILD as $stub_out\n\n";
 system 'rm -rf pkg/ pkg.tar.gz';
 
 __DATA__
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 
@@ -153,7 +153,7 @@ if ($fh) {
 }
 
 if ($want ne $have) {
-	system("/bin/bash", "-c", "rm -rf $root/*");
+	system("/usr/bin/env bash", "-c", "rm -rf $root/*");
 	my $action = $have ? "updating" : "installing";
 
 	# extract the payload

--- a/pack
+++ b/pack
@@ -9,7 +9,7 @@ use POSIX qw(strftime);
 
 ######################################################################
 
-system "perl -c -Ilib /bin/genesis";
+system "perl -c -Ilib bin/genesis";
 die "Perl compilation failed, not packing\n" if $?;
 
 # ---

--- a/t/04-compiling.t
+++ b/t/04-compiling.t
@@ -679,13 +679,13 @@ EOF
 
 unlink "$kitdir/hooks/new" if -f "$kitdir/hooks/new";
 put_file("$kitdir/hooks/new", <<EOF);
-#!/bin/bash
+#!/usr/bin/env bash
 set -ue
 echo "tada!"
 EOF
 
 put_file("$kitdir/hooks/blueprint", <<EOF);
-#!/bin/bash
+#!/usr/bin/env bash
 set -ue
 echo "something.yml"
 EOF
@@ -694,7 +694,7 @@ system("(cd $kitdir && git add hooks && git commit -m 'commited changes') >/dev/
 system("(cd $kitdir && git add ci && git rm -f hooks/blueprint) >/dev/null");
 
 put_file("$kitdir/hooks/check", <<EOF);
-#!/bin/bash
+#!/usr/bin/env bash
 set -ue
 exit 1
 EOF

--- a/t/10-top.t
+++ b/t/10-top.t
@@ -173,7 +173,7 @@ subtest 'embedding stuff' => sub {
 	my $tmp = workdir;
 	my $top = Genesis::Top->create($tmp, 'thing', vault=>$VAULT_URL);
 	put_file("$tmp/not-genesis", <<EOF);
-#!/bin/bash
+#!/usr/bin/env bash
 echo "this is not genesis"
 EOF
 	system("$tmp/not-genesis 2>/dev/null");

--- a/t/21-hooks.t
+++ b/t/21-hooks.t
@@ -547,7 +547,7 @@ genesis:
 EOF
 
 	put_file $fancy->path('hooks/blueprint'), <<EOF;
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 validate_features always-first a-thing bob shazzam

--- a/t/bin/vault
+++ b/t/bin/vault
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ue
 
 bail() {

--- a/t/helper.pm
+++ b/t/helper.pm
@@ -189,7 +189,7 @@ sub fake_bosh {
 EOF
     my $json_printout = join("\n", map {(my $l = $_) =~ s/'/'\\''/g; "    echo '$l'"} split("\n", $json));
     $script=<<EOF;
-#!/bin/bash
+#!/usr/bin/env bash
 args="\$(echo "bosh \$*" | sed -e 's/"/"\\""/g')"
 if [[ \$args =~ \\ --json(\\ |\$) ]] ; then
   (
@@ -326,7 +326,7 @@ sub write_bosh_config {
 					"-----END CERTIFICATE-----"
 			};
 			{
-				my @cmd = ('/bin/bash', "-c", 'echo "$1" | jq -r . | safe import 2>&1', 'bash', JSON::PP::encode_json($exodus));
+				my @cmd = ('/usr/bin/env bash', "-c", 'echo "$1" | jq -r . | safe import 2>&1', 'bash', JSON::PP::encode_json($exodus));
 				open my $pipe, "-|", @cmd;
 				$out = do { local $/; <$pipe> };
 				$out =~ s/\s+$//;

--- a/t/kits/ask-params/hooks/new
+++ b/t/kits/ask-params/hooks/new
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 out="$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml"
 cat <<EOF > "$out"

--- a/t/kits/asksecrets/hooks/new
+++ b/t/kits/asksecrets/hooks/new
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 dir="$GENESIS_ROOT"

--- a/t/kits/certificates/hooks/blueprint
+++ b/t/kits/certificates/hooks/blueprint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 echo "manifest.yml"

--- a/t/kits/certificates/hooks/new
+++ b/t/kits/certificates/hooks/new
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 ymlfile="$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml"

--- a/t/kits/more-hooks/hooks/params
+++ b/t/kits/more-hooks/hooks/params
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 source "$(dirname "$0")/params_helper"

--- a/t/kits/more-hooks/hooks/params_helper
+++ b/t/kits/more-hooks/hooks/params_helper
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "helping you"

--- a/t/kits/more-hooks/hooks/subkit
+++ b/t/kits/more-hooks/hooks/subkit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # this hook is intentionally non-executable + a failure.
 # the test will run it, expect failure, chmod, run, expect more failure,

--- a/t/kits/omega-v2.7.0/hooks/new
+++ b/t/kits/omega-v2.7.0/hooks/new
@@ -1,4 +1,4 @@
-:#!/bin/bash
+:#!/usr/bin/env bash
 set -eu
 
 dir="$GENESIS_ROOT"

--- a/t/kits/secrets-2.7.0/hooks/blueprint
+++ b/t/kits/secrets-2.7.0/hooks/blueprint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 echo "manifest.yml"

--- a/t/kits/secrets-2.7.0/hooks/new
+++ b/t/kits/secrets-2.7.0/hooks/new
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 dir="$GENESIS_ROOT"

--- a/t/kits/version-prereq-bad/hooks/prereqs
+++ b/t/kits/version-prereq-bad/hooks/prereqs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # The point of this script is to exit 0 if all
 # required bits of functionality are present on

--- a/t/kits/version-prereq/hooks/prereqs
+++ b/t/kits/version-prereq/hooks/prereqs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # The point of this script is to exit 0 if all
 # required bits of functionality are present on

--- a/t/repos/compile-test-genesis-kit/ci/repipe
+++ b/t/repos/compile-test-genesis-kit/ci/repipe
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ci/repipe
 #

--- a/t/repos/manifest-test/dev/hooks/blueprint
+++ b/t/repos/manifest-test/dev/hooks/blueprint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 shopt -s nullglob
 set -eu
 

--- a/t/repos/manifest-test/dev/hooks/new
+++ b/t/repos/manifest-test/dev/hooks/new
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 cat > "$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml" <<EOF

--- a/t/repos/pipeline-test/dev/hooks/blueprint
+++ b/t/repos/pipeline-test/dev/hooks/blueprint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 shopt -s nullglob
 set -eu
 

--- a/t/repos/pipeline-test/dev/hooks/new
+++ b/t/repos/pipeline-test/dev/hooks/new
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 cat > "$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml" <<EOF

--- a/t/secrets.t
+++ b/t/secrets.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use utf8;
@@ -27,7 +27,7 @@ subtest 'secrets-v2.7.0' => sub {
 	my $vault_target = vault_ok;
 	bosh2_cli_ok;
 	fake_bosh <<EOF;
-#/bin/bash
+#/usr/bin/env bash
 echo "test_user"
 EOF
 	my @directors = fake_bosh_directors('c-azure-us1-dev', 'c-azure-us1-prod');

--- a/t/src/creator/hooks/blueprint
+++ b/t/src/creator/hooks/blueprint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 echo "everything.yml"

--- a/t/src/creator/hooks/new
+++ b/t/src/creator/hooks/new
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 dir="$GENESIS_ROOT"

--- a/t/src/custom-bosh/hooks/addon
+++ b/t/src/custom-bosh/hooks/addon
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 if [[ ${HOOK_SHOULD_FAIL:-no} = "yes" ]]; then

--- a/t/src/custom-bosh/hooks/blueprint
+++ b/t/src/custom-bosh/hooks/blueprint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 if [[ ${HOOK_SHOULD_FAIL:-no} = "yes" ]]; then

--- a/t/src/custom-bosh/hooks/check
+++ b/t/src/custom-bosh/hooks/check
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 if [[ ${HOOK_SHOULD_FAIL:-no} = "yes" ]]; then

--- a/t/src/custom-bosh/hooks/features-disabled
+++ b/t/src/custom-bosh/hooks/features-disabled
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ ${HOOK_SHOULD_FAIL:-no} = "yes" ]]; then
 	set -u

--- a/t/src/custom-bosh/hooks/info
+++ b/t/src/custom-bosh/hooks/info
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 if [[ ${HOOK_SHOULD_FAIL:-no} = "yes" ]]; then

--- a/t/src/custom-bosh/hooks/new
+++ b/t/src/custom-bosh/hooks/new
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 if [[ ${HOOK_SHOULD_FAIL:-no} = "yes" ]]; then

--- a/t/src/custom-bosh/hooks/secrets
+++ b/t/src/custom-bosh/hooks/secrets
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 exec 2>&1
 

--- a/t/src/custom-bosh/hooks/xyzzy
+++ b/t/src/custom-bosh/hooks/xyzzy
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo this is a bogus hook
 exit 0

--- a/t/src/fancy/hooks/addon
+++ b/t/src/fancy/hooks/addon
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 if [[ ${HOOK_SHOULD_FAIL:-no} = "yes" ]]; then

--- a/t/src/fancy/hooks/blueprint
+++ b/t/src/fancy/hooks/blueprint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 if [[ ${HOOK_SHOULD_FAIL:-no} = "yes" ]]; then

--- a/t/src/fancy/hooks/check
+++ b/t/src/fancy/hooks/check
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 if [[ ${HOOK_SHOULD_FAIL:-no} = "yes" ]]; then

--- a/t/src/fancy/hooks/features-disabled
+++ b/t/src/fancy/hooks/features-disabled
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ ${HOOK_SHOULD_FAIL:-no} = "yes" ]]; then
 	set -u

--- a/t/src/fancy/hooks/info
+++ b/t/src/fancy/hooks/info
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 if [[ ${HOOK_SHOULD_FAIL:-no} = "yes" ]]; then

--- a/t/src/fancy/hooks/new
+++ b/t/src/fancy/hooks/new
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 if [[ ${HOOK_SHOULD_FAIL:-no} = "yes" ]]; then

--- a/t/src/fancy/hooks/secrets
+++ b/t/src/fancy/hooks/secrets
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 # for brevity's sake

--- a/t/src/fancy/hooks/xyzzy
+++ b/t/src/fancy/hooks/xyzzy
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo this is a bogus hook
 exit 0

--- a/t/src/legacy/hooks/subkit
+++ b/t/src/legacy/hooks/subkit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ ${HOOK_SHOULD_FAIL:-no} = "yes" ]]; then
   exit 42;

--- a/t/src/simple/hooks/blueprint
+++ b/t/src/simple/hooks/blueprint
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 echo "manifest.yml"

--- a/t/src/simple/hooks/new
+++ b/t/src/simple/hooks/new
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 root=$GENESIS_ROOT
 env=$GENESIS_ENVIRONMENT


### PR DESCRIPTION
Modifies all of the source files that refers to either `bash` or `perl` using `/usr/bin` or `/bin` in the shebangs.
Shebangs like that make assumption that program will be found under a specified path, whereas in proposed change the `env` is used to actually localize the path of the given program. 

It will make CLI tool more portable as it should be runnable from almost any OS/Unix distribution since different *nix based systems.

Tested by running locally `perl pack` which generates the dev-based package of `genesis` tool.

https://stackoverflow.com/a/10383546
https://stackoverflow.com/a/16365367
https://stackoverflow.com/a/2792076