### PR TITLE
Add POD for Env::Secrets modules

### DIFF
--- a/lib/Genesis/Env/Secrets/Parser.pod
+++ b/lib/Genesis/Env/Secrets/Parser.pod
@@ -1,0 +1,124 @@
+=head1 NAME
+
+Genesis::Env::Secrets::Parser - Abstract base class for Genesis environment secret parsers
+
+=head1 SYNOPSIS
+
+  use Genesis::Env::Secrets::Parser;
+
+  # Never instantiate this class directly.
+  # Use a concrete subclass instead:
+
+  use Genesis::Env::Secrets::Parser::FromKit;
+  my $parser = Genesis::Env::Secrets::Parser::FromKit->new($env);
+  my @secrets = $parser->parse();
+
+  use Genesis::Env::Secrets::Parser::FromManifest;
+  my $parser = Genesis::Env::Secrets::Parser::FromManifest->new($env);
+  my @secrets = $parser->parse();
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::Secrets::Parser> is the abstract base class for all secret
+definition parsers in the Genesis secrets management system. It provides the
+common constructor and environment accessor that all concrete parsers share.
+
+This class cannot be instantiated meaningfully on its own. Use one of the
+concrete subclasses to parse secrets from a specific source:
+
+=over 4
+
+=item * C<Genesis::Env::Secrets::Parser::FromKit> -- parses secret
+definitions from the kit definition file (certificates, provided, and
+credentials blocks)
+
+=item * C<Genesis::Env::Secrets::Parser::FromManifest> -- parses secret
+definitions from the BOSH manifest variables block
+
+=back
+
+Concrete subclasses must implement the C<parse> method. The return value is
+a list of C<Genesis::Secret> objects (or C<Genesis::Secret::Invalid> objects
+for any definitions that fail validation).
+
+=head1 METHODS
+
+=head2 new
+
+  my $parser = $class->new($env);
+
+Constructor. Creates a new parser bound to the given Genesis environment
+object. Called by derived classes; see subclass documentation for the full
+interface.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$env> - A C<Genesis::Env> object representing the deployment
+environment whose secrets are to be parsed. May be C<undef> for subclasses
+that accept kit metadata and feature lists directly as options to the C<parse>
+method.
+
+=back
+
+B<Returns:> A blessed parser object of the calling class.
+
+The constructed object exposes a single accessor, C<env>, which returns the
+C<Genesis::Env> object passed to C<new()>, or C<undef> if none was provided.
+
+B<Examples:>
+
+  my $parser = Genesis::Env::Secrets::Parser::FromKit->new($env);
+  print ref($parser);      # prints 'Genesis::Env::Secrets::Parser::FromKit'
+  print ref($parser->env); # prints 'Genesis::Env'
+
+=head1 ABSTRACT METHODS
+
+Methods that derived classes B<must> implement. The base class provides
+only an empty stub that returns nothing.
+
+=head2 parse
+
+  my @secrets = $parser->parse(%opts);
+
+Parses secret definitions from the parser's configured source and returns
+a list of C<Genesis::Secret> objects. The base class implementation is an
+empty stub. Subclasses must override this method to produce actual secret
+definitions.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<%opts> - Options controlling parse behavior. Accepted keys are
+defined by the concrete subclass.
+
+=back
+
+B<Returns:> A list of C<Genesis::Secret> objects (or
+C<Genesis::Secret::Invalid> objects for invalid definitions). The base class
+stub returns an empty list.
+
+B<Examples:>
+
+  # In a derived class:
+  my @secrets = $parser->parse(notify => 1);
+  print scalar(@secrets), " secrets found\n"; # prints e.g. '5 secrets found'
+
+=head1 SEE ALSO
+
+L<Genesis::Env::Secrets::Parser::FromKit>,
+L<Genesis::Env::Secrets::Parser::FromManifest>,
+L<Genesis::Env::Secrets::Plan>,
+L<Genesis::Env>
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Secrets/Parser/FromKit.pod
+++ b/lib/Genesis/Env/Secrets/Parser/FromKit.pod
@@ -117,13 +117,13 @@ notice and should not be called directly.
   $self->_parse_x509_secret_definition($path, $data, $feature)
 
 Parses a single entry from the C<certificates> block for a given feature.
-Validates that C<$path> does not contain colons and that C<$data> is a
-hashref. On success, delegates to C<_parse_x509_subpaths> for each key in
-C<$data>. Called from a C<while> loop in C<parse()>; a bare C<next> inside
-this method skips to the next loop iteration when C<$data> is undefined.
+Returns an empty list if C<$data> is undefined. Validates that C<$path>
+does not contain colons and that C<$data> is a hashref. On success,
+delegates to C<_parse_x509_subpaths> for each key in C<$data>.
 
-Returns one or more C<Genesis::Secret::X509> objects, or a
-C<Genesis::Secret::Invalid> object if validation fails.
+B<Returns:> An empty list if C<$data> is undefined. One or more
+C<Genesis::Secret::X509> objects on success. A C<Genesis::Secret::Invalid>
+object if validation fails.
 
 B<Parameters:>
 
@@ -148,10 +148,11 @@ B<Examples:>
 
   $self->_parse_x509_subpaths($path, $subpath, $subdata, $feature)
 
-Parses a single subpath entry within an X.509 certificate group. Constructs
-the extended path as C<"$path/$subpath">, validates that C<$subdata> is a
-hashref, and creates a C<Genesis::Secret::X509> object with all fields
-passed through from C<$subdata>.
+Parses a single subpath entry within an X.509 certificate group. Returns
+an empty list if C<$subdata> is undefined. Constructs the extended path as
+C<"$path/$subpath">, validates that C<$subdata> is a hashref, and creates
+a C<Genesis::Secret::X509> object with all fields passed through from
+C<$subdata>.
 
 Applies two automatic defaults:
 
@@ -166,7 +167,12 @@ C<"application/certs/ca">.
 
 =back
 
-Returns a C<Genesis::Secret::X509> object, or a C<Genesis::Secret::Invalid>
+B<Side Effects:> Modifies C<$subdata> in place. The C<is_ca> key may be
+added and the C<signed_by> value may be rewritten directly on the passed-in
+hashref. See L<FWT-681|https://fivetwenty.atlassian.net/browse/FWT-681>.
+
+B<Returns:> An empty list if C<$subdata> is undefined. A
+C<Genesis::Secret::X509> object on success. A C<Genesis::Secret::Invalid>
 object if C<$subdata> is not a hashref.
 
 B<Parameters:>
@@ -194,8 +200,9 @@ B<Examples:>
   $self->_parse_provided_secret_definition($path, $data, $feature)
 
 Parses a single entry from the C<provided> block for a given feature.
-Validates that C<$path> does not contain colons and that C<$data> is a
-hashref. Defaults C<$data->{type}> to C<'generic'> if not present.
+Returns an empty list if C<$data> is undefined. Validates that C<$path>
+does not contain colons and that C<$data> is a hashref. Defaults
+C<$data->{type}> to C<'generic'> if not present.
 
 For type C<'generic'>, validates that C<$data->{keys}> is a hashref, then
 creates one C<Genesis::Secret::UserProvided> object per key, with the
@@ -205,8 +212,11 @@ C<Genesis::Secret::Invalid> object instead.
 Any C<type> value other than C<'generic'> produces a
 C<Genesis::Secret::Invalid> object.
 
-Returns a list of C<Genesis::Secret::UserProvided> or
-C<Genesis::Secret::Invalid> objects.
+B<Side Effects:> Sets C<< $data->{type} >> to C<'generic'> in place if the
+key is not already present.
+
+B<Returns:> An empty list if C<$data> is undefined. A list of
+C<Genesis::Secret::UserProvided> or C<Genesis::Secret::Invalid> objects.
 
 B<Parameters:>
 
@@ -232,8 +242,9 @@ B<Examples:>
   $self->_parse_credential_definition($path, $data, $feature)
 
 Parses a single entry from the C<credentials> block for a given feature.
-Validates that C<$path> does not contain colons, then dispatches based
-on the structure and value of C<$data>:
+Returns an empty list if C<$data> is undefined. Validates that C<$path>
+does not contain colons, then dispatches based on the structure and value
+of C<$data>:
 
 =over 4
 
@@ -272,6 +283,10 @@ from the kit metadata.
 =item * C<$feature> - The feature name this definition belongs to.
 
 =back
+
+B<Returns:> An empty list if C<$data> is undefined. One or more secret
+objects on success (type depends on the definition). A
+C<Genesis::Secret::Invalid> object if validation fails.
 
 B<Examples:>
 
@@ -421,6 +436,18 @@ B<Examples:>
   # Returns: 1 if $metadata->{certificates}{tls} is a hashref
   # Returns: 0 and pushes a Genesis::Secret::Invalid if it exists but is not a hashref
   # Returns: 0 silently if the block is not defined for this feature
+
+=head1 KNOWN ISSUES
+
+=over 4
+
+=item * C<_parse_x509_subpaths> modifies its C<$subdata> argument in place,
+adding C<is_ca> and rewriting C<signed_by> directly on the caller's
+hashref (see B<Side Effects> in the method documentation). This may cause
+subtle bugs if the same hashref is reused. Tracked in
+L<FWT-681|https://fivetwenty.atlassian.net/browse/FWT-681>.
+
+=back
 
 =head1 SEE ALSO
 

--- a/lib/Genesis/Env/Secrets/Parser/FromKit.pod
+++ b/lib/Genesis/Env/Secrets/Parser/FromKit.pod
@@ -117,13 +117,16 @@ notice and should not be called directly.
   $self->_parse_x509_secret_definition($path, $data, $feature)
 
 Parses a single entry from the C<certificates> block for a given feature.
-Returns an empty list if C<$data> is undefined. Validates that C<$path>
-does not contain colons and that C<$data> is a hashref. On success,
-delegates to C<_parse_x509_subpaths> for each key in C<$data>.
+When C<$data> is undefined, executes a bare C<next> statement to skip the
+current iteration of the caller's C<while> loop (see L<KNOWN ISSUES>).
+Validates that C<$path> does not contain colons and that C<$data> is a
+hashref. On success, delegates to C<_parse_x509_subpaths> for each key in
+C<$data>.
 
-B<Returns:> An empty list if C<$data> is undefined. One or more
-C<Genesis::Secret::X509> objects on success. A C<Genesis::Secret::Invalid>
-object if validation fails.
+B<Returns:> Skips the caller's loop iteration via bare C<next> if C<$data>
+is undefined (see L<KNOWN ISSUES>). One or more C<Genesis::Secret::X509>
+objects on success. A C<Genesis::Secret::Invalid> object if validation
+fails.
 
 B<Parameters:>
 
@@ -148,8 +151,10 @@ B<Examples:>
 
   $self->_parse_x509_subpaths($path, $subpath, $subdata, $feature)
 
-Parses a single subpath entry within an X.509 certificate group. Returns
-an empty list if C<$subdata> is undefined. Constructs the extended path as
+Parses a single subpath entry within an X.509 certificate group. When
+C<$subdata> is undefined, executes a bare C<next> statement to skip the
+current iteration of the caller's C<while> loop (see L<KNOWN ISSUES>).
+Constructs the extended path as
 C<"$path/$subpath">, validates that C<$subdata> is a hashref, and creates
 a C<Genesis::Secret::X509> object with all fields passed through from
 C<$subdata>.
@@ -171,9 +176,10 @@ B<Side Effects:> Modifies C<$subdata> in place. The C<is_ca> key may be
 added and the C<signed_by> value may be rewritten directly on the passed-in
 hashref. See L<FWT-681|https://fivetwenty.atlassian.net/browse/FWT-681>.
 
-B<Returns:> An empty list if C<$subdata> is undefined. A
-C<Genesis::Secret::X509> object on success. A C<Genesis::Secret::Invalid>
-object if C<$subdata> is not a hashref.
+B<Returns:> Skips the caller's loop iteration via bare C<next> if
+C<$subdata> is undefined (see L<KNOWN ISSUES>). A C<Genesis::Secret::X509>
+object on success. A C<Genesis::Secret::Invalid> object if C<$subdata> is
+not a hashref.
 
 B<Parameters:>
 
@@ -200,9 +206,10 @@ B<Examples:>
   $self->_parse_provided_secret_definition($path, $data, $feature)
 
 Parses a single entry from the C<provided> block for a given feature.
-Returns an empty list if C<$data> is undefined. Validates that C<$path>
-does not contain colons and that C<$data> is a hashref. Defaults
-C<$data->{type}> to C<'generic'> if not present.
+When C<$data> is undefined, executes a bare C<next> statement to skip the
+current iteration of the caller's C<while> loop (see L<KNOWN ISSUES>).
+Validates that C<$path> does not contain colons and that C<$data> is a
+hashref. Defaults C<$data->{type}> to C<'generic'> if not present.
 
 For type C<'generic'>, validates that C<$data->{keys}> is a hashref, then
 creates one C<Genesis::Secret::UserProvided> object per key, with the
@@ -215,8 +222,9 @@ C<Genesis::Secret::Invalid> object.
 B<Side Effects:> Sets C<< $data->{type} >> to C<'generic'> in place if the
 key is not already present.
 
-B<Returns:> An empty list if C<$data> is undefined. A list of
-C<Genesis::Secret::UserProvided> or C<Genesis::Secret::Invalid> objects.
+B<Returns:> Skips the caller's loop iteration via bare C<next> if C<$data>
+is undefined (see L<KNOWN ISSUES>). A list of C<Genesis::Secret::UserProvided>
+or C<Genesis::Secret::Invalid> objects.
 
 B<Parameters:>
 
@@ -242,9 +250,10 @@ B<Examples:>
   $self->_parse_credential_definition($path, $data, $feature)
 
 Parses a single entry from the C<credentials> block for a given feature.
-Returns an empty list if C<$data> is undefined. Validates that C<$path>
-does not contain colons, then dispatches based on the structure and value
-of C<$data>:
+When C<$data> is undefined, executes a bare C<next> statement to skip the
+current iteration of the caller's C<while> loop (see L<KNOWN ISSUES>).
+Validates that C<$path> does not contain colons, then dispatches based on
+the structure and value of C<$data>:
 
 =over 4
 
@@ -284,9 +293,10 @@ from the kit metadata.
 
 =back
 
-B<Returns:> An empty list if C<$data> is undefined. One or more secret
-objects on success (type depends on the definition). A
-C<Genesis::Secret::Invalid> object if validation fails.
+B<Returns:> Skips the caller's loop iteration via bare C<next> if C<$data>
+is undefined (see L<KNOWN ISSUES>). One or more secret objects on success
+(type depends on the definition). A C<Genesis::Secret::Invalid> object if
+validation fails.
 
 B<Examples:>
 
@@ -298,9 +308,10 @@ B<Examples:>
 
   $self->_parse_credential_key($path, $key, $data, $feature)
 
-Parses a single key within a credential hashmap entry. Validates that
-C<$key> does not contain colons. Constructs the extended path as
-C<"$path:$key">, then dispatches based on C<$data>:
+Parses a single key within a credential hashmap entry. Returns a
+C<Genesis::Secret::Invalid> object immediately if C<$key> contains a colon.
+Otherwise constructs the extended path as C<"$path:$key"> and dispatches
+based on C<$data>:
 
 =over 4
 
@@ -411,7 +422,10 @@ Returns C<0> if the block is not defined for this feature (no action
 taken).
 
 Returns C<0> and pushes a C<Genesis::Secret::Invalid> object onto
-C<$secrets> if the block exists but is not a hashref.
+C<$secrets> if the block exists but is not a hashref. Due to a known
+defect, this call passes only 3 of the 5 required arguments to
+C<_invalid_secret>, leaving the C<data> and C<_feature> fields as C<undef>
+on the resulting object (see L<KNOWN ISSUES>).
 
 B<Parameters:>
 
@@ -446,6 +460,50 @@ adding C<is_ca> and rewriting C<signed_by> directly on the caller's
 hashref (see B<Side Effects> in the method documentation). This may cause
 subtle bugs if the same hashref is reused. Tracked in
 L<FWT-681|https://fivetwenty.atlassian.net/browse/FWT-681>.
