### PR TITLE
Improve YAML-encoding in generated pipelines

### DIFF
--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -6,7 +6,12 @@ use Genesis;
 use Genesis::Top;
 use Genesis::UI;
 use Socket qw/inet_ntoa/;
+use JSON::PP qw/encode_json/;
 
+sub string_to_yaml {
+	# Note: the resulting string MUST be surrounded by double quotes
+	return substr(encode_json($_[0]), 1, -1);
+}
 sub boolean_to_yaml {
 	return $_[0] ? "true" : "false";
 }
@@ -22,6 +27,7 @@ sub _gen_notifications {
 	my ($pipeline, $message, $alias) = @_;
 	$alias = "" unless defined $alias;
 	my $notification = "in_parallel: [\n";
+	my $message_as_yaml = string_to_yaml($message);
 	if ($pipeline->{pipeline}{slack}) {
 		$notification .= <<EOF;
 {
@@ -30,7 +36,7 @@ sub _gen_notifications {
     channel: "(( grab pipeline.slack.channel ))",
     username: "(( grab pipeline.slack.username ))",
     icon_url: "(( grab pipeline.slack.icon ))",
-    text: '(( concat pipeline.name ": $message" ))'
+    text: "(( concat pipeline.name \": $message_as_yaml\" ))"
   }
 },
 EOF
@@ -42,7 +48,7 @@ EOF
   params: {
     from: "(( grab pipeline.hipchat.username ))",
     color: "gray",
-    message: '(( concat pipeline.name ": $message" ))',
+    message: "(( concat pipeline.name \": $message_as_yaml\" ))",
     notify: "(( grab pipeline.hipchat.notify ))"
   }
 },
@@ -54,7 +60,7 @@ EOF
   put: "stride",
   params: {
     conversation: "(( grab pipeline.stride.conversation ))",
-    message: '(( concat pipeline.name ": $message" ))'
+    message: "(( concat pipeline.name \": $message_as_yaml\" ))"
   }
 },
 EOF
@@ -64,12 +70,10 @@ EOF
 		if ($pipeline->{pipeline}{registry}{uri}) {
 			$registry_prefix = $pipeline->{pipeline}{registry}{uri} . "/";
 			if ($pipeline->{pipeline}{registry}{username}) {
-				my $escaped_registry_password = $pipeline->{pipeline}{registry}{password};
-				$escaped_registry_password =~ s/\\/\\\\/;
-				$escaped_registry_password =~ s/"/\\"/;
+				my $registry_password_as_yaml = string_to_yaml($pipeline->{pipeline}{registry}{password});
 				$registry_creds = <<EOF
           username: $pipeline->{pipeline}{registry}{username},
-          password: "$escaped_registry_password",
+          password: "$registry_password_as_yaml",
 EOF
 			}
 		}
@@ -97,7 +101,7 @@ ${registry_creds}
         path: bash,
         args: [
           "-exc",
-          "mkdir -p email ; rm -rf email/* ; echo \\\"\${PIPELINE_NAME}\\\" > email/subject ; echo \\\"${message}\\\" > email/body",
+          "mkdir -p email ; rm -rf email/* ; echo \\\"\${PIPELINE_NAME}\\\" > email/subject ; echo \\\"${message_as_yaml}\\\" > email/body",
         ],
       },
     },
@@ -760,7 +764,8 @@ EOF
 	if ($pipeline->{pipeline}{git}{private_key}) {
 		$git_credentials = "    private_key: |-\n      ".join("\n      ",split("\n",$pipeline->{pipeline}{git}{private_key}));
 	} else {
-		$git_credentials = "    username:    $pipeline->{pipeline}{git}{username}\n    password:    $pipeline->{pipeline}{git}{password}";
+		my $git_password_as_yaml = string_to_yaml($pipeline->{pipeline}{git}{password});
+		$git_credentials = "    username:    $pipeline->{pipeline}{git}{username}\n    password:    \"$git_password_as_yaml\"";
 	}
 	print $OUT <<"EOF";
   git:
@@ -1182,16 +1187,14 @@ EOF
 	}
 
 	# }}}
-	my ($registry_prefix, $registry_creds, $escaped_registry_password) = ("", "", "");
+	my ($registry_prefix, $registry_creds, $registry_password_as_yaml) = ("", "", "");
 	if ($pipeline->{pipeline}{registry}{uri}) {
 		$registry_prefix = $pipeline->{pipeline}{registry}{uri} . "/";
 		if ($pipeline->{pipeline}{registry}{username}) {
-			$escaped_registry_password = $pipeline->{pipeline}{registry}{password};
-			$escaped_registry_password =~ s/\\/\\\\/;
-			$escaped_registry_password =~ s/"/\\"/;
+			$registry_password_as_yaml = string_to_yaml($pipeline->{pipeline}{registry}{password});
 			$registry_creds = <<EOF
       username: $pipeline->{pipeline}{registry}{username}
-      password: "$escaped_registry_password"
+      password: "$registry_password_as_yaml"
 EOF
 		}
 	}
@@ -1243,7 +1246,7 @@ EOF
 		# We redefine registry credentials with different indenting
 		$registry_creds = <<EOF
               username: $pipeline->{pipeline}{registry}{username}
-              password: "$escaped_registry_password"
+              password: "$registry_password_as_yaml"
 EOF
 	}
 	for my $env (sort @{$pipeline->{envs}}) {
@@ -1641,12 +1644,10 @@ EOF
 			$subdir_msg = " under $pipeline->{pipeline}{git}{root}";
 		}
 		if ($pipeline->{pipeline}{registry}{uri} && $pipeline->{pipeline}{registry}{username}) {
-			my $escaped_registry_password = $pipeline->{pipeline}{registry}{password};
-			$escaped_registry_password =~ s/\\/\\\\/;
-			$escaped_registry_password =~ s/"/\\"/;
+			my $registry_password_as_yaml = string_to_yaml($pipeline->{pipeline}{registry}{password});
 			$registry_creds = <<EOF
             username: $pipeline->{pipeline}{registry}{username}
-            password: "$escaped_registry_password"
+            password: "$registry_password_as_yaml"
 EOF
 		}
 		print $OUT <<EOF;


### PR DESCRIPTION
Hi there,

This PR improves the way registry and Git passwords are YAML-encoded when generating pipeline.

This time, the ad-hoc implementation is replaced by the solid `encode_json()` function from the `JSON::PP` module, that is already used elsewhere in Genesis.

Best,
Benjamin