### PR TITLE
fix: invoke post-deploy hook before exodus export

### DIFF
--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -3320,6 +3320,16 @@ sub _post_deploy {
 		$opts{'canaries'} ? "canaries=$opts{'canaries'}" : undef,
 		$opts{'max-in-flight'} ? "max-in-flight=$opts{'max-in-flight'}" : undef,
 	));
+
+	# Run post-deploy hook 
+	$self->run_hook(
+		'post-deploy',
+		rc => $state->{results}[1],
+		data => $state->{predeploy_data},
+		interactive => !$noprompt,
+		flags => $opt_flags,
+	) if $self->has_hook('post-deploy');
+
 	my $exodus_overrides = {};
 	if ($self->is_bosh_director && $self->cpi_enabled) {
 		$exodus_overrides->{default_cpi_config} = $self->cpi_name;
@@ -3355,15 +3365,6 @@ sub _post_deploy {
 			info("  - #G{network map successfully updated}");
 		}
 	}
-
-	# Run post-deploy hook
-	$self->run_hook(
-		'post-deploy',
-		rc => $state->{results}[1],
-		data => $state->{predeploy_data},
-		interactive => !$noprompt,
-		flags => $opt_flags,
-	) if $self->has_hook('post-deploy');
 
 	# Clean up deployment state
 	delete $self->{deployment_state};


### PR DESCRIPTION
Move the ‘post-deploy’ hook invocation up in _post_deploy so it runs immediately before the exodus metadata export (update_deployment_exodus). This guarantees that any automatic unseal logic in the post-deploy hook has been executed—and Vault is unsealed—before Genesis tries to authenticate with it for metadata export.