+
+=item * B<Bare C<next> in subroutines>: Four methods use a bare C<next>
+statement inside subroutines that are called from C<parse()>'s C<while>
+loops. The C<next> relies on Perl's dynamic scope to escape into the
+caller's loop, which is fragile and may produce a C<"Can't \"next\" outside
+a loop block"> runtime error under strict conditions. Affects:
+C<_parse_x509_secret_definition> (line 60), C<_parse_x509_subpaths> (line
+81), C<_parse_provided_secret_definition> (line 105), and
+C<_parse_credential_definition> (line 157). All should use C<return ()>
+instead. Tracked in L<FWT-681|https://fivetwenty.atlassian.net/browse/FWT-681>.
+
+=item * B<Incomplete arguments to C<_invalid_secret> in
+C<_validate_feature_block>>: Lines 271-276 pass only 3 of 5 required
+arguments to C<_invalid_secret>, leaving the C<data> and C<_feature> fields
+as C<undef> on the resulting C<Genesis::Secret::Invalid> object. Tracked in
+L<FWT-681|https://fivetwenty.atlassian.net/browse/FWT-681>.
+
+=item * B<Silent mutation via C<//=> in C<_parse_provided_secret_definition>>:
+Line 118 mutates C<$data-E<gt>{type}> in-place via the C<//=> operator (see
+B<Side Effects> in the method documentation). Callers that reuse the same
+hashref will observe the injected C<'generic'> value on subsequent accesses.
+Tracked in L<FWT-682|https://fivetwenty.atlassian.net/browse/FWT-682>.
+
+=item * B<Broken regex for ssh/rsa size parameter in
+C<_parse_credential_definition>>: Line 166 makes the key size mandatory in
+the regex (C<(?:\s+(\d+))> with no C<?> quantifier), but the code provides
+a default of C<2048> via C<$2//2048>. The default is unreachable dead code
+because the regex will not match if the size is absent. Tracked in
+L<FWT-683|https://fivetwenty.atlassian.net/browse/FWT-683>.
+
+=item * B<Narrow regex for path-level C<random>/C<uuid> guards in
+C<_parse_credential_definition>>: Lines 171 and 176 use C<.?> which matches
+only 0 or 1 characters after the keyword, missing most real-world values
+(e.g., C<"random 32">). The guard branches are effectively dead for any
+non-trivial input and fall through to the C<"Unrecognized request"> branch
+instead. Tracked in
+L<FWT-684|https://fivetwenty.atlassian.net/browse/FWT-684>.
+
+=item * B<Wrong subject label in C<_parse_credential_key> fallthrough>:
+Lines 238-241 hardcode C<"Random"> as the subject for the
+C<Genesis::Secret::Invalid> object produced when a per-key value is neither
+C<random> nor C<uuid>. The error message C<"Bad generate-password format
+'$data'"> is also misleading for non-password types. Tracked in
+L<FWT-685|https://fivetwenty.atlassian.net/browse/FWT-685>.
 
 =back
 

--- a/lib/Genesis/Env/Secrets/Parser/FromKit.pod
+++ b/lib/Genesis/Env/Secrets/Parser/FromKit.pod
@@ -1,0 +1,446 @@
+=head1 NAME
+
+Genesis::Env::Secrets::Parser::FromKit - Parse secret definitions from a kit definition file
+
+=head1 SYNOPSIS
+
+  use Genesis::Env::Secrets::Parser::FromKit;
+
+  my $parser = Genesis::Env::Secrets::Parser::FromKit->new($env);
+  my @secrets = $parser->parse();
+
+  # Or supply kit metadata and features directly (no environment required):
+  my @secrets = $parser->parse(
+    kit_metadata => $metadata,
+    features     => ['tls', 'ha'],
+  );
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::Secrets::Parser::FromKit> is a concrete subclass of
+L<Genesis::Env::Secrets::Parser> that parses secret definitions from a
+Genesis kit definition file. It reads the C<certificates>, C<provided>,
+and C<credentials> blocks of kit metadata and produces a list of
+C<Genesis::Secret> objects, one per defined secret.
+
+The parser iterates over the C<base> feature and all configured features,
+converting each definition into the appropriate secret type:
+
+=over 4
+
+=item * C<certificates> blocks produce C<Genesis::Secret::X509> objects
+
+=item * C<provided> blocks produce C<Genesis::Secret::UserProvided> objects
+
+=item * C<credentials> blocks produce C<Genesis::Secret::SSH>,
+C<Genesis::Secret::RSA>, C<Genesis::Secret::DHParams>,
+C<Genesis::Secret::Random>, or C<Genesis::Secret::UUID> objects depending
+on the definition syntax
+
+=back
+
+If any definition contains a structural error (wrong type, missing
+required fields, invalid path, unrecognized syntax), the parser emits a
+C<Genesis::Secret::Invalid> object in place of the malformed definition
+rather than aborting. This allows callers to report all problems at once.
+
+=head1 METHODS
+
+=head2 parse
+
+  my @secrets = $parser->parse(%opts);
+
+Parses all secret definitions from the kit metadata and returns them as a
+flat list of C<Genesis::Secret> objects. Iterates over C<base> and each
+configured feature, processing the C<certificates>, C<provided>, and
+C<credentials> blocks in that order.
+
+If the parser was constructed without an environment object, both
+C<kit_metadata> and C<features> must be supplied as options.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<notify> - Optional boolean. When true, emits a progress message
+before parsing and a count summary after. Defaults to false.
+
+=item * C<kit_metadata> - Optional hashref of kit definition metadata
+(the dereferenced kit metadata hash). Required if the parser has no bound
+environment. When omitted, C<< $env->dereferenced_kit_metadata >> is called
+on the bound environment.
+
+=item * C<features> - Optional arrayref of active feature names.
+Required if the parser has no bound environment. When omitted,
+C<< [$env->features] >> is used.
+
+=back
+
+B<Returns:> A list of C<Genesis::Secret> objects. Definitions that fail
+structural validation are represented as C<Genesis::Secret::Invalid>
+objects in the returned list. Returns an empty list if no secrets are
+defined.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"No environment provided, and no kit metadata or features list were passed in as options."> -
+Dies if neither an environment is bound nor both C<kit_metadata> and
+C<features> are supplied as options.
+
+=back
+
+B<Examples:>
+
+  # Parse from a bound environment
+  my $parser  = Genesis::Env::Secrets::Parser::FromKit->new($env);
+  my @secrets = $parser->parse(notify => 1);
+  printf "Found %d secrets\n", scalar @secrets;
+  # prints e.g. 'Found 12 secrets'
+
+  # Parse from raw metadata (no environment required)
+  my $parser  = Genesis::Env::Secrets::Parser::FromKit->new(undef);
+  my @secrets = $parser->parse(
+    kit_metadata => $metadata,
+    features     => ['tls', 'ha'],
+  );
+  # Returns: list of Genesis::Secret objects
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _parse_x509_secret_definition
+
+  $self->_parse_x509_secret_definition($path, $data, $feature)
+
+Parses a single entry from the C<certificates> block for a given feature.
+Validates that C<$path> does not contain colons and that C<$data> is a
+hashref. On success, delegates to C<_parse_x509_subpaths> for each key in
+C<$data>. Called from a C<while> loop in C<parse()>; a bare C<next> inside
+this method skips to the next loop iteration when C<$data> is undefined.
+
+Returns one or more C<Genesis::Secret::X509> objects, or a
+C<Genesis::Secret::Invalid> object if validation fails.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$path> - The Vault path string for the certificate group.
+
+=item * C<$data> - The certificate definition value from the kit metadata.
+Must be a hashref mapping subpath names to subpath definitions.
+
+=item * C<$feature> - The feature name this definition belongs to.
+
+=back
+
+B<Examples:>
+
+  # Called internally by parse() while iterating certificates block
+  my @secrets = $self->_parse_x509_secret_definition('path/to/certs', $data, 'tls');
+  # Returns: one or more Genesis::Secret::X509 objects, or Genesis::Secret::Invalid
+
+=head2 _parse_x509_subpaths
+
+  $self->_parse_x509_subpaths($path, $subpath, $subdata, $feature)
+
+Parses a single subpath entry within an X.509 certificate group. Constructs
+the extended path as C<"$path/$subpath">, validates that C<$subdata> is a
+hashref, and creates a C<Genesis::Secret::X509> object with all fields
+passed through from C<$subdata>.
+
+Applies two automatic defaults:
+
+=over 4
+
+=item * If C<$subpath> is C<'ca'> and C<is_ca> is not explicitly set, sets
+C<is_ca =E<gt> 1> on the definition.
+
+=item * If C<signed_by> equals the legacy value C<"base.application/certs.ca">
+(a known conflict from cf-genesis-kit v1.8.0-v1.10.x), rewrites it to
+C<"application/certs/ca">.
+
+=back
+
+Returns a C<Genesis::Secret::X509> object, or a C<Genesis::Secret::Invalid>
+object if C<$subdata> is not a hashref.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$path> - The parent Vault path for the certificate group.
+
+=item * C<$subpath> - The subpath name (e.g., C<'ca'>, C<'server'>).
+
+=item * C<$subdata> - The subpath definition hashref from the kit metadata.
+
+=item * C<$feature> - The feature name this definition belongs to.
+
+=back
+
+B<Examples:>
+
+  # Called internally by parse() while iterating certificates block subpaths
+  my $secret = $self->_parse_x509_subpaths('path/to/certs', 'ca', $subdata, 'base');
+  # Returns: Genesis::Secret::X509 with is_ca => 1, or Genesis::Secret::Invalid
+
+=head2 _parse_provided_secret_definition
+
+  $self->_parse_provided_secret_definition($path, $data, $feature)
+
+Parses a single entry from the C<provided> block for a given feature.
+Validates that C<$path> does not contain colons and that C<$data> is a
+hashref. Defaults C<$data->{type}> to C<'generic'> if not present.
+
+For type C<'generic'>, validates that C<$data->{keys}> is a hashref, then
+creates one C<Genesis::Secret::UserProvided> object per key, with the
+extended path C<"$path:$key">. Keys that contain colons produce a
+C<Genesis::Secret::Invalid> object instead.
+
+Any C<type> value other than C<'generic'> produces a
+C<Genesis::Secret::Invalid> object.
+
+Returns a list of C<Genesis::Secret::UserProvided> or
+C<Genesis::Secret::Invalid> objects.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$path> - The Vault path string for the provided secret group.
+
+=item * C<$data> - The provided secret definition hashref from the kit
+metadata.
+
+=item * C<$feature> - The feature name this definition belongs to.
+
+=back
+
+B<Examples:>
+
+  # Called internally by parse() while iterating provided block
+  my @secrets = $self->_parse_provided_secret_definition('path/to/creds', $data, 'base');
+  # Returns: list of Genesis::Secret::UserProvided objects, or Genesis::Secret::Invalid
+
+=head2 _parse_credential_definition
+
+  $self->_parse_credential_definition($path, $data, $feature)
+
+Parses a single entry from the C<credentials> block for a given feature.
+Validates that C<$path> does not contain colons, then dispatches based
+on the structure and value of C<$data>:
+
+=over 4
+
+=item * B<hashref> - Delegates each key to C<_parse_credential_key> to
+produce per-key secrets (e.g., C<random> or C<uuid> values).
+
+=item * B<C<ssh E<lt>sizeE<gt> [fixed]>> or B<C<rsa E<lt>sizeE<gt> [fixed]>> -
+Creates a C<Genesis::Secret::SSH> or C<Genesis::Secret::RSA> object with
+the given key size.
+
+=item * B<C<dhparam(s) E<lt>sizeE<gt> [fixed]>> - Creates a
+C<Genesis::Secret::DHParams> object with the given parameter size.
+
+=item * B<C<random ...>> at the path level - Returns a
+C<Genesis::Secret::Invalid> object; random passwords must be defined per
+key in a hashmap.
+
+=item * B<C<uuid ...>> at the path level - Returns a
+C<Genesis::Secret::Invalid> object; UUIDs must be defined per key in a
+hashmap.
+
+=item * Anything else - Returns a C<Genesis::Secret::Invalid> object with
+C<"Unrecognized request '$data'">.
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$path> - The Vault path string for the credential.
+
+=item * C<$data> - The credential definition value (hashref or string)
+from the kit metadata.
+
+=item * C<$feature> - The feature name this definition belongs to.
+
+=back
+
+B<Examples:>
+
+  # Called internally by parse() while iterating credentials block
+  my @secrets = $self->_parse_credential_definition('path/to/key', 'ssh 4096', 'ha');
+  # Returns: Genesis::Secret::SSH with size => 4096, or Genesis::Secret::Invalid
+
+=head2 _parse_credential_key
+
+  $self->_parse_credential_key($path, $key, $data, $feature)
+
+Parses a single key within a credential hashmap entry. Validates that
+C<$key> does not contain colons. Constructs the extended path as
+C<"$path:$key">, then dispatches based on C<$data>:
+
+=over 4
+
+=item * B<C<random E<lt>sizeE<gt> [fmt E<lt>formatE<gt> [at E<lt>keyE<gt>]] [allowed-chars E<lt>charsE<gt>] [fixed]>> -
+Creates a C<Genesis::Secret::Random> object. Returns a
+C<Genesis::Secret::Invalid> object if the syntax does not match.
+
+=item * B<C<uuid [E<lt>versionE<gt>] [namespace E<lt>nsE<gt>] [name E<lt>nameE<gt>] [fixed]>> -
+Creates a C<Genesis::Secret::UUID> object. Version may be one of
+C<v1>/C<time>, C<v3>/C<md5>, C<v4>/C<random>, or C<v5>/C<sha1>;
+defaults to C<v4>. Namespace may be a named constant (C<dns>, C<url>,
+C<oid>, C<x500>) or a bare UUID string. Returns a
+C<Genesis::Secret::Invalid> object if the syntax does not match.
+
+=item * Anything else - Returns a C<Genesis::Secret::Invalid> object with
+C<"Bad generate-password format '$data'">.
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$path> - The parent Vault path for the credential group.
+
+=item * C<$key> - The key name within the hashmap entry.
+
+=item * C<$data> - The credential string definition for this key.
+
+=item * C<$feature> - The feature name this definition belongs to.
+
+=back
+
+B<Examples:>
+
+  # Called internally by _parse_credential_definition for hashmap entries
+  my $secret = $self->_parse_credential_key('path/to/creds', 'password', 'random 32', 'base');
+  # Returns: Genesis::Secret::Random with size => 32, or Genesis::Secret::Invalid
+
+=head2 _invalid_secret
+
+  _invalid_secret($subject, $message_or_arrayref, $path, $data, $feature)
+
+Static helper. Constructs and returns a C<Genesis::Secret::Invalid>
+object representing a parse failure. Called as a plain function (not as a
+method).
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$subject> - A short label identifying the secret type or section
+(e.g., C<"X.509 certificate">, C<"Random">, C<"Credentials">).
+
+=item * C<$message_or_arrayref> - Either a single error message string or
+an arrayref of error message strings.
+
+=item * C<$path> - The Vault path at which the error occurred.
+
+=item * C<$data> - The raw definition data that failed validation, stored
+on the invalid object for diagnostic purposes.
+
+=item * C<$feature> - The feature name this definition belongs to.
+
+=back
+
+Returns a C<Genesis::Secret::Invalid> object.
+
+=head2 _ref_description
+
+  _ref_description($val)
+
+Static helper. Returns a brief human-readable description of C<$val>'s
+type for use in error messages. Called as a plain function (not as a
+method).
+
+Returns the lowercased reference type (e.g., C<'hash'>, C<'array'>) if
+C<$val> is a reference, the quoted scalar value (e.g., C<"'foo'">) if
+C<$val> is a defined non-reference, or C<'E<lt>nullE<gt>'> if C<$val> is
+undefined.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$val> - The value to describe.
+
+=back
+
+B<Examples:>
+
+  _ref_description({});          # Returns: 'hash'
+  _ref_description([]);          # Returns: 'array'
+  _ref_description('foo');       # Returns: "'foo'"
+  _ref_description(undef);       # Returns: '<null>'
+
+=head2 _validate_feature_block
+
+  _validate_feature_block($data, $block, $feature, $secrets)
+
+Static helper. Checks whether a given feature's block within the kit
+metadata is defined and structurally valid. Called as a plain function
+(not as a method).
+
+Returns C<1> if C<$data-E<gt>{$block}{$feature}> exists and is a hashref.
+
+Returns C<0> if the block is not defined for this feature (no action
+taken).
+
+Returns C<0> and pushes a C<Genesis::Secret::Invalid> object onto
+C<$secrets> if the block exists but is not a hashref.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$data> - The full kit metadata hashref.
+
+=item * C<$block> - The metadata section name: C<'certificates'>,
+C<'provided'>, or C<'credentials'>.
+
+=item * C<$feature> - The feature name to check within the block.
+
+=item * C<$secrets> - Arrayref to which invalid secret objects are
+appended on structural errors.
+
+=back
+
+B<Examples:>
+
+  my @invalid;
+  my $ok = _validate_feature_block($metadata, 'certificates', 'tls', \@invalid);
+  # Returns: 1 if $metadata->{certificates}{tls} is a hashref
+  # Returns: 0 and pushes a Genesis::Secret::Invalid if it exists but is not a hashref
+  # Returns: 0 silently if the block is not defined for this feature
+
+=head1 SEE ALSO
+
+L<Genesis::Env::Secrets::Parser>,
+L<Genesis::Env::Secrets::Parser::FromManifest>,
+L<Genesis::Secret::X509>,
+L<Genesis::Secret::UserProvided>,
+L<Genesis::Secret::SSH>,
+L<Genesis::Secret::RSA>,
+L<Genesis::Secret::DHParams>,
+L<Genesis::Secret::Random>,
+L<Genesis::Secret::UUID>,
+L<Genesis::Secret::Invalid>
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Secrets/Parser/FromManifest.pod
+++ b/lib/Genesis/Env/Secrets/Parser/FromManifest.pod
@@ -241,13 +241,6 @@ B<Examples:>
 
 =head1 SEE ALSO
 
