### PR TITLE
Working implementation for email notifications

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,3 +18,20 @@ your interactions with the project.
 
 3. After review and approval, your Pull Request will be merged by
    a repository owner.
+
+## Test your changes
+
+In order to test your changes, you can use the following development workflow:
+
+- Clone this repo
+- Do some changes
+- Build a development `genesis` CLI running `make release VERSION=x.y.z`
+- Symlink the generated `genesis-x.y.z` (or `genesis-x.y.z-dirty` if you
+  didn't commit your code yet) file to `genesis` with
+  `ln -s genesis-x.y.z-dirty genesis` (to be done once only)
+- Add the current directory in your `PATH` with `export PATH=$PWD:$PATH` (to
+  be done only once per shell session) or just copy it to you `~/bin`
+  directory if it exists and is on your path
+- Go to some deployment directory, check the genesis CLI you'll be using with
+  `which genesis` and `genesis version`
+- Run the usual `genesis` CLI commands and verify it behaves as expected


### PR DESCRIPTION
Hi,

In this PR I've reworked a bit the way email notifications are implemented in the Genesis-generated pipelines, when some `pipeline.email` hash is specified in the `ci.yml` of some deployment.

You'll notice that I've got rid of the `build-email-*` script resources. I must say that modeling a script generation using a resource just doesn't fit with what Concourse mean by "resource"—It's supposed to be something that can have a new version (`check`) and from which one can get that version (`get`) or create a new one (`put`). Just using some ad-hoc Bash code just looks better.

The `starkandwayne/concourse` image is hardwired and possibly should rely on `$pipeline->{pipeline}{task}{image}` like elsewhere in the code. Don't hesitate to mention that in your review.

Also the Bash script code has ugly escape sequences. This come from the fact that the `_gen_notifications` subroutine is to be agnostic of the YAML indentation level from where it is invoked in the YAML tree. If you insist, I can try to write this script as a multi-line YAML string and see if it works. That would read a little bit better, I admit.

About the `X-Concourse-Site-Env:` MIME header, I didn't get it why it was here. I've also wondered where the `${CI_SITE_ENV}` environment variable was supposed to come from, without being able to locate anything in Genesis or Concourse. So, I've dropped the feature here, that I've guessed to be experimental. We can always implement it again properly when we know more about it.

Best,
Benjamin