### PR TITLE
Proper secrets mount in generated pipelines

### DIFF
--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -1548,7 +1548,15 @@ ${registry_creds}
             CI_NO_REDACT:         $pipeline->{pipeline}{unredacted}
             CURRENT_ENV:          $env
             ERRAND_NAME:          $errand_name
+            VAULT_ROLE_ID:        (( grab pipeline.vault.role ))
+            VAULT_SECRET_ID:      (( grab pipeline.vault.secret ))
+            VAULT_ADDR:           $pipeline->{pipeline}{vault}{url}
+            VAULT_SKIP_VERIFY:    ${\($pipeline->{pipeline}{vault}{verify} ? 'false' : 'true')}
 EOF
+			print $OUT "            VAULT_NO_STRONGBOX:   1\n"
+				if $pipeline->{pipeline}{vault}{'no-strongbox'};
+			print $OUT "            VAULT_NAMESPACE:      $pipeline->{pipeline}{vault}{namespace}\n"
+				if $pipeline->{pipeline}{vault}{namespace};
 			print $OUT <<EOF if $pipeline->{pipeline}{debug};
             DEBUG:                $pipeline->{pipeline}{debug}
 EOF

--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -1360,6 +1360,8 @@ EOF
 			if $pipeline->{pipeline}{vault}{'no-strongbox'};
 		print $OUT "            VAULT_NAMESPACE:      $pipeline->{pipeline}{vault}{namespace}\n"
 			if $pipeline->{pipeline}{vault}{namespace};
+		print $OUT "            GENESIS_SECRETS_MOUNT:      $ENV{GENESIS_SECRETS_MOUNT}\n"
+			if $ENV{GENESIS_SECRETS_MOUNT};
 		print $OUT <<EOF if $pipeline->{pipeline}{debug};
             DEBUG:                $pipeline->{pipeline}{debug}
 EOF
@@ -1494,6 +1496,8 @@ EOF
 			if $pipeline->{pipeline}{vault}{'no-strongbox'};
 		print $OUT "            VAULT_NAMESPACE:      $pipeline->{pipeline}{vault}{namespace}\n"
 			if $pipeline->{pipeline}{vault}{namespace};
+		print $OUT "            GENESIS_SECRETS_MOUNT:      $ENV{GENESIS_SECRETS_MOUNT}\n"
+			if $ENV{GENESIS_SECRETS_MOUNT};
 		print $OUT <<EOF if $pipeline->{pipeline}{debug};
             DEBUG:                $pipeline->{pipeline}{debug}
 EOF
@@ -1557,6 +1561,8 @@ EOF
 				if $pipeline->{pipeline}{vault}{'no-strongbox'};
 			print $OUT "            VAULT_NAMESPACE:      $pipeline->{pipeline}{vault}{namespace}\n"
 				if $pipeline->{pipeline}{vault}{namespace};
+			print $OUT "            GENESIS_SECRETS_MOUNT:      $ENV{GENESIS_SECRETS_MOUNT}\n"
+				if $ENV{GENESIS_SECRETS_MOUNT};
 			print $OUT <<EOF if $pipeline->{pipeline}{debug};
             DEBUG:                $pipeline->{pipeline}{debug}
 EOF


### PR DESCRIPTION
Hi there,

Seems the Vault credentials have been missing when running errand from generated pipelines. We haven't tested it unfortunately, as we still don't have the CF pipeline working, which should happen soon. In the meantime @dennisjbell could you confirm that these Vault environment variables are indeed required?

Then, we've added the `GENESIS_SECRETS_MOUNT` env var, so that `genesis` invocations in pipeline task get their `genesis.secrets_mount` forced to the correct value.

Please note that this code is not tested yet, thus the Draft PR. I'll update here when it is.

Best,
Benjamin