-L<Genesis::Env::Secrets::Parser> -- the abstract base class
-
-L<Genesis::Env::Secrets::Parser::_legacy_cf_support_mixin> -- mixin that
-injects additional legacy CF kit secrets when the kit ID matches C<cf/2.*>
-
-=head1 SEE ALSO
-
 L<Genesis::Env::Secrets::Parser>,
 L<Genesis::Env::Secrets::Parser::FromKit>,
 L<Genesis::Env::Secrets::Parser::_legacy_cf_support_mixin>,

--- a/lib/Genesis/Env/Secrets/Parser/FromManifest.pod
+++ b/lib/Genesis/Env/Secrets/Parser/FromManifest.pod
@@ -1,0 +1,268 @@
+=head1 NAME
+
+Genesis::Env::Secrets::Parser::FromManifest - Parse secret definitions from a BOSH manifest variables block
+
+=head1 SYNOPSIS
+
+  use Genesis::Env::Secrets::Parser::FromManifest;
+
+  my $parser = Genesis::Env::Secrets::Parser::FromManifest->new($env);
+  my @secrets = $parser->parse(notify => 1);
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::Secrets::Parser::FromManifest> is a concrete subclass of
+L<Genesis::Env::Secrets::Parser> that extracts secret definitions from the
+C<variables> block of a rendered BOSH manifest. Each entry in the variables
+block is translated into a C<Genesis::Secret> object of the appropriate
+subtype based on its C<type> field:
+
+=over 4
+
+=item * C<certificate> -- becomes a C<Genesis::Secret::X509> object
+
+=item * C<password> -- becomes a C<Genesis::Secret::Random> object
+
+=item * C<rsa> -- becomes a C<Genesis::Secret::RSA> object
+
+=item * C<ssh> -- becomes a C<Genesis::Secret::SSH> object
+
+=item * Any other type -- becomes a C<Genesis::Secret::Invalid> object with
+error C<"Unknown variable type">
+
+=back
+
+Before processing the C<variables> list, any BOSH variable interpolations of
+the form C<((name))> or C<((!name))> that appear as values within the
+variables block are resolved using the C<bosh-variables> map from the same
+manifest metadata.
+
+For environments whose kit ID matches C<cf/2.*>, the parser conditionally
+loads L<Genesis::Env::Secrets::Parser::_legacy_cf_support_mixin> and invokes
+C<process_legacy_cf_secrets> to inject additional user-provided secrets
+required by legacy CF kit features (external databases, HA Proxy TLS
+certificates, and cloud-provider blobstore credentials).
+
+=head1 METHODS
+
+=head2 parse
+
+  my @secrets = $parser->parse(%opts);
+
+Fetches the C<credhub_vars> manifest subset from the environment's manifest
+provider, resolves any BOSH variable references within the C<variables> list,
+then iterates over each variable definition and constructs the corresponding
+C<Genesis::Secret> object. After processing all definitions, applies legacy
+CF kit support if the environment's kit ID matches C<cf/2.*>.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<notify> -- Optional boolean. When true, emits a progress message
+via the logger before parsing begins and a count summary after parsing
+completes.
+
+=back
+
+B<Returns:> A list of C<Genesis::Secret> objects (one per variable
+definition found in the manifest). Returns an empty list when the manifest
+contains no C<variables> entries.
+
+B<Examples:>
+
+  my $parser = Genesis::Env::Secrets::Parser::FromManifest->new($env);
+
+  # Parse without progress notification
+  my @secrets = $parser->parse();
+  printf "Found %d secrets\n", scalar(@secrets);
+  # Returns: Found 12 secrets
+
+  # Parse with progress notification (logs status to the terminal)
+  my @secrets = $parser->parse(notify => 1);
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _parse_password
+
+  $parser->_parse_password(%opts)
+
+Constructs a C<Genesis::Secret::Random> object from a C<password>-type
+variable definition. The secret path is C<< $opts{name} . ":password" >>.
+
+The character policy is assembled from the variable's C<options> hash:
+C<A-Z> is included unless C<exclude_upper> is set, C<a-z> unless
+C<exclude_lower> is set, and C<0-9> unless C<exclude_number> is set.
+The default length is 30 characters unless C<options.length> is specified.
+The C<fixed> flag is set if C<metadata.fixed> is truthy.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<%opts> -- A hash representing the variable definition. Relevant
+keys: C<name> (variable path), C<options.length>, C<options.exclude_upper>,
+C<options.exclude_lower>, C<options.exclude_number>, and C<metadata.fixed>.
+
+=back
+
+B<Returns:> A C<Genesis::Secret::Random> object.
+
+B<Examples:>
+
+  my $secret = $parser->_parse_password(
+      name    => 'db_password',
+      options => { length => 20, exclude_upper => 1 },
+      metadata => { fixed => 0 },
+  );
+  print ref($secret);   # Returns: Genesis::Secret::Random
+  print $secret->path;  # Returns: db_password:password
+
+=head2 _parse_ssh
+
+  $parser->_parse_ssh(%opts)
+
+Constructs a C<Genesis::Secret::SSH> object from an C<ssh>-type variable
+definition. The key size defaults to 2048 bits unless C<options.key_length>
+is specified. The C<fixed> flag is always set to 0.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<%opts> -- A hash representing the variable definition. Relevant
+keys: C<name> (variable path) and C<options.key_length>.
+
+=back
+
+B<Returns:> A C<Genesis::Secret::SSH> object.
+
+B<Examples:>
+
+  my $secret = $parser->_parse_ssh(
+      name    => 'diego_ssh',
+      options => { key_length => 4096 },
+  );
+  print ref($secret);   # Returns: Genesis::Secret::SSH
+  print $secret->path;  # Returns: diego_ssh
+
+=head2 _parse_rsa
+
+  $parser->_parse_rsa(%opts)
+
+Constructs a C<Genesis::Secret::RSA> object from an C<rsa>-type variable
+definition. The key size defaults to 2048 bits unless C<options.key_length>
+is specified. The C<fixed> flag is always set to 0.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<%opts> -- A hash representing the variable definition. Relevant
+keys: C<name> (variable path) and C<options.key_length>.
+
+=back
+
+B<Returns:> A C<Genesis::Secret::RSA> object.
+
+B<Examples:>
+
+  my $secret = $parser->_parse_rsa(
+      name    => 'service_account_key',
+      options => { key_length => 2048 },
+  );
+  print ref($secret);   # Returns: Genesis::Secret::RSA
+  print $secret->path;  # Returns: service_account_key
+
+=head2 _parse_certificate
+
+  $parser->_parse_certificate(%opts)
+
+Constructs a C<Genesis::Secret::X509> object from a C<certificate>-type
+variable definition.
+
+The validity duration is taken from C<options.duration> (suffixed with C<d>
+for days) if present. Otherwise, CA certificates default to C<10y> and leaf
+certificates default to C<3y>.
+
+Subject alternative names are taken from C<options.alternative_names>. Two
+kit-specific overrides apply:
+
+=over 4
+
+=item * For CF kit v2.0.x (C<cf/2.0.*>): the C<nats_server_cert> variable
+receives hard-coded SANs C<nats.service.cf.internal> and
+C<*.nats.service.cf.internal>. Additionally, when no SANs would otherwise be
+set, the C<common_name> is added as a SAN.
+
+=item * For CF App Autoscaler kit v4 through v7 (C<cf-app-autoscaler/[4567].*>): when
+no SANs would otherwise be set, the C<common_name> is added as a SAN.
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item * C<%opts> -- A hash representing the variable definition. Relevant
+keys: C<name> (variable path), C<options.duration>, C<options.is_ca>,
+C<options.ca>, C<options.common_name>, C<options.alternative_names>, and
+C<options.extended_key_usage>.
+
+=back
+
+B<Returns:> A C<Genesis::Secret::X509> object.
+
+B<Examples:>
+
+  # Leaf certificate with explicit duration and SANs
+  my $secret = $parser->_parse_certificate(
+      name    => 'router_tls',
+      options => {
+          duration          => 365,
+          is_ca             => 0,
+          ca                => 'root_ca',
+          common_name       => 'router.service.cf.internal',
+          alternative_names => ['*.router.service.cf.internal'],
+      },
+  );
+  print ref($secret);          # Returns: Genesis::Secret::X509
+  print $secret->path;         # Returns: router_tls
+
+  # CA certificate (defaults to 10y validity)
+  my $ca_secret = $parser->_parse_certificate(
+      name    => 'root_ca',
+      options => { is_ca => 1, common_name => 'Root CA' },
+  );
+  print $ca_secret->valid_for; # Returns: 10y
+
+=head1 SEE ALSO
+
+L<Genesis::Env::Secrets::Parser> -- the abstract base class
+
+L<Genesis::Env::Secrets::Parser::_legacy_cf_support_mixin> -- mixin that
+injects additional legacy CF kit secrets when the kit ID matches C<cf/2.*>
+
+=head1 SEE ALSO
+
+L<Genesis::Env::Secrets::Parser>,
+L<Genesis::Env::Secrets::Parser::FromKit>,
+L<Genesis::Env::Secrets::Parser::_legacy_cf_support_mixin>,
+L<Genesis::Secret::X509>,
+L<Genesis::Secret::Random>,
+L<Genesis::Secret::SSH>,
+L<Genesis::Secret::RSA>,
+L<Genesis::Secret::Invalid>
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Secrets/Parser/_legacy_cf_support_mixin.pod
+++ b/lib/Genesis/Env/Secrets/Parser/_legacy_cf_support_mixin.pod
@@ -1,0 +1,144 @@
+=head1 NAME
+
+Genesis::Env::Secrets::Parser::_legacy_cf_support_mixin - Mixin providing legacy CF kit secret support for manifest secret parsers
+
+=head1 DESCRIPTION
+
+This is a mixin module. It has no C<package> declaration and is included into
+consuming classes via C<require>. The single function it defines,
+C<process_legacy_cf_secrets>, becomes available in the consuming class's
+namespace after inclusion.
+
+This mixin extends C<Genesis::Env::Secrets::Parser::FromManifest> to handle
+secret definitions that legacy Cloud Foundry kit versions (CF kit 2.x) cannot
+express via the standard BOSH manifest C<variables> block. It injects
+user-provided secret entries for a fixed set of CF subsystems whose
+credentials must be supplied by the operator rather than generated:
+
+=over 4
+
+=item * B<CC DB encryption key> -- marks the existing C<cc_db_encryption_key>
+secret as fixed so it is never rotated without explicit operator intent.
+
+=item * B<External databases> -- when the C<mysql-db> or C<postgres-db>
+feature is active, injects username and password entries for the external
+MySQL or PostgreSQL database.
+
+=item * B<HAProxy TLS> -- when the C<haproxy>, C<tls>, and NOT
+C<self-signed> features are all active, injects the HAProxy SSL certificate
+and private key.
+
+=item * B<AWS blobstore> -- when the C<aws-blobstore> feature is active,
+injects Amazon S3 access key ID and secret access key.
+
+=item * B<Azure blobstore> -- when the C<azure-blobstore> feature is active,
+injects Azure Storage account name and access key.
+
+=item * B<GCP blobstore> -- when the C<gcp-blobstore> feature is active,
+injects either a GCP access key pair (if C<gcp-use-access-key> is also
+active) or a GCP project name, service account email, and service account
+JSON key.
+
+=back
+
+All injected secrets are constructed as C<Genesis::Secret::UserProvided>
+objects and are marked C<fixed> (never overwritten if already set) and
+C<sensitive> (input is hidden when prompting the operator).
+
+=head1 USAGE
+
+Include this mixin in your class before calling C<process_legacy_cf_secrets>:
+
+    # As used by Genesis::Env::Secrets::Parser::FromManifest:
+    require Genesis::Env::Secrets::Parser::_legacy_cf_support_mixin;
+    process_legacy_cf_secrets(\@secrets, [$self->env->features]);
+
+After the C<require>, C<process_legacy_cf_secrets> is available as a
+package-level function in the calling namespace.
+
+=head1 METHODS
+
+=head2 process_legacy_cf_secrets
+
+    process_legacy_cf_secrets($secrets, $features);
+
+Augments a list of C<Genesis::Secret> objects with user-provided secret
+entries required by legacy CF kit versions. Inspects the C<$features>
+array to determine which optional subsystems are enabled, then pushes the
+appropriate C<Genesis::Secret::UserProvided> objects onto C<$secrets>.
+
+This function becomes part of the consuming class's namespace after the
+mixin is included via C<require>.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$secrets> - An arrayref of C<Genesis::Secret> objects, typically
+built from the BOSH manifest C<variables> block. Modified in place: new
+C<Genesis::Secret::UserProvided> objects are pushed onto this arrayref,
+and the C<cc_db_encryption_key> entry (if present) is mutated to set its
+C<fixed> flag.
+
+=item * C<$features> - An arrayref of feature strings describing which
+optional subsystems are active for the CF deployment. The following feature
+strings are recognised:
+
+=over 4
+
+=item * C<mysql-db> -- external MySQL database
+
+=item * C<postgres-db> -- external PostgreSQL database
+
+=item * C<haproxy> -- HAProxy load balancer is present
+
+=item * C<tls> -- TLS is enabled on HAProxy
+
+=item * C<self-signed> -- HAProxy TLS is using a self-signed certificate
+(suppresses injection of user-provided certs)
+
+=item * C<aws-blobstore> -- AWS S3 blobstore
+
+=item * C<azure-blobstore> -- Azure Storage blobstore
+
+=item * C<gcp-blobstore> -- Google Cloud Storage blobstore
+
+=item * C<gcp-use-access-key> -- GCP blobstore uses an HMAC access key
+pair rather than a service account JSON key
+
+=back
+
+=back
+
+B<Returns:> Nothing. All changes are made by mutating C<$secrets> in place.
+
+B<Examples:>
+
+    require Genesis::Env::Secrets::Parser::_legacy_cf_support_mixin;
+
+    my @secrets = (
+        # ... secrets parsed from the manifest variables block ...
+    );
+    my @features = qw(mysql-db aws-blobstore);
+
+    process_legacy_cf_secrets(\@secrets, \@features);
+    # Returns: nothing; @secrets is modified in place to also contain:
+    #   external_db:username         (MySQL username, user-provided, fixed, sensitive)
+    #   external_db:password         (MySQL password, user-provided, fixed, sensitive)
+    #   blobstore:aws_access_key     (S3 Access Key ID, user-provided, fixed, sensitive)
+    #   blobstore:aws_access_secret  (S3 Secret Access Key, user-provided, fixed, sensitive)
+
+=head1 SEE ALSO
+
+L<Genesis::Env::Secrets::Parser::FromManifest>,
+L<Genesis::Secret::UserProvided>
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Secrets/Plan.pod
+++ b/lib/Genesis/Env/Secrets/Plan.pod
@@ -34,8 +34,8 @@ Genesis::Env::Secrets::Plan - Orchestrator for environment secret lifecycle oper
 C<Genesis::Env::Secrets::Plan> is the central orchestrator for all secret
 lifecycle operations in Genesis.  It holds a resolved, dependency-ordered list
 of C<Genesis::Secret::*> objects for a given environment and dispatches
-bulk operations -- check, generate, validate, rotate, and remove -- against
-that list.
+bulk operations -- check, generate, validate, regenerate (also called
+"rotate" in progress output), and remove -- against that list.
 
 A plan is always constructed for a specific environment and backed by two
 storage handles: a Vault store for most secrets and a CredHub handle for
@@ -787,8 +787,23 @@ B<Examples:>
     $plan->notify($action, \%opts, $state, %args);
 
 State-machine callback that drives progress display for all bulk operations.
