### PR TITLE
Support for private registry in generated pipelines, for air-gapped environments

### DIFF
--- a/docs/PIPELINES.md
+++ b/docs/PIPELINES.md
@@ -510,6 +510,12 @@ being deployed, or vice versa.
 - **pipeline.task.privileged** - A list of environments that require the
   bosh-deployment tasks to be run in privileged mode.  Defaults to empty list.
 
+#### Default Image Registry
+
+- **pipeline.registry.uri** - The URI of the default image registry tu use, for
+  fetching custom resource types.
+
+
 #### Groups
 
 - pipeline.groups - Groups jobs together under a header and show them on

--- a/docs/PIPELINES.md
+++ b/docs/PIPELINES.md
@@ -515,6 +515,12 @@ being deployed, or vice versa.
 - **pipeline.registry.uri** - The URI of the default image registry tu use, for
   fetching custom resource types.
 
+- **pipeline.registry.username** - The username to use when accessing the image
+  registry.
+
+- **pipeline.registry.password** - The password to use when accessing the image
+  registry.
+
 
 #### Groups
 

--- a/docs/PIPELINES.md
+++ b/docs/PIPELINES.md
@@ -513,7 +513,8 @@ being deployed, or vice versa.
 #### Default Image Registry
 
 - **pipeline.registry.uri** - The URI of the default image registry tu use, for
-  fetching custom resource types.
+  fetching custom resource types. Whenever this is defined, it will be prepended
+  to any custom task image name defined by **pipeline.task.image**.
 
 - **pipeline.registry.username** - The username to use when accessing the image
   registry.

