### PR TITLE
bugfix:introduce early post deploy for vault kit.

### DIFF
--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -3307,6 +3307,16 @@ sub _post_deploy {
 		$opts{'canaries'} ? "canaries=$opts{'canaries'}" : undef,
 		$opts{'max-in-flight'} ? "max-in-flight=$opts{'max-in-flight'}" : undef,
 	));
+
+	# Run early-post-deploy hook
+	$self->run_hook(
+		'early-post-deploy',
+		rc => $state->{results}[1],
+		data => $state->{predeploy_data},
+		interactive => !$noprompt,
+		flags => $opt_flags,
+	) if $self->has_hook('early-post-deploy');
+
 	my $exodus_overrides = {};
 	if ($self->is_bosh_director && $self->cpi_enabled) {
 		$exodus_overrides->{default_cpi_config} = $self->cpi_name;


### PR DESCRIPTION
- by introducing an early post deploy hook, we can run a hook before it is exported to exodus metadata.
- this addresses the vault unseal issue edge case