-Called internally by C<check_secrets()>, C<validate_secrets()>,
-C<generate_secrets()>, C<regenerate_secrets()>, and C<remove_secrets()>.
+Called internally by the following public methods, in this sequence for each
+operation: C<init> E<rarr> (C<start-item> E<rarr> C<done-item>)E<times>N
+E<rarr> C<completed>.
+
+=over 4
+
+=item * C<check_secrets()> - action C<check>
+
+=item * C<validate_secrets()> - action C<validate>
+
+=item * C<generate_secrets()> - action C<add>
+
+=item * C<regenerate_secrets()> - action C<rotate>
+
+=item * C<remove_secrets()> - action C<remove>
+
+=back
 
 C<$action> names the current bulk operation (e.g., C<check>, C<validate>,
 C<add>, C<rotate>, C<remove>).  C<$state> selects the display behavior.
@@ -962,11 +977,12 @@ B<Returns:> The plan object itself.
 
     my $signer_path = _next_x509_signer(\%signers);
 
+B<Internal function> (not part of the public API).
+
 Static function (no C<$self>).  Given the C<%signers> hash that maps signer
 paths to their pending signee lists, returns the path of the next signer
 whose signees have not yet been processed -- specifically, a signer that is
-not itself in another signer's pending signee list.  C<$candidate> is a
-local iteration variable used during the search.
+not itself in another signer's pending signee list.
 
 Returns C<undef> when all signers have been exhausted.
 
@@ -977,11 +993,8 @@ B<Parameters:>
 =item C<\%signers>
 
 Hashref mapping signer path strings to arrayrefs of C<Genesis::Secret::X509>
-objects that are signed by that path.
-
-=item C<$candidate>
-
-Used internally during iteration over available signer paths.
+objects that are signed by that path. This is an internal data structure
+built by C<_order_secrets> and should not be constructed manually.
 
 =back
 