--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -312,7 +312,9 @@ sub parse_pipeline {
 
 	# validate (optional) pipeline.task.*
 	if (exists $p->{pipeline}{task}) {
-		if (ref($p->{pipeline}{task}) eq 'HASH') {
+		if (ref($p->{pipeline}{task}) ne 'HASH') {
+			push @errors, "`pipeline.task' must be a map.";
+		} else {
 			# allowed subkeys
 			for (keys %{$p->{pipeline}{task}}) {
 				push @errors, "Unrecognized `pipeline.task.$_' key found."
@@ -321,8 +323,6 @@ sub parse_pipeline {
 			if (exists($p->{pipeline}{task}{privileged}) && ref($p->{pipeline}{task}{privileged}) ne "ARRAY") {
 				push @errors, "`pipeline.task.privileged` must be an array.";
 			}
-		} else {
-			push @errors, "`pipeline.task' must be a map.";
 		}
 	}
 

--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -1147,9 +1147,15 @@ EOF
 	}
 
 	# }}}
-	my $registry_prefix = "";
+	my ($registry_prefix, $registry_creds) = ("", "");
 	if ($pipeline->{pipeline}{registry}{uri}) {
 		$registry_prefix = $pipeline->{pipeline}{registry}{uri} . "/";
+		if ($pipeline->{pipeline}{registry}{username}) {
+			$registry_creds = <<EOF
+      username: $pipeline->{pipeline}{registry}{username}
+      password: $pipeline->{pipeline}{registry}{password}
+EOF
+		}
 	}
 	# CONCOURSE: resource types {{{
 	print $OUT <<EOF;
@@ -1159,37 +1165,37 @@ resource_types:
     type: registry-image
     source:
       repository: ${registry_prefix}cfcommunity/script-resource
-
+${registry_creds}
   - name: email
     type: registry-image
     source:
       repository: ${registry_prefix}pcfseceng/email-resource
-
+${registry_creds}
   - name: slack-notification
     type: registry-image
     source:
       repository: ${registry_prefix}cfcommunity/slack-notification-resource
-
+${registry_creds}
   - name: hipchat-notification
     type: registry-image
     source:
       repository: ${registry_prefix}cfcommunity/hipchat-notification-resource
-
+${registry_creds}
   - name: stride-notification
     type: registry-image
     source:
       repository: ${registry_prefix}starkandwayne/stride-notification-resource
-
+${registry_creds}
   - name: bosh-config
     type: registry-image
     source:
       repository: ${registry_prefix}cfcommunity/bosh-config-resource
-
+${registry_creds}
   - name: locker
     type: registry-image
     source:
       repository: ${registry_prefix}cfcommunity/locker-resource
-
+${registry_creds}
 EOF
 	# }}}
 	print $OUT <<EOF;

--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -71,7 +71,7 @@ EOF
       platform: linux,
       image_resource: {
         type: registry-image,
-        source: { repository: starkandwayne/concourse },
+        source: { repository: $pipeline->{pipeline}{task}{image} },
       },
       outputs: [
         { name: email },

--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -131,7 +131,7 @@ sub parse_pipeline {
 	}
 	for (keys %{$p->{pipeline}}) {
 		push @errors, "Unrecognized `pipeline.$_' key found."
-			unless m/^(name|public|tagged|errands|vault|git|slack|hipchat|stride|email|boshes|task|layout|layouts|groups|debug|locker|unredacted|notifications|auto-update)$/;
+			unless m/^(name|public|tagged|errands|vault|git|slack|hipchat|stride|email|boshes|task|layout|layouts|groups|debug|locker|unredacted|notifications|auto-update|registry)$/;
 	}
 	for (qw(name vault git boshes)) {
 		push @errors, "`pipeline.$_' is required."

--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -310,6 +310,19 @@ sub parse_pipeline {
 		}
 	}
 
+	# validate (optional) pipeline.registry.*
+	if (exists $p->{pipeline}{registry}) {
+		if (ref($p->{pipeline}{registry}) ne 'HASH') {
+			push @errors, "`pipeline.registry' must be a map.";
+		} else {
+			# allowed subkeys
+			for (keys %{$p->{pipeline}{registry}}) {
+				push @errors, "Unrecognized `pipeline.registry.$_' key found."
+					unless m/^(uri|username|password)$/;
+			}
+		}
+	}
+
 	# validate (optional) pipeline.task.*
 	if (exists $p->{pipeline}{task}) {
 		if (ref($p->{pipeline}{task}) ne 'HASH') {
@@ -1134,44 +1147,48 @@ EOF
 	}
 
 	# }}}
+	my $registry_prefix = "";
+	if ($pipeline->{pipeline}{registry}{uri}) {
+		$registry_prefix = $pipeline->{pipeline}{registry}{uri} . "/";
+	}
 	# CONCOURSE: resource types {{{
-	print $OUT <<'EOF';
+	print $OUT <<EOF;
 
 resource_types:
   - name: script
     type: registry-image
     source:
-      repository: cfcommunity/script-resource
+      repository: ${registry_prefix}cfcommunity/script-resource
 
   - name: email
     type: registry-image
     source:
-      repository: pcfseceng/email-resource
+      repository: ${registry_prefix}pcfseceng/email-resource
 
   - name: slack-notification
     type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
+      repository: ${registry_prefix}cfcommunity/slack-notification-resource
 
   - name: hipchat-notification
     type: registry-image
     source:
-      repository: cfcommunity/hipchat-notification-resource
+      repository: ${registry_prefix}cfcommunity/hipchat-notification-resource
 
   - name: stride-notification
     type: registry-image
     source:
-      repository: starkandwayne/stride-notification-resource
+      repository: ${registry_prefix}starkandwayne/stride-notification-resource
 
   - name: bosh-config
     type: registry-image
     source:
-      repository: cfcommunity/bosh-config-resource
+      repository: ${registry_prefix}cfcommunity/bosh-config-resource
 
   - name: locker
     type: registry-image
     source:
-      repository: cfcommunity/locker-resource
+      repository: ${registry_prefix}cfcommunity/locker-resource
 
 EOF
 	# }}}


### PR DESCRIPTION
Hi,

In this PR, I've introduced 3 new configs `pipeline.registry.{uri,username,password}` so that pipelines in air-gapped environments can fetch their custom resource types from a private registry.

For task images, I've chosen to forcefully prepend the registry prefix to the image repo whenever the registry is defined, assuming that operators wouldn't need to fetch images from different private registries.

Don't hesitate to comment.

Best,
Benjamin