### PR TITLE
Unset https_proxy env var for bosh calls

### DIFF
--- a/lib/Genesis/BOSH.pm
+++ b/lib/Genesis/BOSH.pm
@@ -86,8 +86,8 @@ sub execute {
 	$env{$_} = $opts->{env}{$_} for (keys %{$opts->{env}||{}});
 	$opts->{env} = \%env;
 	unless ($ENV{GENESIS_HONOR_ENV}) {
-		$opts->{env}{HTTPS_PROXY} = ''; # bosh dislikes this env var
-		$opts->{env}{https_proxy} = ''; # bosh dislikes this env var
+		$opts->{env}{HTTPS_PROXY} = undef # bosh dislikes this env var
+		$opts->{env}{https_proxy} = undef # bosh dislikes this env var
 	}
 	my $noninteractive = envset('BOSH_NON_INTERACTIVE') ? ' -n' : '';
 


### PR DESCRIPTION
[Bug Fixes]

* Genesis doesn't like the `https_proxy` or `HTTPS_PROXY` environment
  variables being set, but BOSH was happy when they were set to "".
  However, upstream BOSH now considers that an error, so Genesis is
  going to simply unset them.

  If you need to use HTTPS proxy, you can still set `GENESIS_HONOR_ENV`
  to a truthy value, and it will keep `HTTPS_PROXY` and `https_proxy`
  environment variables from the calling scope, but only do this if
  you encounter an error.

---

Fixes #484