--- a/lib/Genesis/Env/Secrets/Plan.pod
+++ b/lib/Genesis/Env/Secrets/Plan.pod
@@ -1,0 +1,1286 @@
+=encoding utf8
+
+=head1 NAME
+
+Genesis::Env::Secrets::Plan - Orchestrator for environment secret lifecycle operations
+
+=head1 SYNOPSIS
+
+    use Genesis::Env::Secrets::Plan;
+
+    # Create a new plan for an environment
+    my $plan = Genesis::Env::Secrets::Plan->new($env, $store, $credhub);
+
+    # Populate with secrets from parsers or objects
+    $plan->populate(
+        'Genesis::Env::Secrets::Parser::Kit',
+        'Genesis::Env::Secrets::Parser::Credhub',
+    );
+
+    # Abort early if any secret definitions are structurally invalid
+    $plan->validate;
+
+    # Run lifecycle operations
+    my ($results, $msg) = $plan->check_secrets;
+    my ($results, $msg) = $plan->generate_secrets;
+    my ($results, $msg) = $plan->validate_secrets;
+
+    # Operate on a filtered subset
+    my $subset = $plan->filter('type=x509', '/ca$/');
+    $subset->regenerate_secrets;
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::Secrets::Plan> is the central orchestrator for all secret
+lifecycle operations in Genesis.  It holds a resolved, dependency-ordered list
+of C<Genesis::Secret::*> objects for a given environment and dispatches
+bulk operations -- check, generate, validate, rotate, and remove -- against
+that list.
+
+A plan is always constructed for a specific environment and backed by two
+storage handles: a Vault store for most secrets and a CredHub handle for
+manifest-vaultified secrets.  Once populated, the plan is immutable with
+respect to the secret list; operations that need a subset of secrets use
+C<filter()> to create a linked child plan rather than modifying the parent.
+
+Key behaviors:
+
+=over 4
+
+=item *
+
+X.509 certificates are automatically ordered so that signing CAs are
+processed before the certificates they sign.
+
+=item *
+
+C<filter()> supports explicit path matching, property equality/inequality/regex
+comparisons, path regexes, and C<||>-delimited OR expressions.
+
+=item *
+
+C<notify()> is a state-machine callback that drives the progress display for
+all bulk operations.  It accepts a named state (C<init>, C<start-item>,
+C<done-item>, C<completed>, C<prompt>, C<inline-prompt>, C<wait>,
+C<wait-done>, C<notify>) and emits appropriately formatted terminal output.
+
+=item *
+
+C<remove_secrets()> understands multiple removal severities: all, invalid,
+problematic, unused vault entries, unused imported CredHub entries, and
+outdated entombed CredHub entries.
+
+=back
+
+=head1 METHODS
+
+=head2 new
+
+    my $plan = Genesis::Env::Secrets::Plan->new($env, $store, $credhub, %opts);
+
+Creates a new, empty plan object.  No secrets are loaded; call C<populate()>
+to add them.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env>
+
+A C<Genesis::Env> object representing the target environment.  May be C<undef>
+for testing or headless use; in that case verbose output is suppressed.
+
+=item C<$store>
+
+A Vault-backed secret store object used as the primary secret store.
+
+=item C<$credhub>
+
+A CredHub handle object used for manifest-vaultified secrets.
+
+=item C<%opts>
+
+Optional key-value pairs.  Recognized keys:
+
+=over 4
+
+=item C<verbose>
+
+Boolean (default C<1>).  When true, progress notifications are emitted to the
+terminal during populate and bulk operations.
+
+=back
+
+=back
+
+B<Returns:> A new C<Genesis::Env::Secrets::Plan> object.
+
+B<Examples:>
+
+    my $plan = Genesis::Env::Secrets::Plan->new($env, $store, $credhub);
+    # Returns: a Genesis::Env::Secrets::Plan object with no secrets loaded
+
+    my $silent_plan = Genesis::Env::Secrets::Plan->new(
+        $env, $store, $credhub, verbose => 0
+    );
+    # Returns: a plan that suppresses terminal progress output
+
+=head2 env
+
+    my $env     = $plan->env;
+    my $store   = $plan->store;
+    my $credhub = $plan->credhub;
+    my $parent  = $plan->parent;
+    my @secrets = $plan->secrets;
+    my @paths   = $plan->paths;
+    my $secret  = $plan->secret_at($path);
+    my @errors  = $plan->errors;
+    my $verbose = $plan->verbose;
+    $plan->verbose($value);
+
+Read accessors for the plan's core attributes.  C<verbose> may also be
+called with an argument to set the verbosity flag.
+
+=over 4
+
+=item C<env>
+
+Returns the C<Genesis::Env> object the plan was created for, or C<undef>
+if none was provided to C<new()>.
+
+=item C<store>
+
+Returns the Vault-backed secret store object passed to C<new()>.
+
+=item C<credhub>
+
+Returns the CredHub handle passed to C<new()>.
+
+=item C<parent>
+
+Returns the parent C<Genesis::Env::Secrets::Plan> if this plan was created
+by C<filter()>, or C<undef> for a root plan.
+
+=item C<secrets>
+
+Returns a list of all C<Genesis::Secret::*> objects in the plan, in
+dependency order (CAs before the certificates they sign, then all non-X.509
+secrets sorted by path).
+
+=item C<paths>
+
+Returns a sorted list of all secret path strings in the plan.
+
+=item C<secret_at($path)>
+
+Returns the C<Genesis::Secret::*> object at the given vault path, or
+C<undef> if not found.
+
+=item C<errors>
+
+Returns all secrets that are C<Genesis::Secret::Invalid> instances -- that
+is, secrets found structurally invalid during parsing or ordering.  Returns
+an empty list when there are no such secrets.
+
+=item C<verbose([$value])>
+
+Gets or sets the verbosity flag.  When called with a true or false value,
+sets the flag and subsequent calls reflect the change.  Returns C<1> if
+verbose is enabled, C<0> otherwise.  Modifies the object in-place when
+called with an argument.
+
+=back
+
+B<Examples:>
+
+    my $name = $plan->env->name;
+    # Returns: the environment name string
+
+    my $base = $plan->store->base;
+    # Returns: the Vault base path string
+
+    my @all = $plan->secrets;
+    printf "Plan contains %d secrets\n", scalar @all;
+    # Returns: list of Genesis::Secret::* objects
+
+    my $secret = $plan->secret_at('env/name/secret/ca');
+    # Returns: a Genesis::Secret::X509 object (or undef if not present)
+
+    if (my @errs = $plan->errors) {
+        printf "Found %d invalid secret definitions\n", scalar @errs;
+    }
+    # Returns: list of Genesis::Secret::Invalid objects
+
+    $plan->verbose(0);
+    print $plan->verbose;
+    # Returns: 0
+
+=head2 filters
+
+    my @filters = $plan->filters;
+
+Returns the accumulated list of filter expressions applied to this plan and
+all its ancestor plans.  For a root plan (one not created by C<filter()>),
+this returns an empty list.  For a child plan, it returns the parent's filters
+followed by this plan's own filters.
+
+B<Returns:> A list of filter expression strings, ordered from outermost
+ancestor to this plan.
+
+B<Examples:>
+
+    my $root   = $plan->filter('type=x509');
+    my $nested = $root->filter('/ca$/');
+
+    my @f = $nested->filters;
+    # Returns: ('type=x509', '/ca$/')
+
+=head2 populate
+
+    $plan->populate(@sources);
+
+Loads secrets into the plan from one or more sources.  Can be called
+multiple times to add additional secrets.  After loading, X.509 secrets
+are automatically ordered by signing-chain dependency and a C<paths> lookup
+index is built.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@sources>
+
+One or more secret sources.  Each element may be:
+
+=over 4
+
+=item *
+
+A C<Genesis::Secret::*> object -- added directly to the plan.
+
+=item *
+
+A C<Genesis::Env::Secrets::Parser::*> class name string -- the class is
+C<require>d, instantiated with the plan's environment object, and its
+parse method is called to produce secrets.
+
+=item *
+
+A C<Genesis::Env::Secrets::Parser> object -- its parse method is called
+to produce secrets.
+
+=back
+
+=back
+
+B<Returns:> The plan object itself (for chaining).
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Error encountered while trying to require $secret_src perl module:\n\n$@"> -- if a parser class name string cannot be loaded via C<require>.
+
+=item *
+
+C<"Genesis::Env::Secrets::Plan->populate was given an argument that wasn't a Genesis::Secret object or a Genesis::Env::Secret::Parser object or class."> -- if a source argument is none of the recognized types.
+
+=back
+
+B<Examples:>
+
+    $plan->populate(
+        'Genesis::Env::Secrets::Parser::Kit',
+        'Genesis::Env::Secrets::Parser::Credhub',
+    );
+    # Returns: $plan (the same object, now populated)
+
+    # Populate with a pre-built parser object
+    my $parser = Genesis::Env::Secrets::Parser::Kit->new($env);
+    $plan->populate($parser);
+    # Returns: $plan
+
+=head2 filter
+
+    my $child_plan = $plan->filter(@filters);
+
+Creates and returns a new child plan containing only the secrets that match
+all of the given filter expressions.  The original plan is unchanged.  If
+no filters are provided, returns the original plan unchanged.
+
+Each filter expression is ANDed with the others.  Within a single filter,
+C<||> separates OR alternatives.
+
+Supported filter syntaxes:
+
+=over 4
+
+=item Explicit path
+
+A filter that exactly matches a secret's path string selects that secret
+directly, bypassing the property-matching logic.
+
+=item Property comparison: C<key=value>, C<key!=value>
+
+Compares the secret's property C<key> to C<value> by string equality or
+inequality.  C<key> may be C<path>, C<type>, or any property accessible via
+C<$secret->get($key)>.  For boolean properties, C<value> may be C<true> or
+C<false>.
+
+=item Property regex: C<key=~/pattern/i>, C<key!~/pattern/i>
+
+Matches or negates a regex against the property value.  The trailing C</i>
+flag is optional.
+
+=item Path regex: C</pattern/i>, C<!/pattern/i>
+
+Matches or negates a regex against the secret's path.
+
+=item OR expression: C<expr1||expr2>
+
+Unions the results of two filter expressions within a single filter argument.
+
+=back
+
+The resulting child plan has C<parent> set to the original plan and records
+the applied filters so C<filters()> can reconstruct the full chain.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@filters>
+
+One or more filter expression strings.
+
+=back
+
+B<Returns:> A new C<Genesis::Env::Secrets::Plan> child object, or C<$self> if
+C<@filters> is empty.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"\nCould not understand path filter of '%s'"> -- if a filter expression does
+not match any recognized syntax.  The C<%s> placeholder is replaced by the
+unrecognized expression.
+
+=back
+
+B<Examples:>
+
+    # Filter by secret type
+    my $x509_plan = $plan->filter('type=x509');
+    # Returns: child plan with only X.509 secrets
+
+    # Filter by path regex
+    my $ca_plan = $plan->filter('/\/ca$/');
+    # Returns: child plan with secrets whose paths end in '/ca'
+
+    # Filter with OR
+    my $combo = $plan->filter('type=x509||type=ssh');
+    # Returns: child plan with X.509 or SSH secrets
+
+    # AND multiple filters (each arg is ANDed)
+    my $narrow = $plan->filter('type=x509', '!/ca$/');
+    # Returns: child plan with non-CA X.509 secrets
+
+=head2 autoload
+
+    $plan->autoload;
+
+Sets the C<autoload> flag on every secret in the plan to C<1>.  This signals
+to secret handlers that they should load their current value automatically
+during bulk operations rather than waiting to be filled explicitly.
+
+B<Returns:> The plan object itself (for chaining).
+
+B<Examples:>
+
+    $plan->autoload;
+    # Returns: $plan (all secrets now have autoload set to 1)
+
+=head2 validate
+
+    $plan->validate;
+
+Checks whether the plan contains any structurally invalid secret definitions
+(i.e., secrets returned by the C<errors> accessor).  If there are none, returns C<1>.
+If there are errors, terminates the program with a formatted error message
+listing each invalid definition.
+
+This method should be called after C<populate()> and before performing any
+bulk operations.
+
+B<Returns:> C<1> if there are no errors.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"\nErrors found in %s:\n%s\nThis may be an issue with the kit or with values in your environment file(s)."> -- terminates the program.  The first C<%s> is replaced by a count noun (e.g., C<"1 secret definition">), and the second C<%s> is replaced by the formatted list of invalid definitions.
+
+=back
+
+B<Examples:>
+
+    $plan->populate('Genesis::Env::Secrets::Parser::Kit');
+    $plan->validate;   # aborts if any definitions are invalid
+    # Returns: 1 (if no errors)
+
+=head2 check_secrets
+
+    my ($results, $msg) = $plan->check_secrets(%opts);
+    my $ok = $plan->check_secrets(%opts);
+
+Checks the presence of all secrets in the plan in Vault.  Fills each secret
+with its current Vault value, then calls the secret's C<check_value> method to
+determine whether it exists.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+Options passed through to C<notify()> for display control.  Recognized keys
+include C<level> (output verbosity: C<full> or C<line>) and C<indent>.
+
+=back
+
+B<Returns:> In list context, a two-element list C<($results, $msg)> where
+C<$results> is a hashref of outcome counts (keys: C<ok>, C<missing>, C<error>,
+C<skipped>, etc.) and C<$msg> is an optional message string.  In scalar
+context, returns a true value if there were no errors or missing secrets, false
+otherwise.
+
+B<Examples:>
+
+    my ($results, $msg) = $plan->check_secrets;
+    printf "Missing: %d\n", $results->{missing} // 0;
+    # Returns: hashref of counts and optional message
+
+    my $ok = $plan->check_secrets;
+    # Returns: true if all secrets are present
+
+=head2 validate_secrets
+
+    my ($results, $msg) = $plan->validate_secrets(%opts);
+    my $ok = $plan->validate_secrets(%opts);
+
+Validates the content and structure of all secrets in the plan.  Fills each
+secret from Vault, then calls the secret's C<validate_value> method to verify
+format, expiry, key sizes, and other content constraints.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+Options passed through to C<notify()> for display control.  Recognized keys
+include C<level>, C<indent>, and C<allow_oversized> (to suppress warnings for
+secrets that exceed expected size limits).
+
+=back
+
+B<Returns:> In list context, a two-element list C<($results, $msg)> where
+C<$results> is a hashref of outcome counts (keys: C<ok>, C<warn>, C<error>,
+C<missing>, C<skipped>, etc.) and C<$msg> is an optional message string.  In
+scalar context, returns a true value if there were no errors, false otherwise.
+
+B<Examples:>
+
+    my $ok = $plan->validate_secrets;
+    # Returns: true if all secrets are structurally valid
+
+    my ($results) = $plan->validate_secrets(level => 'full');
+    printf "Warnings: %d\n", $results->{warn} // 0;
+    # Returns: hashref of outcome counts
+
+=head2 generate_secrets
+
+    my ($results, $msg) = $plan->generate_secrets(%opts);
+    my $ok = $plan->generate_secrets(%opts);
+
+Generates any secrets in the plan that are not yet present in Vault.
+Secrets that already have a value are skipped.  For manifest-sourced secrets
+when C<import> is set, attempts to import the value from CredHub before
+generating a new one.
+
+Interactive secrets (those requiring terminal prompts) are handled only
+when running in a controlling terminal.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+Options passed through to C<notify()> and secret command dispatch.
+Recognized keys include:
+
+=over 4
+
+=item C<import>
+
+If true, attempts to import manifest-sourced secrets from CredHub before
+generating new values.
+
+=item C<level>
+
+Output verbosity: C<full> or C<line>.
+
+=item C<indent>
+
+Indentation string for progress output.
+
+=back
+
+=back
+
+B<Returns:> In list context, a two-element list C<($results, $msg)>.
+C<$results> is a hashref of outcome counts (keys: C<ok>, C<imported>,
+C<generated>, C<skipped>, C<error>).  In scalar context, returns a true value
+if there were no errors, false otherwise.
+
+B<Examples:>
+
+    my $ok = $plan->generate_secrets;
+    # Returns: true if all missing secrets were successfully generated
+
+    my ($results) = $plan->generate_secrets(import => 1);
+    printf "Imported: %d  Generated: %d\n",
+        $results->{imported} // 0,
+        $results->{generated} // 0;
+    # Returns: hashref of outcome counts
+
+=head2 regenerate_secrets
+
+    my ($results, $msg) = $plan->regenerate_secrets(%opts);
+
+Rotates (regenerates) secrets in the plan, optionally limiting to invalid or
+problematic ones.  Prompts for user confirmation before proceeding unless
+C<no_prompt> is set.
+
+When C<invalid> is set to C<1>, only secrets that fail validation (invalid or
+missing) are rotated.  When set to C<2>, secrets with warnings (problematic)
+are also included.
+
+When C<interactive> is set, prompts for each secret individually (C<y/n/q>).
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+Recognized keys:
+
+=over 4
+
+=item C<action>
+
+The action name string used in progress display (default: C<rotate>).
+
+=item C<invalid>
+
+C<0> (all), C<1> (invalid/missing only), or C<2> (invalid, missing, or
+problematic).  Default: C<0>.
+
+=item C<no_prompt>
+
+If true, skips the confirmation prompt and proceeds immediately.
+
+=item C<interactive>
+
+If true, prompts for each individual secret with C<y/n/q>.
+
+=item C<notice>
+
+Override string for the top-level progress notification
+(default: C<"rotating environment secrets...">).
+
+=item C<level>
+
+Output verbosity: C<full> or C<line>.
+
+=item C<indent>
+
+Indentation string for progress output.
+
+=back
+
+=back
+
+B<Returns:> In list context, one of:
+
+=over 4
+
+=item *
+
+C<({empty => 1}, "- no $label secrets found to rotate.\n")> -- when
+C<invalid> filtering finds no qualifying secrets.
+
+=item *
+
+C<({abort => 1})> -- when the user declines the confirmation prompt.
+
+=item *
+
+C<({abort => 1}, "Quit!")> -- when the user quits mid-interactive rotation.
+
+=item *
+
+C<($results, $msg)> -- on normal completion, where C<$results> is a hashref
+of outcome counts and C<$msg> is a summary string.
+
+=back
+
+B<Examples:>
+
+    # Rotate all secrets, prompting for confirmation
+    my ($results, $msg) = $plan->regenerate_secrets;
+    # Returns: hashref of outcome counts and summary message
+
+    # Rotate only invalid secrets without prompting
+    my ($r) = $plan->regenerate_secrets(invalid => 1, no_prompt => 1);
+    # Returns: hashref of outcome counts or empty/abort sentinel
+
+=head2 remove_secrets
+
+    my ($results, $msg) = $plan->remove_secrets(%opts);
+
+Removes secrets from Vault and/or CredHub.  Supports multiple removal
+modes controlled by the C<invalid> option:
+
+=over 4
+
+=item C<0> (default)
+
+Removes all secrets in the plan.
+
+=item C<1>
+
+Removes only invalid or missing secrets (determined by C<validate_value>).
+
+=item C<2>
+
+Removes invalid, missing, or problematic secrets (warnings included).
+
+=item C<3>
+
+Removes unused Vault secrets -- paths present in Vault but not referenced
+by the current kit or environment manifest -- then also removes unused
+imported CredHub entries and outdated entombed CredHub entries.
+
+=item C<4>
+
+Removes unused Vault secrets only.
+
+=item C<5>
+
+Removes imported CredHub secrets that have already been copied to Vault.
+
+=item C<6>
+
+Removes outdated entombed CredHub secrets that are no longer referenced by
+the last deployed manifest.
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+Recognized keys:
+
+=over 4
+
+=item C<invalid>
+
+Integer C<0>-C<6> selecting the removal mode (see above).  Default: C<0>.
+
+=item C<no_prompt>
+
+If true, skips confirmation prompts.
+
+=item C<interactive>
+
+If true, prompts for each secret individually (C<y/n/q/a>).
+
+=item C<level>
+
+Output verbosity: C<full> or C<line>.
+
+=item C<indent>
+
+Indentation string for progress output.
+
+=back
+
+=back
+
+B<Returns:> One of:
+
+=over 4
+
+=item *
+
+The return value of C<_remove_secrets()> for most modes -- a two-element list
+C<($results, $msg)> where C<$results> is a hashref of outcome counts.
+
+=item *
+
+C<(\%results, $msg)> -- when C<invalid => 3> (C<unused>) processes all three
+sub-modes and aggregates their counts.
+
+=back
+
+B<Examples:>
+
+    # Remove all secrets (with confirmation prompt)
+    my ($results, $msg) = $plan->remove_secrets;
+    # Returns: hashref of outcome counts and message
+
+    # Remove unused vault entries without prompting
+    my ($r) = $plan->remove_secrets(invalid => 3, no_prompt => 1);
+    # Returns: hashref of aggregated outcome counts
+
+=head2 reset_secrets
+
+    $plan->reset_secrets(%opts);
+
+Empties the in-memory cached values for all secrets in the plan by calling
+the store's C<empty> method.  Does not remove secrets from Vault; this only
+clears the local cache so that subsequent operations re-read from Vault.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+Currently unused; reserved for future use.
+
+=back
+
+B<Returns:> No meaningful return value.
+
+B<Examples:>
+
+    $plan->reset_secrets;
+    # Clears in-memory cached secret values (no return value)
+
+=head2 notify
+
+    $plan->notify($action);
+    $plan->notify($action, \%opts, $state, %args);
+
+State-machine callback that drives progress display for all bulk operations.
+Called internally by C<check_secrets()>, C<validate_secrets()>,
+C<generate_secrets()>, C<regenerate_secrets()>, and C<remove_secrets()>.
+
+C<$action> names the current bulk operation (e.g., C<check>, C<validate>,
+C<add>, C<rotate>, C<remove>).  C<$state> selects the display behavior.
+
+Recognized states:
+
+=over 4
+
+=item C<init>
+
+Initializes the progress counter for a new batch.  Emits the batch header
+line showing the action, count, and Vault base path.
+
+Expected C<%args>: C<total> (integer), C<indent> (string), C<action>
+(optional override string), C<base_path> (optional override for the base
+path), C<secret_label> (optional noun for the type of secret, default
+C<secret>).
+
+=item C<start-item>
+
+Emits a pending progress line for an individual secret.
+
+Expected C<%args>: C<path>, C<label>, C<details>.
+
+=item C<done-item>
+
+Completes the pending progress line with a result indicator.
+
+Expected C<%args>: C<result> (one of C<ok>, C<error>, C<warn>, C<missing>,
+C<skipped>, C<imported>, C<generated>, C<aborted>), C<action> (optional
+override), C<msg> (optional detail message).
+
+=item C<completed>
+
+Emits the batch summary line with timing, counts, and status.
+
+Expected C<%args>: C<msg> (optional summary suffix), C<errors> (optional
+arrayref of additional error items).
+
+Returns: In list context, C<($results, $msg)> where C<$results> is a hashref
+of outcome counts by result type.  In scalar context, true if there were no
+errors, false otherwise.
+
+=item C<prompt>
+
+Displays a message and prompts for a full-line text response.  Requires a
+controlling terminal.
+
+Expected C<%args>: C<msg> (the prompt body), C<prompt> (the prompt line),
+C<class> (optional: C<warning>), C<default> (optional default value).
+
+Returns: The user's input string.
+
+=item C<inline-prompt>
+
+Displays a short inline prompt and returns the user's response.  Requires a
+controlling terminal.
+
+Expected C<%args>: C<prompt> (the prompt string), C<noclear> (if true,
+does not erase the prompt after input), C<validation>, C<err_msg>,
+C<default>.
+
+Returns: The user's input string.
+
+=item C<wait>
+
+Emits a pending "waiting" message.
+
+Expected C<%args>: C<msg>.
+
+=item C<wait-done>
+
+Completes a pending wait with a result indicator.
+
+Expected C<%args>: C<result> (C<ok> or C<error>), C<msg> (error detail,
+if applicable).
+
+=item C<notify>
+
+Emits an informational message at the current indent level.
+
+Expected C<%args>: C<msg>, C<nonl> (if true, does not append a newline).
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item C<$action>
+
+The bulk operation name (e.g., C<check>, C<validate>, C<add>, C<rotate>,
+C<remove>).
+
+=item C<\%opts> (optional)
+
+A hashref of display options.  If omitted, the plan's stored
+C<notification_options> are used.  Recognized keys: C<level> (C<full> or
+C<line>), C<indent>.
+
+=item C<$state>
+
+One of the state names listed above.
+
+=item C<%args>
+
+State-specific arguments as documented above.
+
+=back
+
+B<Returns:> Varies by state.  Most states return no meaningful value.
+The C<completed> state returns C<($results, $msg)> in list context or a
+boolean in scalar context.  The C<prompt> and C<inline-prompt> states return
+the user's input string.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"notify encountered an unknown state '$state'"> -- if an unrecognized state
+name is passed.
+
+=item *
+
+C<"Failure to specify $action"> -- if C<$action> is undefined or empty.
+
+=item *
+
+C<"Cannot prompt for confirmation to $action secrets outside a controlling terminal.  Use #C{-y|--no-prompt} option to provide confirmation to bypass this limitation."> -- from C<inline-prompt> or C<prompt> states when there is no controlling terminal.
+
+=back
+
+B<Examples:>
+
+    # Called internally -- typical usage pattern:
+    $self->notify('rotate', {indent => '    '}, 'init',
+        total => scalar($self->secrets)
+    );
+    # Emits: "    rotating N secrets under path 'base/path':"
+
+    my ($results, $msg) = $self->notify('check', 'completed');
+    # Returns: hashref of outcome counts and message string
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation.  They may change without
+notice and should not be called directly.
+
+=head2 _order_secrets
+
+    $plan->_order_secrets;
+
+Reorders the C<secrets> list so that X.509 certificates are processed in
+signing-chain order (signing CAs come before the certs they sign).
+Non-X.509 secrets are appended after all X.509 secrets, sorted by path.
+
+Self-signed CAs and unsigned certificates are given explicit C<self_signed>
+and C<signed_by> attributes during this pass.  Certificates whose signing CA
+cannot be determined are replaced with C<Genesis::Secret::Invalid> entries.
+
+Calls C<set_plan> on every secret in the reordered list so that each
+secret holds a back-reference to this plan.
+
+Modifies the object in-place.
+
+B<Returns:> The plan object itself.
+
+=head2 _next_x509_signer
+
+    my $signer_path = _next_x509_signer(\%signers);
+
+Static function (no C<$self>).  Given the C<%signers> hash that maps signer
+paths to their pending signee lists, returns the path of the next signer
+whose signees have not yet been processed -- specifically, a signer that is
+not itself in another signer's pending signee list.  C<$candidate> is a
+local iteration variable used during the search.
+
+Returns C<undef> when all signers have been exhausted.
+
+B<Parameters:>
+
+=over 4
+
+=item C<\%signers>
+
+Hashref mapping signer path strings to arrayrefs of C<Genesis::Secret::X509>
+objects that are signed by that path.
+
+=item C<$candidate>
+
+Used internally during iteration over available signer paths.
+
+=back
+
+B<Returns:> A signer path string, or C<undef>.
+
+B<Examples:>
+
+    my $next = _next_x509_signer(\%signers);
+    # Returns: a signer path string, or undef when exhausted
+
+=head2 _order_x509_secrets
+
+    _order_x509_secrets(
+        $signer_path, \%certs_by_signer, \@src_certs,
+        \@ordered_certs, \@errored_certs, $issuer, $kit_id
+    );
+
+Static recursive function (no C<$self>).  Processes all certificates signed
+by C<$signer_path>, appending them to C<@ordered_certs> in dependency order
+and recursing into any that are themselves CAs.  Cyclical signage and CA
+Common Name conflicts are detected and placed into C<@errored_certs>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$signer_path>
+
+Path of the current signing CA, or C<undef> / empty string for self-signed
+or root-CA-signed certs.
+
+=item C<\%certs_by_signer>
+
+Hashref mapping signer path strings to arrayrefs of pending signee
+C<Genesis::Secret::X509> objects.
+
+=item C<\@src_certs>
+
+The full original list of X.509 secrets (used for reference, not modified).
+
+=item C<\@ordered_certs>
+
+Accumulator for successfully ordered certs (modified in-place).
+
+=item C<\@errored_certs>
+
+Accumulator for rejected certs (modified in-place).
+
+=item C<$issuer>
+
+The C<Genesis::Secret::X509> object for the current signing CA, or
+C<undef> at the top level.
+
+=item C<$kit_id>
+
+The kit identifier string.  CA CN conflict checking is skipped for
+C<cf/v2.x> and higher kits due to a known upstream issue.
+
+=back
+
+B<Returns:> No return value; results are accumulated into C<@ordered_certs>
+and C<@errored_certs>.
+
+B<Examples:>
+
+    _order_x509_secrets(undef, \%signers, \@x509certs,
+        \@ordered, \@errored, undef, 'concourse/1.0');
+    # Returns: nothing; populates @ordered and @errored in-place
+
+=head2 _unused_vault_secrets
+
+    my @paths = $plan->_unused_vault_secrets(%opts);
+
+Identifies Vault secret paths that exist under the environment's Vault base
+path but are not referenced by the current kit's secret definitions or the
+environment's manifest vault paths.
+
+Queries the Vault store for all actual stored paths, then compares them
+against known secret paths (including formatted sub-key paths) and
+manifest-referenced vault paths.  Returns a list of path strings (or
+C<path:key> strings for individual keys) that appear to be orphaned.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+Currently unused; reserved for future use.
+
+=back
+
+B<Returns:> A list of path strings for unused Vault entries.
+
+B<Examples:>
+
+    my @unused = $plan->_unused_vault_secrets;
+    # Returns: list of orphaned vault path strings
+
+=head2 _unused_credhub_secrets
+
+    my @entries = $plan->_unused_credhub_secrets(%opts);
+
+Identifies CredHub entries that have already been imported into Vault and
+are therefore no longer needed in CredHub.
+
+Returns an empty list if the environment is not vaultified.
+
+Each returned element is a hashref with keys C<path> (the CredHub path
+relative to the base), C<secret> (the corresponding C<Genesis::Secret::*>
+object), and C<details> (a display string indicating import status).
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+Currently unused; reserved for future use.
+
+=back
+
+B<Returns:> A list of hashrefs for unused imported CredHub entries, or an
+empty list if the environment is not vaultified or none qualify.
+
+B<Examples:>
+
+    my @unused = $plan->_unused_credhub_secrets;
+    # Returns: list of hashrefs with path, secret, and details keys
+
+=head2 _unused_entombed_secrets
+
+    my @entries = $plan->_unused_entombed_secrets($last_manifest, $type, %opts);
+
+Identifies entombed CredHub secrets (under the C<genesis-entombed/> prefix)
+that are no longer referenced by the last deployed manifest.
+
+Returns an empty hashref if there are no entombed paths.  If the last
+manifest is not an entombed manifest, warns and returns all entombed paths.
+
+Otherwise, compares the set of entombed paths against those referenced in
+the manifest and returns a list of hashrefs for the unreferenced ones.  Each
+hashref has keys C<label>, C<path>, and C<details>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$last_manifest>
+
+The last deployed manifest data structure (as returned by
+C<$env->last_deployed_manifest>).
+
+=item C<$type>
+
+The manifest type string (e.g., C<entombed>, C<redacted>, C<unknown>).
+When C<undef> or C<unknown>, forensic detection is attempted.
+
+=item C<%opts>
+
+Currently unused; reserved for future use.
+
+=back
+
+B<Returns:> A list of hashrefs for unused entombed entries, or an empty
+hashref if there are no entombed paths, or a list of all entombed path
+strings if the last manifest is not an entombed manifest.
+
+B<Examples:>
+
+    my @stale = $plan->_unused_entombed_secrets($manifest, $type);
+    # Returns: list of hashrefs with label, path, and details keys
+
+=head2 _invalid_secrets
+
+    my @secrets = $plan->_invalid_secrets($severity, %opts);
+
+Validates every secret in the plan and returns those that fail validation.
+Emits progress output via C<notify()> as it scans.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$severity>
+
+The string C<'invalid'> to select only secrets with C<error> results, or
+C<'problem'> to also include secrets with C<warn> results.  Secrets with
+C<missing> results are logged via C<notify()> but are not included in the
+returned list.
+
+=item C<%opts>
+
+Currently unused.
+
+=back
+
+B<Returns:> A list of C<Genesis::Secret::*> objects that failed validation
+at the specified severity level.
+
+B<Examples:>
+
+    my @bad = $plan->_invalid_secrets('invalid');
+    # Returns: list of Genesis::Secret::* objects that failed validation (error only)
+
+=head2 _remove_secrets
+
+    my ($results, $msg) = $plan->_remove_secrets(\@selected_secrets, %opts);
+
+Performs the actual removal of a list of secrets from Vault or CredHub.
+Handles confirmation prompts (bulk or per-item), interactive quit/skip
+support, and dispatches to the appropriate remove command for each secret
+type (C<Genesis::Secret::*> objects, raw path strings, or CredHub path
+hashrefs).
+
+B<Parameters:>
+
+=over 4
+
+=item C<\@selected_secrets>
+
+Arrayref of secrets to remove.  Each element may be a C<Genesis::Secret::*>
+object, a raw vault path string, or a hashref with C<path> and optional
+C<label>, C<alt_path>, and C<details> keys.
+
+=item C<%opts>
+
+Recognized keys:
+
+=over 4
+
+=item C<source>
+
+C<vault> (default) or C<credhub>.
+
+=item C<label>
+
+Display label for the type of secret being removed (default: C<secret>).
+
+=item C<confirm>
+
+C<all> (bulk prompt), C<each> (per-item prompt), or C<none> (no prompt).
+
+=item C<no_header>
+
+If true, suppresses the count header line.
+
+=back
+
+=back
+
+B<Returns:> In list context, C<($results, $msg)> where C<$results> is a
+hashref of outcome counts.  Returns early with
+C<({empty => 1}, "- no ${label} found to remove.\n")> if
+C<@selected_secrets> is empty, or
+C<({abort => 1}, "Quit!\n")> if the user declines the bulk prompt.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Credhub removal not yet implemented"> -- if a raw path removal against
+CredHub is attempted.
+
+=item *
+
+C<"Interactive removal of secrets is not yet supported"> -- if a
+C<Genesis::Secret::*> object requires interactive terminal input to remove.
+
+=item *
+
+C<"Unknown secret type for removal"> -- if a selected secret is neither a
+hashref, a string, nor a C<Genesis::Secret::*> object.
+
+=back
+
+B<Examples:>
+
+    my ($results, $msg) = $plan->_remove_secrets(\@secrets, confirm => 'none');
+    # Returns: hashref of outcome counts and completion message
+
+=head1 SEE ALSO
+
+L<Genesis::Env>,
+L<Genesis::Secret>,
+L<Genesis::Env::Secrets::Parser>,
+L<Genesis::Env::Secrets::Parser::FromKit>,
+L<Genesis::Env::Secrets::Parser::FromManifest>,
+L<Genesis::Env::Secrets::Store>,
+L<Genesis::Env::Secrets::Store::Vault>
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Secrets/Plan.pod
+++ b/lib/Genesis/Env/Secrets/Plan.pod
@@ -13,8 +13,8 @@ Genesis::Env::Secrets::Plan - Orchestrator for environment secret lifecycle oper
 
     # Populate with secrets from parsers or objects
     $plan->populate(
-        'Genesis::Env::Secrets::Parser::Kit',
-        'Genesis::Env::Secrets::Parser::Credhub',
+        'Genesis::Env::Secrets::Parser::FromKit',
+        'Genesis::Env::Secrets::Parser::FromManifest',
     );
 
     # Abort early if any secret definitions are structurally invalid
