### PR TITLE
Remove unnecessary Bosh credentials from Genesis-generated pipelines

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -3326,16 +3326,10 @@ sub {
 
 	# environment variables we should have
 	#   CURRENT_ENV - Name of the current environment
-	#   BOSH_ENVIRONMENT   - URL of the BOSH director to deploy on
-	#   BOSH_CA_CERT       - CA Certificate for the BOSH director
-	#   BOSH_CLIENT        - Username or client ID (UAA-auth) to authenticate with
-	#   BOSH_CLIENT_SECRET - Password/Client-Secret to authenticate with
 	#   ERRAND_NAME - Name of the Smoke Test errand to run
 
 	my @undefined = grep { !$ENV{$_} }
-		qw/CURRENT_ENV ERRAND_NAME
-		   BOSH_ENVIRONMENT BOSH_CA_CERT
-		   BOSH_CLIENT BOSH_CLIENT_SECRET/;
+		qw/CURRENT_ENV ERRAND_NAME/;
 	bail_on_missing_pipeline_environment_variables(@undefined);
 
 	my $env = Genesis::Top->new('.')->load_env($ENV{CURRENT_ENV})->with_vault()->with_bosh();

--- a/bin/genesis
+++ b/bin/genesis
@@ -3066,8 +3066,6 @@ sub {
 			$ENV{GIT_BRANCH}, $ENV{CURRENT_ENV});
 	}
 
-	push(@undefined, grep { !$ENV{$_} } qw/BOSH_ENVIRONMENT BOSH_CA_CERT BOSH_CLIENT BOSH_CLIENT_SECRET/)
-		unless $env->use_create_env;
 	bail_on_missing_pipeline_environment_variables(@undefined);
 
 	explain "Preparing to deploy #C{%s}:\n  - based on kit #c{%s}", $env->name, $env->kit->id;
@@ -3157,9 +3155,6 @@ sub {
 		exit 0;
 	}
 
-	push(@undefined, grep { !$ENV{$_} }
-		qw/BOSH_ENVIRONMENT BOSH_CA_CERT
-		   BOSH_CLIENT BOSH_CLIENT_SECRET/);
 	bail_on_missing_pipeline_environment_variables(@undefined);
 
 	mkfile_or_fail "updates.yml", 0644, $env->with_bosh

--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -1300,13 +1300,7 @@ EOF
 		unless ($E->use_create_env) {
 			print $OUT <<EOF;
             BOSH_ENVIRONMENT:     $pipeline->{pipeline}{boshes}{$env}{url}
-            BOSH_CLIENT:          $pipeline->{pipeline}{boshes}{$env}{username}
-            BOSH_CLIENT_SECRET:   $pipeline->{pipeline}{boshes}{$env}{password}
-            BOSH_CA_CERT: |
 EOF
-			for (split /\n/, $pipeline->{pipeline}{boshes}{$env}{ca_cert}) {
-				print $OUT "              $_\n";
-			}
 		}
 		print $OUT <<EOF if $pipeline->{pipeline}{debug};
             DEBUG:                $pipeline->{pipeline}{debug}
@@ -1446,15 +1440,7 @@ EOF
 		unless ($E->use_create_env) {
 			print $OUT <<EOF;
             BOSH_ENVIRONMENT:     $pipeline->{pipeline}{boshes}{$env}{url}
-            BOSH_CLIENT:          $pipeline->{pipeline}{boshes}{$env}{username}
-            BOSH_CLIENT_SECRET:   $pipeline->{pipeline}{boshes}{$env}{password}
-            BOSH_CA_CERT: |
 EOF
-			for (split /\n/, $pipeline->{pipeline}{boshes}{$env}{ca_cert}) {
-				print $OUT <<EOF;
-              $_
-EOF
-			}
 		}
 		print $OUT <<EOF if $pipeline->{pipeline}{debug};
             DEBUG:                $pipeline->{pipeline}{debug}
@@ -1511,17 +1497,6 @@ EOF
             ERRAND_NAME:          $errand_name
 
             BOSH_ENVIRONMENT:     $pipeline->{pipeline}{boshes}{$env}{url}
-            BOSH_CA_CERT: |
-EOF
-			for (split /\n/, $pipeline->{pipeline}{boshes}{$env}{ca_cert}) {
-				print $OUT <<EOF;
-              $_
-EOF
-			}
-			print $OUT <<EOF;
-            BOSH_CLIENT:          $pipeline->{pipeline}{boshes}{$env}{username}
-            BOSH_CLIENT:          $pipeline->{pipeline}{boshes}{$env}{username}
-            BOSH_CLIENT_SECRET:   $pipeline->{pipeline}{boshes}{$env}{password}
 EOF
 			print $OUT <<EOF if $pipeline->{pipeline}{debug};
             DEBUG:                $pipeline->{pipeline}{debug}

--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -1295,13 +1295,6 @@ EOF
 			if $pipeline->{pipeline}{vault}{'no-strongbox'};
 		print $OUT "            VAULT_NAMESPACE:      $pipeline->{pipeline}{vault}{namespace}\n"
 			if $pipeline->{pipeline}{vault}{namespace};
-
-		# don't supply bosh creds if we're create-env, because no one to talk to
-		unless ($E->use_create_env) {
-			print $OUT <<EOF;
-            BOSH_ENVIRONMENT:     $pipeline->{pipeline}{boshes}{$env}{url}
-EOF
-		}
 		print $OUT <<EOF if $pipeline->{pipeline}{debug};
             DEBUG:                $pipeline->{pipeline}{debug}
 EOF
@@ -1435,13 +1428,6 @@ EOF
 			if $pipeline->{pipeline}{vault}{'no-strongbox'};
 		print $OUT "            VAULT_NAMESPACE:      $pipeline->{pipeline}{vault}{namespace}\n"
 			if $pipeline->{pipeline}{vault}{namespace};
-
-		# don't supply bosh creds if we're create-env, because no one to talk to
-		unless ($E->use_create_env) {
-			print $OUT <<EOF;
-            BOSH_ENVIRONMENT:     $pipeline->{pipeline}{boshes}{$env}{url}
-EOF
-		}
 		print $OUT <<EOF if $pipeline->{pipeline}{debug};
             DEBUG:                $pipeline->{pipeline}{debug}
 EOF
@@ -1495,8 +1481,6 @@ EOF
             CI_NO_REDACT:         $pipeline->{pipeline}{unredacted}
             CURRENT_ENV:          $env
             ERRAND_NAME:          $errand_name
-
-            BOSH_ENVIRONMENT:     $pipeline->{pipeline}{boshes}{$env}{url}
 EOF
 			print $OUT <<EOF if $pipeline->{pipeline}{debug};
             DEBUG:                $pipeline->{pipeline}{debug}


### PR DESCRIPTION
Hi there,

In this PR, we implement what we've discussed with you @dennisjbell two weeks ago about removing _some_ credentials from Genesis-generated pipelines.

Only _some_ of those indeed, because it turns out that the `bosh-config` resources defined for Cloud Config and Runtime Config of each environment _also_ need Bosh credentials.

So here, we only remove the credentials that are passed to the various `genesis` CLI invocations. For those to work, we had to remove the requirement for related environment variables for the `ci-pipeline-deploy` and `ci-show-changes` Genesis commands.

These changes have proved to pass on our “codex” environment. The `genesis` CLI invocations are running fine as can be seen [in this job run](https://concourse.codex.starkandwayne.com/teams/main/pipelines/cf-platform-pipeline/jobs/sandbox-cf/builds/29).

Best,
Benjamin