### PR TITLE
 Add pre and post deployment reactions

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -1658,6 +1658,9 @@ env environment.
       --max-in-flight #  Override the default number of maximum VMs in flight
                          per instance group.
 
+      --[no-]reactions   Determines if reactions specified in the environment
+                         file will be processed if present (default: yes)
+
 
 Can specify one of the follow three:
   -n, --dry-run          Build the manifest and validate it against the current
@@ -3031,7 +3034,7 @@ sub {
 	eval {
 		$result = $env->with_bosh
 		              ->download_required_configs('deploy')
-		              ->deploy(redact => !envset('CI_NO_REDACT'));
+		              ->deploy(redact => !envset('CI_NO_REDACT'), reactions => 1);
 	};
 
 	if ($@ || !$result) {
@@ -3256,6 +3259,7 @@ sub {
 	push(@cachables, "$common_path/kit-overrides.yml") if -f "$common_path/kit-overrides.yml";
 	copy_or_fail($_, "$target_dir/") for (@cachables);
 	copy_tree_or_fail("$common_path/ops", "$target_dir", "$common_path/") if -d "$common_path/ops";
+	copy_tree_or_fail("$common_path/bin", "$target_dir", "$common_path/") if -d "$common_path/bin";
 	return if envset("GENESIS_TESTING");
 	commit_changes($ENV{WORKING_DIR}, $ENV{OUT_DIR}, $ENV{GIT_BRANCH}, "generated cache for $ENV{CURRENT_ENV}");
 });

--- a/lib/Genesis.pm
+++ b/lib/Genesis.pm
@@ -514,6 +514,12 @@ sub run {
 	$tracemsg .= csprintf("#M{Executing:} `#C{%s}`%s", $prog, ($opts{interactive} ? " #Y{(interactively)}" : ''));
 	if (@args) {
 		unshift @args, basename($shell);
+		if ($opts{eval_var_args}) {
+			@args = map {
+				s/(?<!\\)\$(?:{([^}]+)}|([A-Za-z0-9_]*))/my $v = $ENV{$1||$2}; defined($v) ? $v : ""/eg;
+				$_
+			} @args;
+		}
 		$tracemsg .= csprintf("\n#M{ - with arguments:}");
 		$tracemsg .= csprintf("\n#M{%4s:} '#C{%s}'", $_, $args[$_]) for (1..$#args);
 	}

--- a/lib/Genesis/Base.pm
+++ b/lib/Genesis/Base.pm
@@ -1,0 +1,18 @@
+package Genesis::Base;
+
+use strict;
+use warnings;
+use utf8;
+
+# _memoize - cache value to be returned on subsequent calls {{{
+sub _memoize {
+	my ($self, $token, $initialize) = @_;
+	if (ref($token) eq 'CODE') {
+		$initialize = $token;
+		($token = (caller(1))[3]) =~ s/^(.*::)?/__/g;
+	}
+	return $self->{$token} if defined($self->{$token});
+	$self->{$token} = $initialize->($self);
+}
+
+1;

--- a/lib/Genesis/Top.pm
+++ b/lib/Genesis/Top.pm
@@ -2,6 +2,8 @@ package Genesis::Top;
 use strict;
 use warnings;
 
+use base 'Genesis::Base';
+
 use Genesis;
 use Genesis::Env;
 use Genesis::Kit::Compiled;
@@ -235,7 +237,7 @@ EOF
 # Kit Provider handling
 # kit_provider - return the kit provider for the Top object {{{
 sub kit_provider {
-	my $ref = $_[0]->_memoize('__kit_provider', sub {
+	my $ref = $_[0]->_memoize(sub {
 		my ($self) = @_;
 		return Genesis::Kit::Provider->new(%{$self->config->get("kit_provider", {})});
 	});
@@ -281,7 +283,7 @@ sub kit_provider_info {
 # Secrets provider handling
 # vault - initialize connectivity to the vault specified by the secrets provider {{{
 sub vault {
-	my $ref = $_[0]->_memoize('__vault', sub {
+	my $ref = $_[0]->_memoize(sub {
 		my ($self) = @_;
 		if (in_callback && $ENV{GENESIS_TARGET_VAULT}) {
 			return Genesis::Vault->rebind();
@@ -430,7 +432,7 @@ sub mkdir {
 # config - read the configuration of the repo {{{
 sub config {
 	my ($self) = @_;
-	my $ref = $self->_memoize('__config', sub {
+	my $ref = $self->_memoize(sub {
 		my ($self) = @_;
 		return Genesis::Config->new($self->path(".genesis/config"));
 	});
@@ -606,17 +608,6 @@ sub download_kit {
 	$self->kit_provider->fetch_kit_version($name,$version,$target,$opts{force});
 }
 
-# }}}
-# }}}
-
-### Private Instance Methods {{{
-
-# _memoize - cache value to be returned on subsequent calls {{{
-sub _memoize {
-	my ($self, $token, $initialize) = @_;
-	return $self->{$token} if defined($self->{$token});
-	$self->{$token} = $initialize->($self);
-}
 # }}}
 # }}}
 

--- a/t/helper.pm
+++ b/t/helper.pm
@@ -56,6 +56,13 @@ sub import {
 	runs_ok("genesis ping") or die "`genesis ping` failed...\n";
 }
 
+sub reset_kit {
+	my $kit = shift;
+	$kit->{root} = undef;
+	$kit->{__hook_check} = undef;
+	$kit->{extract};
+}
+
 our $WORKDIR = undef;
 sub workdir {
 	$WORKDIR ||= tempdir(CLEANUP => 1);
@@ -74,7 +81,7 @@ sub mkdir_or_fail {
 	return $dir;
 }
 
-sub put_file($$) {
+sub put_file {
 	local $Test::Builder::Level = $Test::Builder::Level + 1;
 	my ($file, $mode, $contents) = @_;
 	if (! defined($contents)) {

--- a/t/src/reactions/hooks/addon
+++ b/t/src/reactions/hooks/addon
@@ -1,0 +1,12 @@
+#!/bin/bash
+if [[ "$GENESIS_ADDON_SCRIPT" == "working-addon" ]] ; then
+  echo >&2 "This addon worked, with arguments of $*"
+  exit 0
+elif [[ "$GENESIS_ADDON_SCRIPT" == "broken-addon" ]] ; then
+  echo >&2 "This addon is broken, with arguments of $*"
+  exit 1
+else
+  echo >&2"Unknown addon: $GENESIS_ADDON_SCRIPT (arguments of $*)"
+	exit 2
+fi
+EOF

--- a/t/src/reactions/hooks/blueprint
+++ b/t/src/reactions/hooks/blueprint
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -eu
+echo "manifest.yml"

--- a/t/src/reactions/hooks/new
+++ b/t/src/reactions/hooks/new
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+root=$GENESIS_ROOT
+env=$GENESIS_ENVIRONMENT
+
+cat >$root/$env.yml <<EOF
+kit:
+  name:    $GENESIS_KIT_NAME
+  version: $GENESIS_KIT_VERSION
+  features: []
+EOF
+genesis_config_block >> $root/$env.yml
+exit 0

--- a/t/src/reactions/kit.yml
+++ b/t/src/reactions/kit.yml
@@ -1,0 +1,10 @@
+---
+name:   reations
+author: Dennis Bell <dbell@starkandwayne.com>
+docs:   https://github.com/genesis-community/simple-genesis-kit
+code:   https://github.com/genesis-community/simple-genesis-kit
+
+genesis_version_min: 2.8.6-rc0
+
+description: |
+  This kit provides the kit to test pre and post reactions.

--- a/t/src/reactions/manifest.yml
+++ b/t/src/reactions/manifest.yml
@@ -1,0 +1,6 @@
+---
+reactions:
+  - all
+  - of
+  - them
+


### PR DESCRIPTION
[Improvements]

* Add pre-deploy and post-deploy reactions on a per-environment basis.

  Sometimes different environments need to perform tasks prior to and
  after doing a deploy.  This feature allows you to specify scripts that
  will be run in those circumstances.  Add the following structure to
  your environment file:

  ````
  genesis:
    reactions:
      pre-deploy:
        - script: put-up-maintenance-page
        - script: update-jira
          args:   [ 'some-argument', '$SOME_ENV_VAR' ]
      post-deploy:
        - addon: valid-addon-for-kit
        - script: remove-maintenance-page
  ````

  The scripts are located in the bin/ dir under the repository root
  directory, and are propagated via the pipeline cache system.

  The scripts have access to the following environment variables:

  * GENESIS_PREDEPLOY_DATAFILE -- file path that contains any data
    gathered by the predeploy hook

  * GENESIS_MANIFEST_FILE -- file path to the full unredacted unpruned
    manifest for the current deployment

  * GENESIS_BOSHVARS_FILE -- file path to any BOSH variables for the
    deployment

  * GENESIS_DEPLOY_OPTIONS -- JSON representation of the options passed
    to the deploy call

  * GENESIS_DEPLOY_DRYRUN -- "true" if the deployment is a dry-run,
    "false" otherwise

  * GENESIS_DEPLOY_RC -- return code of the BOSH deploy call.  0 if
    successful, 1 otherwise.  Only available for post-deploy reactions

--- 

Also, internal changes to support the above:

* Extracted _memoize to a base class
* Allow the passing of extra env vars to kit hook runs (internal only)
* Allow interpolation of passed env vars in run arguments

Resolved #427 