### PR TITLE
Missing fixes for OCFP support in generated pipelines

### DIFF
--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -407,7 +407,7 @@ sub parse_pipeline {
 				# allowed subkeys
 				for (keys %{$p->{pipeline}{boshes}{$env}}) {
 					push @errors, "Unrecognized `pipeline.boshes[$env].$_' key found."
-						unless m/^(url|ca_cert|username|password|alias)$/;
+						unless m/^(url|ca_cert|username|password|alias|genesis_env)$/;
 				}
 			}
 		}

--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -396,11 +396,7 @@ sub parse_pipeline {
 						unless m/^(alias)$/;
 				}
 			} else {
-				my @required_bosh_props = qw(url ca_cert username password);
-				if (exists $p->{pipeline}{ocfp} && yaml_bool($p->{pipeline}{ocfp}, 0)) {
-					push @required_bosh_props, 'genesis_env';
-				}
-				for (@required_bosh_props) {
+				for (qw(url ca_cert username password)) {
 					push @errors, "`pipeline.boshes[$env].$_' is required."
 						unless $p->{pipeline}{boshes}{$env}{$_};
 				}


### PR DESCRIPTION
Hello,
This PR brings back the two commits from `pipelines-ocfp-fixes` branch of PR #502 that are missing in the `v2.8.x-dev` branch.
- Commit 067e6eeb “Allow the 'genesis_env' property”
- Commit fa8d3474 “Don't require the optional 'genesis_env' setting”
Best,
Benjamin