### PR TITLE
Fix: rotate_secrets exits prematurely during deployment

### DIFF
--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -4197,7 +4197,7 @@ sub rotate_secrets {
 		} else {
 			$self->notify(success => "doesn't have any secrets to rotate.\n");
 		}
-		exit 0;
+		return ({empty => 1});
 	}
 
 	kit_bug(


### PR DESCRIPTION
## Description
Fixes a bug where `genesis deploy` exits prematurely when no secrets are defined in the kit.

## Problem
When `rotate_secrets()` is called internally during deployment (via `_fix_secrets()`), it calls `exit 0` if no secrets are found, terminating the entire Genesis process before BOSH deployment can occur.

## Root Cause
The bug was introduced in commit 8ae11b0 (May 2025) when deployment preflight checks were enhanced. The `rotate_secrets()` method was originally designed as a command handler that could safely exit, but is now also used as an internal method during deployment that must return values to its caller.

## Solution
Changed `exit 0` to `return ({empty => 1})` to match the pattern used by other secret-related methods (`add_secrets`, `remove_secrets`), allowing `_fix_secrets()` to properly handle the empty secrets case as a success condition.

## Testing
- Tested with jumpbox-genesis-kit without openvpn feature (no secrets defined)
- Deployment now proceeds normally instead of exiting early
- Message "doesn't have any secrets to rotate" still appears but deployment continues

## Impact
- Minimal change (1 line)
- Fixes deployments for any kit with optional secrets or no secrets at all
- No breaking changes - maintains same behavior for rotate-secrets command