### PR TITLE
Escape registry password

### DIFF
--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -64,9 +64,12 @@ EOF
 		if ($pipeline->{pipeline}{registry}{uri}) {
 			$registry_prefix = $pipeline->{pipeline}{registry}{uri} . "/";
 			if ($pipeline->{pipeline}{registry}{username}) {
+				my $escaped_registry_password = $pipeline->{pipeline}{registry}{password};
+				$escaped_registry_password =~ s/\\/\\\\/;
+				$escaped_registry_password =~ s/"/\\"/;
 				$registry_creds = <<EOF
           username: $pipeline->{pipeline}{registry}{username},
-          password: $pipeline->{pipeline}{registry}{password},
+          password: "$escaped_registry_password",
 EOF
 			}
 		}
@@ -1175,13 +1178,16 @@ EOF
 	}
 
 	# }}}
-	my ($registry_prefix, $registry_creds) = ("", "");
+	my ($registry_prefix, $registry_creds, $escaped_registry_password) = ("", "", "");
 	if ($pipeline->{pipeline}{registry}{uri}) {
 		$registry_prefix = $pipeline->{pipeline}{registry}{uri} . "/";
 		if ($pipeline->{pipeline}{registry}{username}) {
+			$escaped_registry_password = $pipeline->{pipeline}{registry}{password};
+			$escaped_registry_password =~ s/\\/\\\\/;
+			$escaped_registry_password =~ s/"/\\"/;
 			$registry_creds = <<EOF
       username: $pipeline->{pipeline}{registry}{username}
-      password: $pipeline->{pipeline}{registry}{password}
+      password: "$escaped_registry_password"
 EOF
 		}
 	}
@@ -1230,9 +1236,10 @@ EOF
 jobs:
 EOF
 	if ($pipeline->{pipeline}{registry}{uri} && $pipeline->{pipeline}{registry}{username}) {
+		# We redefine registry credentials with different indenting
 		$registry_creds = <<EOF
               username: $pipeline->{pipeline}{registry}{username}
-              password: $pipeline->{pipeline}{registry}{password}
+              password: "$escaped_registry_password"
 EOF
 	}
 	for my $env (sort @{$pipeline->{envs}}) {
@@ -1671,9 +1678,12 @@ EOF
 			$subdir_msg = " under $pipeline->{pipeline}{git}{root}";
 		}
 		if ($pipeline->{pipeline}{registry}{uri} && $pipeline->{pipeline}{registry}{username}) {
+			my $escaped_registry_password = $pipeline->{pipeline}{registry}{password};
+			$escaped_registry_password =~ s/\\/\\\\/;
+			$escaped_registry_password =~ s/"/\\"/;
 			$registry_creds = <<EOF
             username: $pipeline->{pipeline}{registry}{username}
-            password: $pipeline->{pipeline}{registry}{password}
+            password: "$escaped_registry_password"
 EOF
 		}
 		print $OUT <<EOF;


### PR DESCRIPTION
This brings some improvement on top of the #498 new feature.

In case it may contain characters that conflict with the YAML syntax, which has been the case with the pipelines we are currently generating.