@@ -292,13 +292,13 @@ C<"Genesis::Env::Secrets::Plan->populate was given an argument that wasn't a Gen
 B<Examples:>
 
     $plan->populate(
-        'Genesis::Env::Secrets::Parser::Kit',
-        'Genesis::Env::Secrets::Parser::Credhub',
+        'Genesis::Env::Secrets::Parser::FromKit',
+        'Genesis::Env::Secrets::Parser::FromManifest',
     );
     # Returns: $plan (the same object, now populated)
 
     # Populate with a pre-built parser object
-    my $parser = Genesis::Env::Secrets::Parser::Kit->new($env);
+    my $parser = Genesis::Env::Secrets::Parser::FromKit->new($env);
     $plan->populate($parser);
     # Returns: $plan
 
@@ -431,7 +431,7 @@ C<"\nErrors found in %s:\n%s\nThis may be an issue with the kit or with values i
 
 B<Examples:>
 
-    $plan->populate('Genesis::Env::Secrets::Parser::Kit');
+    $plan->populate('Genesis::Env::Secrets::Parser::FromKit');
     $plan->validate;   # aborts if any definitions are invalid
     # Returns: 1 (if no errors)
 

--- a/lib/Genesis/Env/Secrets/Store.pod
+++ b/lib/Genesis/Env/Secrets/Store.pod
@@ -5,10 +5,12 @@ Genesis::Env::Secrets::Store - Abstract base class for environment secrets store
 =head1 SYNOPSIS
 
     # Never instantiate directly -- use the factory method
-    my $store = Genesis::Env::Secrets::Store->provide($env, $service);
+    my $store = Genesis::Env::Secrets::Store->provide(
+        $env, $vault_service, %options
+    );
 
     # Work with the store through its interface
-    my @paths = $store->list();
+    my @paths = $store->list($filter, keys => 1);
     my $value = $store->get('path/to/secret', 'key');
     $store->set('path/to/secret', { key => 'value' });
 
@@ -52,11 +54,10 @@ determines which backend is used:
 =over 4
 
 =item * C<Service::Vault::Remote> or C<Service::Vault::Local> - returns a
-C<Genesis::Env::Secrets::Store::Vault> instance via that class's C<provide()>
-method.
+C<Genesis::Env::Secrets::Store::Vault> instance via C<< Vault->new() >>.
 
 =item * C<Service::Credhub> - returns a C<Genesis::Env::Secrets::Store::Credhub>
-instance via that class's C<provide()> method.
+instance via C<< Credhub->new() >>.
 
 =back
 
@@ -68,17 +69,17 @@ B<Parameters:>
 being created.
 
 =item * C<$service> - A service object whose class determines the backend
-type.
+type. Passed through to the subclass constructor as the C<service> option.
 
-=item * C<%options> - Optional key-value pairs accepted by the delegated
-C<provide()> implementation (currently unused at this level).
+=item * C<%options> - Optional key-value pairs forwarded to the subclass
+constructor.
 
 =back
 
 B<Returns:>
 
-A concrete C<Genesis::Env::Secrets::Store> subclass instance, or C<undef>
-if the service type is not recognized.
+A concrete C<Genesis::Env::Secrets::Store> subclass instance. Calls
+C<bug()> and does not return if the service type is not recognized.
 
 B<Examples:>
 

--- a/lib/Genesis/Env/Secrets/Store.pod
+++ b/lib/Genesis/Env/Secrets/Store.pod
@@ -1,0 +1,718 @@
+=head1 NAME
+
+Genesis::Env::Secrets::Store - Abstract base class for environment secrets stores
+
+=head1 SYNOPSIS
+
+    # Never instantiate directly -- use the factory method
+    my $store = Genesis::Env::Secrets::Store->provide($env, $service);
+
+    # Work with the store through its interface
+    my @paths = $store->list();
+    my $value = $store->get('path/to/secret', 'key');
+    $store->set('path/to/secret', { key => 'value' });
+
+    # Navigate paths
+    my $base      = $store->base;
+    my $full_path = $store->path('my/secret', 'key');
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::Secrets::Store> is the abstract base class for all secrets
+store backends used by Genesis environments. It defines the interface that
+concrete store implementations (Vault, CredHub) must satisfy, and provides
+a factory method for creating the correct store based on a service object.
+
+This class cannot be instantiated directly. Use C<provide()> to obtain a
+store instance appropriate for the environment's backing service. Concrete
+implementations live in:
+
+=over 4
+
+=item * L<Genesis::Env::Secrets::Store::Vault> - for Vault (local or remote)
+
+=item * C<Genesis::Env::Secrets::Store::Credhub> - for CredHub
+
+=back
+
+Each store exposes a path hierarchy rooted at C<mount() . slug()>. The
+C<path()> method constructs fully-qualified paths within that hierarchy
+using the store's C<path_separator> (C</>) and C<key_separator> (C<:>).
+
+=head1 METHODS
+
+=head2 provide
+
+    my $store = Genesis::Env::Secrets::Store->provide($env, $service, %options);
+
+Factory method that constructs and returns a secrets store object of the
+correct subclass for the given C<$service>. The service object's class
+determines which backend is used:
+
+=over 4
+
+=item * C<Service::Vault::Remote> or C<Service::Vault::Local> - returns a
+C<Genesis::Env::Secrets::Store::Vault> instance via that class's C<provide()>
+method.
+
+=item * C<Service::Credhub> - returns a C<Genesis::Env::Secrets::Store::Credhub>
+instance via that class's C<provide()> method.
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$env> - The Genesis environment object for which the store is
+being created.
+
+=item * C<$service> - A service object whose class determines the backend
+type.
+
+=item * C<%options> - Optional key-value pairs accepted by the delegated
+C<provide()> implementation (currently unused at this level).
+
+=back
+
+B<Returns:>
+
+A concrete C<Genesis::Env::Secrets::Store> subclass instance, or C<undef>
+if the service type is not recognized.
+
+B<Examples:>
+
+    my $store = Genesis::Env::Secrets::Store->provide($env, $vault_service);
+    print ref($store); # prints 'Genesis::Env::Secrets::Store::Vault'
+
+=head2 path_separator
+
+    my $sep = $store->path_separator;
+
+Returns the string used to join components of a secrets path. The base
+class implementation returns C<'/'>.
+
+Subclasses may override this if the backing store uses a different path
+delimiter.
+
+B<Returns:>
+
+The path separator string. Defaults to C<'/'>.
+
+B<Examples:>
+
+    print $store->path_separator; # prints '/'
+
+=head2 key_separator
+
+    my $sep = $store->key_separator;
+
+Returns the string used to join a secrets path and a key name. The base
+class implementation returns C<':'>.
+
+Subclasses may override this if the backing store uses a different
+key delimiter.
+
+B<Returns:>
+
+The key separator string. Defaults to C<':'>.
+
+B<Examples:>
+
+    print $store->key_separator; # prints ':'
+
+=head2 base
+
+    my $base = $store->base;
+
+Returns the base path for this environment's secrets in the store.
+Computed as C<mount() . slug()>. All secret paths within this store are
+relative to this prefix.
+
+B<Returns:>
+
+A string combining the mount point and the environment slug.
+
+B<Examples:>
+
+    print $store->base; # prints e.g. 'secret/myenv/'
+
+=head2 path
+
+    my $full_path = $store->path($secrets_path, $key);
+
+Constructs the full path for a secret within this store, optionally
+appending a key name.
+
+C<$secrets_path> may be either a scalar string or an array reference
+of path components. When an array reference is given, all components are
+joined with the store's C<path_separator>. The result is prefixed with
+C<base()> using the path separator.
+
+If C<$key> is defined, it is appended to the path using the store's
+C<key_separator>.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$secrets_path> - A string or array reference of path components
+within the store.
+
+=item * C<$key> - Optional. A key name to append to the path.
+
+=back
+
+B<Returns:>
+
+The fully qualified path string, e.g. C<'secret/myenv/my/secret'> or
+C<'secret/myenv/my/secret:key'>.
+
+B<Examples:>
+
+    my $p = $store->path('certs/server');
+    print $p; # prints 'secret/myenv/certs/server'
+
+    my $p2 = $store->path(['certs', 'server'], 'ca');
+    print $p2; # prints 'secret/myenv/certs/server:ca'
+
+=head1 ABSTRACT METHODS
+
+Methods that derived classes B<must> implement. The base class will die
+via C<bug()> if these are called without being overridden by a subclass.
+Each abstract method dies with:
+
+C<"Abstract Method: Expecting %s class to define concrete '%' method">
+
+where C<%s> is the calling class name and C<'%'> is the method name.
+
+=head2 new
+
+    my $store = $class->new();
+
+Constructor for a concrete secrets store. Must be implemented by each
+subclass.
+
+Implementations must accept an environment object and a set of key-value
+option pairs that configure the store. The set of accepted keys is
+determined by the subclass.
+
+B<Returns:>
+
+A new instance of the derived class.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Abstract Method: Expecting %s class to define concrete '%' method">
+where C<%s> is the class name and C<'%'> is C<'new'>.
+
+=back
+
+B<Examples:>
+
+    # Called on a concrete subclass, not directly on this base class
+    my $store = Genesis::Env::Secrets::Store::Vault->new();
+    # Returns: a Vault store instance
+
+=head2 default_mount
+
+    my $mount = $store->default_mount();
+
+Must return a string for the default mount point for secrets in this store
+class, used when the user has not specified a custom mount.
+
+B<Returns:>
+
+A string containing the default mount point.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Abstract Method: Expecting %s class to define concrete '%' method">
+where C<%s> is the class name and C<'%'> is C<'default_mount'>.
+
+=back
+
+B<Examples:>
+
+    # In a derived class:
+    my $mount = $store->default_mount();
+    print $mount; # prints e.g. 'secret/'
+
+=head2 mount
+
+    my $mount = $store->mount();
+
+Must return a string for the actual mount point configured for this store
+instance.
+
+B<Returns:>
+
+A string containing the active mount point for this store.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Abstract Method: Expecting %s class to define concrete '%' method">
+where C<%s> is the class name and C<'%'> is C<'mount'>.
+
+=back
+
+B<Examples:>
+
+    # In a derived class:
+    my $mount = $store->mount();
+    print $mount; # prints e.g. 'secret/'
+
+=head2 default_slug
+
+    my $slug = $store->default_slug();
+
+Must return a string for the default sub-path within the mount, derived
+from the environment's name and type. Used when the user has not specified
+a custom slug.
+
+B<Returns:>
+
+A string containing the default sub-path for this store class.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Abstract Method: Expecting %s class to define concrete '%' method">
+where C<%s> is the class name and C<'%'> is C<'default_slug'>.
+
+=back
+
+B<Examples:>
+
+    # In a derived class:
+    my $slug = $store->default_slug();
+    print $slug; # prints e.g. 'myenv/'
+
+=head2 slug
+
+    my $slug = $store->slug();
+
+Must return a string for the actual sub-path within the mount used by
+this store instance, based on the environment.
+
+B<Returns:>
+
+A string containing the active sub-path for this store.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Abstract Method: Expecting %s class to define concrete '%' method">
+where C<%s> is the class name and C<'%'> is C<'slug'>.
+
+=back
+
+B<Examples:>
+
+    # In a derived class:
+    my $slug = $store->slug();
+    print $slug; # prints e.g. 'myenv/'
+
+=head2 label
+
+    my $label = $store->label();
+
+Must return a human-readable string describing the secrets store for this
+environment, for use in log and error messages.
+
+B<Returns:>
+
+A string describing the store (e.g., C<'Vault at secret/myenv/'>).
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Abstract Method: Expecting %s class to define concrete '%' method">
+where C<%s> is the class name and C<'%'> is C<'label'>.
+
+=back
+
+B<Examples:>
+
+    # In a derived class:
+    print $store->label(); # prints e.g. 'Vault at secret/myenv/'
+
+=head2 list
+
+    my @paths = $store->list();
+
+Must return a list of existing secret paths under the store's base path.
+
+Implementations must accept an optional filter (string, regular expression,
+or hash) and an optional C<keys> boolean flag. When C<keys> is true, keys
+are returned alongside paths. When false (the default), only secret paths
+are returned. A string filter matches as a path prefix; a regular expression
+is applied to each path (or key); a hash filter describes criteria by name,
+type, or feature.
+
+B<Returns:>
+
+A list of matching secret paths under the base path for this store.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Abstract Method: Expecting %s class to define concrete '%' method">
+where C<%s> is the class name and C<'%'> is C<'list'>.
+
+=back
+
+B<Examples:>
+
+    # In a derived class:
+    my @paths = $store->list();
+    print scalar(@paths); # prints the count of secrets
+
+=head2 get
+
+    my $value = $store->get();
+
+Must retrieve and return secrets from the store.
+
+Implementations must accept a path as the first argument, followed by an
+optional single key or list of keys. When a single path and key are
+specified, returns a scalar value. When only a path is given or multiple
+keys are specified, returns a hash reference. Returns C<undef> if the path
+does not exist, or C<undef> for each specified key that does not exist.
+
+B<Returns:>
+
+A scalar value, a hash reference, or C<undef>.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Abstract Method: Expecting %s class to define concrete '%' method">
+where C<%s> is the class name and C<'%'> is C<'get'>.
+
+=back
+
+B<Examples:>
+
+    # In a derived class:
+    my $value = $store->get('certs/server', 'certificate');
+    print defined($value) ? 'found' : 'missing'; # prints 'found' or 'missing'
+
+=head2 set
+
+    $store->set();
+
+Must write a secret value or set of key-value pairs to a path in the store.
+
+Implementations must accept a path as the first argument and a value or
+hash of key-value pairs as the second. If the value is a scalar, it is
+stored under the C<value> key. If it is a hash or hash reference, each
+specified key is set to its corresponding value. Existing keys at the
+path that are not specified are left unchanged.
+
+B<Returns:>
+
+The values set if successful.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Abstract Method: Expecting %s class to define concrete '%' method">
+where C<%s> is the class name and C<'%'> is C<'set'>. Raises an error if
+the write fails.
+
+=back
+
+B<Examples:>
+
+    # In a derived class:
+    $store->set('certs/server', { certificate => $cert, key => $key });
+    # sets the certificate and key fields at the given path
+
+=head2 authenticate
+
+    my $self = $store->authenticate();
+
+Must authenticate to the remote store service.
+
+B<Returns:>
+
+C<$self> if authentication succeeds.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Abstract Method: Expecting %s class to define concrete '%' method">
+where C<%s> is the class name and C<'%'> is C<'authenticate'>. Raises an
+error if authentication fails.
+
+=back
+
+B<Examples:>
+
+    # In a derived class:
+    my $s = $store->authenticate();
+    print ref($s); # prints the store class name
+
+=head2 is_authenticated
+
+    my $bool = $store->is_authenticated();
+
+Must determine whether the store is already authenticated to its remote
+service.
+
+B<Returns:>
+
+C<1> if authenticated, C<undef> if not.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Abstract Method: Expecting %s class to define concrete '%' method">
+where C<%s> is the class name and C<'%'> is C<'is_authenticated'>.
+
+=back
+
+B<Examples:>
+
+    # In a derived class:
+    print $store->is_authenticated() ? 'yes' : 'no'; # prints 'yes' or 'no'
+
+=head2 is_available
+
+    my $bool = $store->is_available();
+
+Must determine whether the remote store service is reachable and targetable.
+
+B<Returns:>
+
+C<1> if available, C<undef> if not.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Abstract Method: Expecting %s class to define concrete '%' method">
+where C<%s> is the class name and C<'%'> is C<'is_available'>.
+
+=back
+
+B<Examples:>
+
+    # In a derived class:
+    print $store->is_available() ? 'up' : 'down'; # prints 'up' or 'down'
+
+=head2 generate
+
+    my $ok = $store->generate();
+
+Must generate secrets for the environment based on the kit plan.
+
+Implementations must accept a C<%options> hash with the following keys:
+
+=over 4
+
+=item * C<filter> - Optional. A filter for which secrets to generate.
+
+=item * C<verbose> - Optional boolean. C<1> for full output; C<0> for
+progress-line style.
+
+=back
+
+B<Returns:>
+
+C<1> if generation succeeds, C<0> otherwise.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Abstract Method: Expecting %s class to define concrete '%' method">
+where C<%s> is the class name and C<'%'> is C<'generate'>.
+
+=back
+
+B<Examples:>
+
+    # In a derived class:
+    my $ok = $store->generate(verbose => 1);
+    print $ok ? 'done' : 'failed'; # prints 'done' or 'failed'
+
+=head2 validate
+
+    my $ok = $store->validate();
+
+Must validate the environment's secrets against the kit plan.
+
+Implementations must accept a C<%options> hash with the following keys:
+
+=over 4
+
+=item * C<filter> - Optional. A filter for which secrets to validate.
+
+=item * C<verbose> - Optional boolean. C<1> for full output; C<0> for
+progress-line style showing only failures.
+
+=item * C<validate> - Optional boolean. C<1> for full validation; C<0>
+to check existence only.
+
+=back
+
+B<Returns:>
+
+C<1> if validation succeeds, C<0> otherwise.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Abstract Method: Expecting %s class to define concrete '%' method">
+where C<%s> is the class name and C<'%'> is C<'validate'>.
+
+=back
+
+B<Examples:>
+
+    # In a derived class:
+    my $ok = $store->validate(validate => 1);
+    print $ok ? 'valid' : 'invalid'; # prints 'valid' or 'invalid'
+
+=head2 regenerate
+
+    my @paths = $store->regenerate();
+
+Must regenerate secrets for the environment according to the provided
+options.
+
+Implementations must accept a C<%options> hash with the following keys:
+
+=over 4
+
+=item * C<filter> - Optional. A filter for which secrets to regenerate.
+
+=item * C<verbose> - Optional boolean. C<1> for full output; C<0> for
+progress-line style showing only failures.
+
+=item * C<validate> - Optional boolean. C<1> for full validation; C<0>
+to check existence only.
+
+=item * C<no_prompt> - Optional boolean. When true, skips confirmation
+prompts before regenerating.
+
+=item * C<interactive> - Optional boolean. When true, prompts before
+regenerating each secret individually.
+
+=item * C<invalid> - Optional boolean. When true, regenerates only secrets
+that are currently invalid.
+
+=item * C<renew> - Optional boolean. When true, renews time-sensitive
+secrets (e.g., x509 certificates) without invalidating the signing key.
+
+=back
+
+B<Returns:>
+
+A list of the matching secret paths that were processed under the base
+path for this store.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Abstract Method: Expecting %s class to define concrete '%' method">
+where C<%s> is the class name and C<'%'> is C<'regenerate'>.
+
+=back
+
+B<Examples:>
+
+    # In a derived class:
+    my @paths = $store->regenerate(filter => 'certs/');
+    print scalar(@paths); # prints count of regenerated paths
+
+=head2 remove
+
+    my @paths = $store->remove();
+
+Must remove secrets matching a given filter.
+
+Implementations must accept a filter argument (string, regular expression,
+or hash) that describes a filter on secret name, type, or feature.
+
+B<Returns:>
+
+A list of the secret paths that were removed.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Abstract Method: Expecting %s class to define concrete '%' method">
+where C<%s> is the class name and C<'%'> is C<'remove'>.
+
+=back
+
+B<Examples:>
+
+    # In a derived class:
+    my @removed = $store->remove('certs/');
+    print scalar(@removed); # prints count of removed paths
+
+=head2 remove_all
+
+    my @paths = $store->remove_all();
+
+Must remove all secrets matching a given filter under this store's base
+path.
+
+Implementations must accept a filter argument (string, regular expression,
+or hash) that describes a filter on secret name, type, or feature.
+
+B<Returns:>
+
+A list of the matching secret paths under the base path for this store.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Abstract Method: Expecting %s class to define concrete '%' method">
+where C<%s> is the class name and C<'%'> is C<'remove_all'>.
+
+=back
+
+B<Examples:>
+
+    # In a derived class:
+    my @paths = $store->remove_all('certs/');
+    print scalar(@paths); # prints count of removed paths
+
+=head1 SEE ALSO
+
+L<Genesis::Env::Secrets::Store::Vault>,
+L<Genesis::Env::Secrets::Plan>,
+L<Genesis::Env>
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Secrets/Store/Vault.pod
+++ b/lib/Genesis/Env/Secrets/Store/Vault.pod
@@ -721,10 +721,6 @@ B<Examples:>
 
 =head1 SEE ALSO
 
