### PR TITLE
Add yaml usage to check env

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -2162,24 +2162,8 @@ sub {
 	usage(1) if @_ != 1;
 	check_prereqs;
 
-	my @files;
-	my $local_label = "./";
-	my $kit_label   = "";
 	my $env = Genesis::Top->new('.')->load_env($_[0])->download_required_configs('blueprint');
-	if ($options{'include-kit'}) {
-		$kit_label = "#G{".$env->kit->id.":} ";
-		$local_label = sprintf("%*s", length($kit_label), "#C{local:} ");
-		my $env_path = $env->path();
-		for ($env->kit_files) {
-			if ($_ =~ qr/^$env_path\/(.*)$/) {
-				push @files, "$local_label$1";
-			} else {
-				push @files, "$kit_label#K{$_}";
-			}
-		}
-	}
-	push @files, map {(my $f = $_) =~ s/^\.\//$local_label/; $f}
-		($env->actual_environment_files);
+	my @files = $env->format_yaml_files(%options);
 	explain join("\n", @files)."\n";
 });
 

--- a/lib/Genesis.pm
+++ b/lib/Genesis.pm
@@ -525,7 +525,8 @@ sub run {
 	if ($opts{interactive}) {
 		system @cmd;
 	} else {
-		open my $pipe, "-|", @cmd;
+		open my $pipe, "-|", @cmd
+		  or bail("Could not open pipe to run #C{%s}", join(' ',@cmd));
 		$out = do { local $/; <$pipe> };
 		$out =~ s/\s+$//;
 		close $pipe;


### PR DESCRIPTION
[Improvements]

* Add the yaml files used during the check process of deployment.  This
  is especially useful when running deployments in pipelines, and when
  running the spec tests.  To enable it, set the environment variable
  GENESIS_CHECK_YAML_ON_DEPLOY to a truthy value (1, yes, true, Y) and
  export it (or set it in params section of the deploy task).