### PR TITLE
Fix compile-kit bugs for standalone kit repositories

### DIFF
--- a/lib/Genesis/Commands/Kit.pm
+++ b/lib/Genesis/Commands/Kit.pm
@@ -64,14 +64,19 @@ sub build_kit {
 
 	my $name = delete $options{name};
 
-	my $top = Genesis::Top->new('.');
-	my @remote_versions = map {$_->{version}} ($top->remote_kit_versions(
-		$name,
-		include_prereleases=>1,
-		include_drafts=>1
-	));
-	my $local_kits = Genesis::Kit::Compiled->local_kits($top->kit_provider, $target);
-	my @local_versions = grep { semver($_) } (keys %{ $local_kits->{$name} });
+	# Only query remote/local kit versions if we're in a deployment repository.
+	# When compiling from a standalone kit source repo, we skip this check.
+	my ($top, @remote_versions, @local_versions);
+	if (Genesis::Top->is_repo('.')) {
+		$top = Genesis::Top->new('.');
+		@remote_versions = map {$_->{version}} ($top->remote_kit_versions(
+			$name,
+			include_prereleases=>1,
+			include_drafts=>1
+		));
+		my $local_kits = Genesis::Kit::Compiled->local_kits($top->kit_provider, $target);
+		@local_versions = grep { semver($_) } (keys %{ $local_kits->{$name} });
+	}
 
 	if ($options{version}) {
 		$options{version} =~ s/^v//; # trim any leading 'v'

--- a/lib/Genesis/Kit/Compiler.pm
+++ b/lib/Genesis/Kit/Compiler.pm
@@ -234,8 +234,9 @@ sub _select_files {
 		return if $exclude_re && $File::Find::name =~ $exclude_re;
 		return if $File::Find::name eq $self->{root}; # skip root dir itself
 
-		# Strip the root path prefix
-		my $filename = substr($File::Find::name, length($self->{root} =~ s{/*}{/}r) + 1);
+		# Strip the root path prefix (ensure root has trailing slash)
+		my $root_with_slash = $self->{root} =~ s{/*$}{/}r;
+		my $filename = substr($File::Find::name, length($root_with_slash));
 		push @all_files, $filename;
 	}, $self->{root});
 	return @all_files;
@@ -269,6 +270,10 @@ sub compile {
 	# Add and remap the files to be under the base dir
 	for my $path (sort @files) {
 		my ($file) = $tar->add_files($path);
+		unless ($file) {
+			warning "Skipping file '%s' - not found", $path;
+			next;
+		}
 		my $full_path = "$base_dir".$file->full_path;
 		$full_path =~ s{/*$}{/} if $file->is_dir;
 		$file->rename($full_path);


### PR DESCRIPTION
- Allow compile-kit to work from kit source directories (not just deployment repos)
  - Only query remote/local kit versions when in a deployment repository
  - Skip version checks when compiling from standalone kit repos

- Fix filename truncation bug in Kit Compiler
  - Corrected regex from s{/*}{/}r to s{/*$}{/}r to only match trailing slashes
  - Removed incorrect +1 offset that was stripping first character of filenames

- Add graceful handling for missing files during compilation
  - Check for undefined return from tar->add_files() instead of crashing
  - Log warning and skip missing files instead of failing

These changes allow kit authors to run 'genesis compile-kit' directly from their kit source repositories without needing a deployment repository context.