### PR TITLE
Add support for OCFP naming conventions in generated pipelines

### DIFF
--- a/docs/PIPELINES.md
+++ b/docs/PIPELINES.md
@@ -297,6 +297,12 @@ pipeline:
   successful deployment / upgrade. This is especially useful for running smoke
   test errands.
 
+- **pipeline.ocfp** - Enable OCFP conventions regarding BOSH _Cloud Config_ and
+  _Runtime Config_ names. Default is `false` and watches for changes on the
+  configs named `default`. When `true`, the watched configs are named after
+  their respective environment names.
+  See also the `pipeline.boshes.<env-name>.genesis_env` property.
+
 #### Secrets
 
 - **pipeline.vault.url** - The URL of your Vault installation, i.e.
@@ -495,6 +501,11 @@ being deployed, or vice versa.
 
 - **pipeline.boshes.&lt;env-name&gt;.password** - The password for the
   configured BOSH user account.  This is **required**.
+
+- **pipeline.boshes.&lt;env-name&gt;.genesis_env** - The Genesis environment
+  name of the BOSH server, for OCFP naming conventions to properly apply. Only
+  useful when `pipeline.ocfp` is set to `true`. Defaults to the `<env-name>`,
+  which is different only when deploying OCFP environment BOSH servers.
 
 
 #### Task Configuration


### PR DESCRIPTION
Dear Genesis fellow developpers,

Turns out Cloud config names are different in OCFP context, which prevents generated pipelines from properly watching for any change on them.

Here we introducing two new pipeline settings `pipeline.ocfp` and `pipeline.boshes.<env-name>.genesis_env` for supporting OCFP naming conventions as far as Cloud and Runtime configs are concerned.

Don't hesitate to comment and reach out to me if you have any questions.

Best,
Benjamin