-L<Genesis::Env::Secrets::Store> - The abstract base class this module implements.
-
-=head1 SEE ALSO
-
 L<Genesis::Env::Secrets::Store>,
 L<Genesis::Env::Secrets::Plan>,
 L<Genesis::Env>

--- a/lib/Genesis/Env/Secrets/Store/Vault.pod
+++ b/lib/Genesis/Env/Secrets/Store/Vault.pod
@@ -99,10 +99,10 @@ B<Errors:>
 
 =over 4
 
-=item * C<"No '$_' specified in call to Genesis::Env::SecretsStore::Vault->new"> -
+=item * C<"No '$_' specified in call to Genesis::Env::Secrets::Store::Vault->new"> -
 if a required option (C<service>) is missing or false.
 
-=item * C<"Unknown '$_' option specified in call to Genesis::Env::SecretsStore::Vault->new"> -
+=item * C<"Unknown '$_' option specified in call to Genesis::Env::Secrets::Store::Vault->new"> -
 if an unrecognised key is passed in C<%opts>, where C<$_> is the unknown
 key name.
 
@@ -123,10 +123,6 @@ B<Examples:>
 
 Returns the Genesis environment object associated with this store.
 
-Also available: C<< $store->service >> returns the underlying
-C<Service::Vault::Remote> or C<Service::Vault::Local> object that was passed
-as the C<service> option to C<new>.
-
 B<Returns:>
 
 The C<$env> object passed to C<new>.
@@ -135,6 +131,19 @@ B<Examples:>
 
     print $store->env->name;
     # Returns: the environment name, e.g. 'myorg-myenv'
+
+=head2 service
+
+    my $service = $store->service;
+
+Returns the underlying C<Service::Vault::Remote> or C<Service::Vault::Local>
+object that was passed as the C<service> option to C<new>.
+
+B<Returns:>
+
+The service object passed to C<new>.
+
+B<Examples:>
 
     print ref($store->service);
     # Returns: e.g. 'Service::Vault::Remote'
@@ -346,11 +355,16 @@ B<Examples:>
 
 =head2 paths
 
-    my @paths = $store->paths;
+    my @paths = $store->paths(@query_paths);
+    my @all   = $store->paths;
 
 Returns the Vault paths matching the given query paths. Accepts one or more
 absolute Vault path strings as arguments. If the store data cache is not
 loaded, delegates directly to C<< $store->service->paths(@_) >>.
+
+When called with no arguments: if the cache is loaded, returns all cached
+paths; if the cache is not loaded, delegates to
+C<< $store->service->paths() >>.
 
 When the cache is loaded, paths that fall under C<base()> are resolved from
 the cache. Paths outside C<base()> are looked up live via the service.
@@ -361,17 +375,25 @@ A list of absolute Vault path strings matching the query.
 
 B<Examples:>
 
-    my @paths = $store->paths;
-    print scalar(@paths), " paths in store\n";
-    # Returns: e.g. '3 paths in store'
+    my @paths = $store->paths('/secret/myorg/myenv/bosh/certs/server');
+    # Returns: matching paths under the query
+
+    my @all = $store->paths;
+    print scalar(@all), " paths in store\n";
+    # Returns: all cached paths (or all service paths if no cache)
 
 =head2 keys
 
-    my @keys = $store->keys;
+    my @keys = $store->keys(@query_paths);
+    my @all  = $store->keys;
 
 Returns all keys present at the given Vault paths. Accepts one or more
 absolute Vault path strings as arguments. If the store data cache is not
 loaded, delegates directly to C<< $store->service->keys(@_) >>.
+
+When called with no arguments: if the cache is loaded, returns all keys
+across all cached paths; if the cache is not loaded, delegates to
+C<< $store->service->keys() >>.
 
 When the cache is loaded, keys for paths under C<base()> are resolved from
 the cache. Keys for paths outside C<base()> are fetched live via the service.
@@ -382,9 +404,12 @@ A list of key name strings.
 
 B<Examples:>
 
-    my @keys = $store->keys;
+    my @keys = $store->keys('/secret/myorg/myenv/bosh/certs/server');
     print join(', ', @keys), "\n";
     # Returns: e.g. 'certificate, key, ca'
+
+    my @all = $store->keys;
+    # Returns: all keys across all cached paths (or all service keys)
 
 =head2 exists
 
@@ -543,7 +568,8 @@ B<Examples:>
 
 Checks whether a secret is present in the store. If the secret does not
 already have a value loaded (C<< $secret->has_value >> is false), fetches
-it via the delegated C<get> method on the service.
+it via C<get>, which is AUTOLOAD-delegated to
+C<< $self-E<gt>{service}-E<gt>get() >>.
 
 B<Parameters:>
 
@@ -637,8 +663,6 @@ B<Errors:>
 
 =item * C<"Regenerate not implemented for Vault store">
 
-=item * C<"Remove not implemented for Vault store"> (from the C<remove> stub, which the extractor groups with C<regenerate>)
-
 =back
 
 B<Examples:>
@@ -646,6 +670,26 @@ B<Examples:>
     eval { $store->regenerate };
     print $@ if $@;
     # Returns: 'Regenerate not implemented for Vault store at ...'
+
+=head2 remove
+
+    $store->remove;
+
+Not implemented for the Vault store backend. Always dies immediately.
+
+B<Returns:>
+
+Never returns.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Remove not implemented for Vault store">
+
+=back
+
+B<Examples:>
 
     eval { $store->remove };
     print $@ if $@;

