### PR TITLE
Fix operator precedence in editor checks

### DIFF
--- a/lib/Genesis/Commands/Env.pm
+++ b/lib/Genesis/Commands/Env.pm
@@ -123,7 +123,7 @@ sub edit {
 	bail(
 		"Cannot specify #Y{--manual} unless the editor is vi-based (vi,vim,mvim,".
 		"nvim,gvim), vscode (code) or emacs: ".
-		"Pull request are welcome for other editors."
+		"Pull requests are welcome for other editors."
 	) if $use_manual && $editor !~ m/^([gmn]?vim|vi|emacs|code)$/;
 	if ($use_manual//1 && $editor =~ m/^([gmn]?vim|vi|emacs|code)$/) {
 		if ($kit_name eq 'dev') {

--- a/lib/Genesis/Commands/Env.pm
+++ b/lib/Genesis/Commands/Env.pm
@@ -124,7 +124,7 @@ sub edit {
 		"Cannot specify #Y{--manual} unless the editor is vi-based (vi,vim,mvim,".
 		"nvim,gvim), vscode (code) or emacs: ".
 		"Pull request are welcome for other editors."
-	) if $use_manual && ! $editor =~ m/^([gmn]?vim|vi|emacs|code)$/;
+	) if $use_manual && $editor !~ m/^([gmn]?vim|vi|emacs|code)$/;
 	if ($use_manual//1 && $editor =~ m/^([gmn]?vim|vi|emacs|code)$/) {
 		if ($kit_name eq 'dev') {
 			if (-d $top->path('dev')) {
@@ -166,7 +166,7 @@ sub edit {
 	bail(
 		"Cannot specify #Y{--include-all-ancestors} unless the editor is vi-based ".
 		"(vi,vim,mvim,nvim,gvim) or vscode (code): Pull request are welcome for other editors."
-	) if $show_ancestors && !$editor =~ m/^([gmn]?vim|vi|^code)$/;
+	) if $show_ancestors && $editor !~ m/^([gmn]?vim|vi|code)$/;
 
 	if ($show_ancestors//1 && $editor =~ m/^([gmn]?vim|vi|code)$/) {
 		my @ancestors = reverse $env->potential_environment_files;

--- a/lib/Genesis/Commands/Env.pm
+++ b/lib/Genesis/Commands/Env.pm
@@ -165,7 +165,7 @@ sub edit {
 	my $show_ancestors = defined(get_options->{ancestors}) ? (get_options->{ancestors} ? 1 : 0) : undef;
 	bail(
 		"Cannot specify #Y{--include-all-ancestors} unless the editor is vi-based ".
-		"(vi,vim,mvim,nvim,gvim) or vscode (code): Pull request are welcome for other editors."
+		"(vi,vim,mvim,nvim,gvim) or vscode (code): Pull requests are welcome for other editors."
 	) if $show_ancestors && $editor !~ m/^([gmn]?vim|vi|code)$/;
 
 	if ($show_ancestors//1 && $editor =~ m/^([gmn]?vim|vi|code)$/) {


### PR DESCRIPTION
## Summary

- Fix `! $editor =~ m/.../` to `$editor !~ m/.../` at two locations in `edit` sub (precedence bug: `!` binds tighter than `=~`)
- Remove errant `^` inside regex alternation group (`^code` → `code`)

Same fix as applied directly to `v3.1.x-dev` in 940fbf3.