### PR TITLE
Bosh debug ops

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -1315,11 +1315,11 @@ sub {
 
 	explain("${ui_nl}Secrets provider for #C{%s} deployment at #M{%s}:", $top->type, $top->path);
 	my %vault_info = $top->vault_status;
-	if ($vault_info{status} eq "unauthenticated") {
-		eval {$top->vault->authenticate}; # Try to auto-authenticate
-		%vault_info = $top->vault_status;
-	}
 	if (%vault_info) {
+		if ($vault_info{status} eq "unauthenticated") {
+			eval {$top->vault->authenticate}; # Try to auto-authenticate
+			%vault_info = $top->vault_status;
+		}
 		explain(
 			"         Type: #G{%s}\n".
 			"          URL: #G{%s} %s\n".

--- a/bin/genesis
+++ b/bin/genesis
@@ -1727,24 +1727,17 @@ director or deployment name.  The options below must come BEFORE any bosh
 command and options, or they will be passed through to the bosh cli.
 
 OPTIONS
-  -h, --help         Show this help screen.  If you want to get the help for
-                     bosh, specify `-- -h`
+$REPO_USAGE
+  -A, --as-director The specified environment is the desired BOSH director
+                    to target, and there is no associated deployment.
+                    Without this option, it will target the BOSH director
+                    used to deploy this environment, with the environment
+                    being the associated deployment.
 
-  -C, --cwd          Effective working directory.  You can also specify the
-                     environment YAML file to use, in which case the working
-                     directory is the one containing the specified file.
-                     Defaults to '.'
-
-  -A, --as-director  The specified environment is the desired BOSH director
-                     to target, and there is no associated deployment.
-                     Without this option, it will target the BOSH director
-                     used to deploy this environment, with the environment
-                     being the associated deployment.
-
-      --connect      Intended to run inside an #C{eval "\$(...)"} wrapper, this
-                     command will set the environment variables required to
-                     connect via the bosh cli, targeting the desired
-                     deployment and associated BOSH director.
+      --connect     Intended to run inside an #C{eval "\$(...)"} wrapper, this
+                    command will set the environment variables required to
+                    connect via the bosh cli, targeting the desired
+                    deployment and associated BOSH director.
 
 EOF
 sub {
@@ -1752,7 +1745,9 @@ sub {
 	my @args;
 	while (@_) {
 		my $entry = shift;
-		if ( $entry =~ /(--connect|--as-director|-A|--help|-h)/) {
+		if ( $entry =~ /^-[TSDhqA]+$/) {
+			push(@args, $entry);
+		} elsif ($entry =~ /^--(trace|show-stack|debug|help|color|no-color|quiet|connect|as-director)$/) {
 			push(@args, $entry);
 		} elsif ( $entry =~ /(--cwd|-C)/) {
 			push(@args, $entry, shift);
@@ -1762,11 +1757,9 @@ sub {
 		}
 	}
 	options(\@args, \%options, qw/
-		BLANK_USAGE
-		cwd|C=s
+		REPO_USAGE
 		as-director|A
 		connect
-		help|h
 	/);
 
 	usage unless @args;

--- a/lib/Genesis/Top.pm
+++ b/lib/Genesis/Top.pm
@@ -28,14 +28,10 @@ sub new {
 	$ENV{GENESIS_ROOT}=$top->path();
 	my $vault;
 	if ($top->config->get("secrets_provider.url")) {
-		my @matches = Genesis::Vault->find(url=>$top->config->get("secrets_provider.url"));
-		bail(
-			"#R{[ERROR]} Cannot find unique vault configuration at #C{%s} in your .saferc",
-			$top->config->get("secrets_provider.url")
-		) if @matches > 1;
-		$vault = $matches[0];
+		$vault = Genesis::Vault->find_single_match_or_bail($top->config->get("secrets_provider.url"));
 	} else {
-		$vault = Genesis::Vault->default;
+		my $default = Genesis::Vault->default;
+		$vault = Genesis::Vault->find_single_match_or_bail($default->url, $default->name);
 	}
 	if ($vault) {
 		$ENV{GENESIS_TARGET_VAULT} = $ENV{SAFE_TARGET} = $vault->ref;


### PR DESCRIPTION
[Bug Fixes]

* When using legacy secrets provider, if the current safe target has the
  same URL as another safe target, a confusing error would be printed.
  This change provides a much more informative error message.

* When using a specified secrets provider for a deployment repo, a more
  instructive error message is provided when multiple safe targets with
  the same URL is specified.

[Improvements]

* `genesis bosh` now supports all the basic options, including
  --[no-]color, -q|--quiet, -D|--debug, -T|--trace, and -D|--show-stack.