--- a/lib/Genesis/Env/Secrets/Store/Vault.pod
+++ b/lib/Genesis/Env/Secrets/Store/Vault.pod
@@ -1,0 +1,696 @@
+=head1 NAME
+
+Genesis::Env::Secrets::Store::Vault - Vault-backed secrets store for Genesis environments
+
+=head1 SYNOPSIS
+
+    use Genesis::Env::Secrets::Store::Vault;
+
+    # Construct directly (typically done via the parent factory)
+    my $store = Genesis::Env::Secrets::Store::Vault->new(
+        $env,
+        service        => $vault_service,
+        mount_override => '/secret/',
+        slug_override  => 'my/env/path',
+    );
+
+    # Navigate paths
+    my $base      = $store->base;       # e.g. '/secret/myorg/myenv/bosh/'
+    my $full_path = $store->path('certs/server');
+
+    # Bulk-load all store data in one Vault export
+    $store->store_data;
+    $store->fill(@secrets);
+    $store->clear_data;
+
+    # Single-secret operations
+    $store->read($secret);
+    $store->write($secret);
+    my $found = $store->exists($secret);
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::Secrets::Store::Vault> is the concrete L<Genesis::Env::Secrets::Store>
+subclass for environments backed by HashiCorp Vault. It wraps a
+C<Service::Vault::Remote> or C<Service::Vault::Local> service object and
+provides path construction, bulk data loading, and per-secret CRUD
+operations scoped to the environment's secrets base path.
+
+The store's path hierarchy is:
+
+    <mount>/<slug>/
+
+where C<mount> defaults to C</secret/> and C<slug> is derived from the
+environment name (dashes replaced with slashes) concatenated with the
+environment type. Both values can be overridden at construction time or via
+the environment's genesis configuration keys (C<genesis.secrets_mount>,
+C<genesis.secrets_path>, C<params.vault_prefix>, C<params.vault>).
+
+B<Method delegation:> Any method called on the store that is not explicitly
+defined here is automatically forwarded to the underlying C<service> object
+via Perl's C<AUTOLOAD> mechanism. This allows callers to invoke vault service
+methods (such as C<get>, C<set>, C<has>, C<paths>, C<keys>) directly on the
+store as a convenience. Note that C<DESTROY> is never forwarded.
+
+B<Stub operations:> C<generate>, C<regenerate>, C<remove>, and C<remove_all>
+are required by the L<Genesis::Env::Secrets::Store> interface but are not yet
+implemented for the Vault backend. Each will die immediately with an
+explanatory message if called.
+
+=head1 METHODS
+
+=head2 new
+
+    my $store = Genesis::Env::Secrets::Store::Vault->new($env, %opts);
+
+Constructs a new Vault-backed secrets store for the given environment.
+
+The C<service> key is required. The override keys are optional; when
+omitted, they are resolved from the environment's genesis configuration.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$env> - The Genesis environment object for this store.
+
+=item * C<service> (required) - A C<Service::Vault::Remote> or
+C<Service::Vault::Local> object to use for all Vault operations.
+
+=item * C<mount_override> (optional) - Override the Vault mount point.
+When omitted, falls back to C<$env->lookup('genesis.secrets_mount')>.
+
+=item * C<slug_override> (optional) - Override the environment path slug.
+When omitted, falls back to the first defined value among
+C<genesis.secrets_path>, C<params.vault_prefix>, and C<params.vault> in
+the environment configuration.
+
+=item * C<root_ca_override> (optional) - Override the root CA Vault path.
+When omitted, falls back to C<$env->lookup('genesis.root_ca_path', '')>
+with any trailing slash stripped.
+
+=back
+
+B<Returns:>
+
+A blessed C<Genesis::Env::Secrets::Store::Vault> instance.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"No '$_' specified in call to Genesis::Env::SecretsStore::Vault->new"> -
+if a required option (C<service>) is missing or false.
+
+=item * C<"Unknown '$_' option specified in call to Genesis::Env::SecretsStore::Vault->new"> -
+if an unrecognised key is passed in C<%opts>, where C<$_> is the unknown
+key name.
+
+=back
+
+B<Examples:>
+
+    my $store = Genesis::Env::Secrets::Store::Vault->new(
+        $env,
+        service => $vault_service,
+    );
+    print ref($store);
+    # Returns: 'Genesis::Env::Secrets::Store::Vault'
+
+=head2 env
+
+    my $env = $store->env;
+
+Returns the Genesis environment object associated with this store.
+
+Also available: C<< $store->service >> returns the underlying
+C<Service::Vault::Remote> or C<Service::Vault::Local> object that was passed
+as the C<service> option to C<new>.
+
+B<Returns:>
+
+The C<$env> object passed to C<new>.
+
+B<Examples:>
+
+    print $store->env->name;
+    # Returns: the environment name, e.g. 'myorg-myenv'
+
+    print ref($store->service);
+    # Returns: e.g. 'Service::Vault::Remote'
+
+=head2 mount
+
+    my $mount = $store->mount;
+
+Returns the active Vault mount point for this store instance, normalised
+to always begin and end with C</>. Uses C<mount_override> if set, otherwise
+falls back to C<default_mount> which returns C<'/secret/'>. The resolved
+value is cached after the first call. Overrides the abstract method in
+L<Genesis::Env::Secrets::Store>.
+
+B<Returns:>
+
+A string of the form C<'/mount/'>, e.g. C<'/secret/'>.
+
+B<Examples:>
+
+    print $store->mount;
+    # Returns: '/secret/'
+
+    print $store->default_mount;
+    # Returns: '/secret/'
+
+=head2 default_slug
+
+    my $slug = $store->default_slug;
+
+Derives the default path slug from the environment name and type.
+Dashes in the environment name are replaced with forward slashes, and the
+environment type is appended after a slash. Overrides the abstract method
+in L<Genesis::Env::Secrets::Store>.
+
+B<Returns:>
+
+A string such as C<'myorg/myenv/bosh'>.
+
+B<Examples:>
+
+    # For env name 'myorg-myenv', type 'bosh':
+    print $store->default_slug;
+    # Returns: 'myorg/myenv/bosh'
+
+=head2 slug
+
+    my $slug = $store->slug;
+
+Returns the active path slug for this store, normalised to have no leading
+or trailing slash. Uses C<slug_override> if set, otherwise falls back to
+C<default_slug>. The resolved value is cached after the first call.
+Overrides the abstract method in L<Genesis::Env::Secrets::Store>.
+
+B<Returns:>
+
+A string such as C<'myorg/myenv/bosh'>.
+
+B<Examples:>
+
+    print $store->slug;
+    # Returns: 'myorg/myenv/bosh'
+
+=head2 base
+
+    my $base = $store->base;
+
+Returns the base secrets path for this environment: C<mount() . slug() . '/'>.
+All secret paths for this environment are relative to this prefix.
+Overrides the base-class implementation in L<Genesis::Env::Secrets::Store>.
+
+B<Returns:>
+
+A string such as C<'/secret/myorg/myenv/bosh/'>.
+
+B<Examples:>
+
+    print $store->base;
+    # Returns: '/secret/myorg/myenv/bosh/'
+
+=head2 path
+
+    my $full_path = $store->path;
+    my $full_path = $store->path($subpath);
+
+Returns the fully qualified Vault path for an optional subpath within this
+store. The result is C<base() . $subpath> with any trailing slash stripped.
+When C<$subpath> is omitted or empty, returns C<base()> with its trailing
+slash removed. Overrides the base-class implementation in
+L<Genesis::Env::Secrets::Store>.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$subpath> (optional) - A relative secret path to append to
+C<base()>. May include a colon-separated key suffix (e.g.
+C<'certs/server:certificate'>).
+
+=back
+
+B<Returns:>
+
+A string such as C<'/secret/myorg/myenv/bosh/certs/server'>.
+
+B<Examples:>
+
+    print $store->path('certs/server');
+    # Returns: '/secret/myorg/myenv/bosh/certs/server'
+
+    print $store->path;
+    # Returns: '/secret/myorg/myenv/bosh'
+
+=head2 root_ca_path
+
+    my $path = $store->root_ca_path;
+
+Returns the Vault path to the root CA secret, normalised to begin with a
+C</> and have no trailing slash. Resolution order:
+
+=over 4
+
+=item 1. C<root_ca_override> passed to C<new>
+
+=item 2. The C<GENESIS_ROOT_CA_PATH> environment variable
+
+=item 3. An empty string (no root CA configured)
+
+=back
+
+The resolved value is cached after the first call.
+
+B<Returns:>
+
+A string such as C<'/secret/root-ca'>, or an empty string if no root CA
+path is configured.
+
+B<Examples:>
+
+    # With GENESIS_ROOT_CA_PATH=/secret/root-ca set in the environment:
+    print $store->root_ca_path;
+    # Returns: '/secret/root-ca'
+
+    # With no root CA configured:
+    print $store->root_ca_path;
+    # Returns: ''
+
+=head2 store_data
+
+    my $data = $store->store_data;
+
+Bulk-loads all secrets from Vault under C<base()> (and C<root_ca_path()> if
+configured) using C<safe export>. The raw JSON is decoded and cached; the
+same hash reference is returned on subsequent calls until C<clear_data> is
+called.
+
+The returned hash is keyed by absolute Vault path; values are hashes of
+key-value pairs at that path.
+
+B<Returns:>
+
+A hash reference mapping Vault paths to their key-value hashes. Returns an
+empty hash reference if no data was loaded.
+
+B<Examples:>
+
+    my $data = $store->store_data;
+    for my $path (sort keys %$data) {
+        print "$path\n";
+    }
+    # Returns: (prints one path per line)
+
+=head2 store_paths
+
+    my @paths = $store->store_paths;
+
+Returns the list of all Vault paths present in the cached store data. Calls
+C<store_data> to populate the cache if it has not been loaded yet.
+
+B<Returns:>
+
+A list of absolute Vault path strings.
+
+B<Examples:>
+
+    my @paths = $store->store_paths;
+    print scalar(@paths), " paths loaded\n";
+    # Returns: e.g. '42 paths loaded'
+
+=head2 clear_data
+
+    $store->clear_data;
+
+Discards the cached bulk store data loaded by C<store_data>. The next call
+to C<store_data>, C<store_paths>, C<paths>, or C<keys> will re-fetch from
+Vault.
+
+B<Returns:>
+
+The deleted cache value (the discarded hash reference), or C<undef> if the
+cache was not populated.
+
+B<Examples:>
+
+    $store->store_data;   # loads cache
+    $store->clear_data;   # discards cache
+    $store->store_data;   # re-fetches from Vault
+    # Returns: (cache is repopulated)
+
+=head2 paths
+
+    my @paths = $store->paths;
+
+Returns the Vault paths matching the given query paths. Accepts one or more
+absolute Vault path strings as arguments. If the store data cache is not
+loaded, delegates directly to C<< $store->service->paths(@_) >>.
+
+When the cache is loaded, paths that fall under C<base()> are resolved from
+the cache. Paths outside C<base()> are looked up live via the service.
+
+B<Returns:>
+
+A list of absolute Vault path strings matching the query.
+
+B<Examples:>
+
+    my @paths = $store->paths;
+    print scalar(@paths), " paths in store\n";
+    # Returns: e.g. '3 paths in store'
+
+=head2 keys
+
+    my @keys = $store->keys;
+
+Returns all keys present at the given Vault paths. Accepts one or more
+absolute Vault path strings as arguments. If the store data cache is not
+loaded, delegates directly to C<< $store->service->keys(@_) >>.
+
+When the cache is loaded, keys for paths under C<base()> are resolved from
+the cache. Keys for paths outside C<base()> are fetched live via the service.
+
+B<Returns:>
+
+A list of key name strings.
+
+B<Examples:>
+
+    my @keys = $store->keys;
+    print join(', ', @keys), "\n";
+    # Returns: e.g. 'certificate, key, ca'
+
+=head2 exists
+
+    my $bool = $store->exists($secret);
+
+Returns true if the secret exists in Vault by checking whether the expected
+key is present at the secret's full path. The path and key are split from
+C<< $secret->full_path >> on the first C<:>; if no key suffix is present,
+C<< $secret->default_key >> is used.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$secret> - A Genesis secret object providing C<full_path> and
+C<default_key> methods.
+
+=back
+
+B<Returns:>
+
+True (C<1>) if the key exists at the path, false otherwise.
+
+B<Examples:>
+
+    if ($store->exists($secret)) {
+        print "secret is present in Vault\n";
+    }
+    # Returns: (true or false depending on Vault state)
+
+=head2 read
+
+    my $secret = $store->read($secret);
+
+Reads the secret's value from Vault and loads it into the secret object.
+Constructs the Vault path from C<< $secret->path >> and C<< $secret->default_key >>.
+If a format path is supported by the secret (C<< $secret->can('format_path') >>),
+reads and sets the format value as well. Promotes the loaded value to stored
+state on the secret.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$secret> - A Genesis secret object whose value will be populated.
+
+=back
+
+B<Returns:>
+
+The C<$secret> object with its value set (or set to C<undef> if the path
+did not exist in Vault).
+
+B<Examples:>
+
+    my $secret = $store->read($secret_obj);
+    print defined($secret->value) ? 'loaded' : 'missing';
+    # Returns: 'loaded' or 'missing'
+
+=head2 write
+
+    my $secret = $store->write($secret);
+
+Writes the secret's value to Vault. The write strategy depends on the
+secret's path and value type:
+
+=over 4
+
+=item * If the path contains a colon (path:key form), sets the specific key
+and optionally writes a format value if the secret supports C<format_path>.
+
+=item * If the value is a hash reference, reconciles the stored keys --
+removing keys present in Vault but not in the new value -- and then sets
+each key-value pair.
+
+=item * Otherwise, stores the value under C<< $secret->default_key >> (or
+C<'value'> if no default key is defined).
+
+=back
+
+The bulk data cache is cleared after a successful write. The secret's stored
+state is promoted if the value field is set.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$secret> - A Genesis secret object whose value will be written to
+Vault.
+
+=back
+
+B<Returns:>
+
+The C<$secret> object.
+
+B<Examples:>
+
+    $store->write($secret);
+    # Returns: $secret (after writing its value to Vault)
+
+=head2 fill
+
+    $store->fill(@secrets);
+
+Bulk-populates a list of secret objects from the cached store data loaded
+by C<store_data>. For each secret, resolves the Vault path and optional key.
+If the path is present in the cache, sets the secret's value (and format
+value if applicable) and promotes it to stored state. Secrets whose paths
+are not in the cache are left unchanged.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<@secrets> - A list of Genesis secret objects to populate.
+
+=back
+
+B<Returns:>
+
+Nothing (returns C<undef> in scalar context).
+
+B<Examples:>
+
+    $store->fill(@all_secrets);
+    # Returns: undef (secrets with matching cache entries now have values set)
+
+=head2 empty
+
+    $store->empty(@secrets);
+
+Resets a list of secret objects to their un-loaded state by calling
+C<reset> on each one.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<@secrets> - A list of Genesis secret objects to reset.
+
+=back
+
+B<Returns:>
+
+Nothing (returns C<undef> in scalar context).
+
+B<Examples:>
+
+    $store->empty(@secrets);
+    # Returns: undef (all secrets are now in their initial, un-loaded state)
+
+=head2 check
+
+    my $ok = $store->check($secret);
+
+Checks whether a secret is present in the store. If the secret does not
+already have a value loaded (C<< $secret->has_value >> is false), fetches
+it via the delegated C<get> method on the service.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$secret> - A Genesis secret object to check.
+
+=back
+
+B<Returns:>
+
+The result of the C<get> call, or C<undef> if the secret already had a
+value loaded.
+
+B<Examples:>
+
+    my $ok = $store->check($secret);
+    print defined($ok) ? 'found' : 'skipped (already loaded)';
+    # Returns: 'found' or 'skipped (already loaded)'
+
+=head2 validate
+
+    my $result = $store->validate($secret);
+
+Validates a secret's stored value. If the secret does not already have a
+value loaded (C<< $secret->has_value >> is false), fetches it via the
+delegated C<get> method on the service before validating.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$secret> - A Genesis secret object to validate.
+
+=back
+
+B<Returns:>
+
+The result of C<< $secret->validate() >>.
+
+B<Examples:>
+
+    my $result = $store->validate($secret);
+    # Returns: the validation result from the secret object
+
+=head2 generate
+
+    $store->generate($secret);
+
+Not implemented for the Vault store backend. Always dies immediately.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$secret> - Accepted but ignored.
+
+=back
+
+B<Returns:>
+
+Never returns.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Generate not implemented for Vault store">
+
+=back
+
+B<Examples:>
+
+    eval { $store->generate($secret) };
+    print $@ if $@;
+    # Returns: 'Generate not implemented for Vault store at ...'
+
+=head2 regenerate
+
+    $store->regenerate;
+
+Not implemented for the Vault store backend. Always dies immediately.
+
+B<Returns:>
+
+Never returns.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Regenerate not implemented for Vault store">
+
+=item * C<"Remove not implemented for Vault store"> (from the C<remove> stub, which the extractor groups with C<regenerate>)
+
+=back
+
+B<Examples:>
+
+    eval { $store->regenerate };
+    print $@ if $@;
+    # Returns: 'Regenerate not implemented for Vault store at ...'
+
+    eval { $store->remove };
+    print $@ if $@;
+    # Returns: 'Remove not implemented for Vault store at ...'
+
+=head2 remove_all
+
+    $store->remove_all;
+
+Not implemented for the Vault store backend. Always dies immediately.
+
+B<Returns:>
+
+Never returns.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Remove_all not implemented for Vault store">
+
+=back
+
+B<Examples:>
+
+    eval { $store->remove_all };
+    print $@ if $@;
+    # Returns: 'Remove_all not implemented for Vault store at ...'
+
+=head1 SEE ALSO
+
+L<Genesis::Env::Secrets::Store> - The abstract base class this module implements.
+
+=head1 SEE ALSO
+
+L<Genesis::Env::Secrets::Store>,
+L<Genesis::Env::Secrets::Plan>,
+L<Genesis::Env>
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut


### PR DESCRIPTION
## Summary

- Add 7 companion `.pod` files for the `Genesis::Env::Secrets` subsystem (Store, Store::Vault, Plan, Parser, FromKit, FromManifest, _legacy_cf_support_mixin)
- All 737 mechanical validation checks pass across all modules
- Resolve 10 of 13 reviewer demerits identified during documentation review (remaining 3 are code defects tracked in [FWT-680](https://fivetwenty.atlassian.net/browse/FWT-680))

## Details

POD covers public API, internal methods, parameters, return values, error messages, and usage examples for each module. Demerits fixed include:

- **Vault.pod**: namespace typo in error messages, `service` accessor extraction, `paths`/`keys` zero-arg docs, AUTOLOAD delegation note, `remove` section
- **Store.pod**: `provide()` updated per FWT-679 (`Vault->new()` not `Vault->provide()`), `bug()` on unrecognized type, SYNOPSIS param names
- **Plan.pod**: rotate→regenerate_secrets wording, `notify` caller docs, `_next_x509_signer` marked internal

## Test plan

- [x] `pod-validate` passes for all 7 modules (737 checks, 0 failures)
- [ ] Visual review of rendered POD (`perldoc` or `pod2html`)
- [ ] Confirm no `.pm` files were modified (POD-only changes)