### PR TITLE
POD: Genesis::Log, Genesis::Term, Genesis::UI

### DIFF
--- a/lib/Genesis/Log.pod
+++ b/lib/Genesis/Log.pod
@@ -56,10 +56,11 @@ Targets may be the terminal (referred to as C<'E<lt>terminalE<gt>'>) or
 named log files. Each target has its own level filter, output style,
 timestamp setting, and other options.
 
-Log output is formatted in one of four styles: C<pointer> (the default
-terminal style with colored level arrows), C<plain> (bracketed level
-labels), C<fun> (emoji-prefixed labels), and C<rfc-5424> (syslog-compliant
-structured format).
+Log output is formatted in one of four styles: C<pointer> (colored level
+arrows), C<plain> (bracketed level labels), C<fun> (emoji-prefixed labels),
+and C<rfc-5424> (syslog-compliant structured format). The active style is
+determined by the C<GENESIS_LOG_STYLE> environment variable if set, otherwise
+the RC config C<output_style> setting (which defaults to C<plain>).
 
 The module is used as a singleton -- C<new()> returns the existing instance
 if one has already been created. Normal callers use the exported C<$Logger>
@@ -253,7 +254,7 @@ path. The following variables are recognized:
 if not set
 
 =item * C<{timestamp}> -- replaced with a UTC timestamp in the form
-C<YYYYMMDDTHHMMSSsss.mmmZ>
+C<YYYYMMDDTHHMMSS.mmmZ>
 
 =item * C<{date}> -- replaced with the UTC date as C<YYYYMMDD>
 
@@ -341,7 +342,7 @@ B<Returns:> The style string for the target.
 B<Examples:>
 
   my $s = $logger->style;
-  print $s;  # Returns: 'pointer' (the default)
+  print $s;  # Returns: 'plain' (the default)
 
   my $file_style = $logger->style('/var/log/genesis.log');
   print $file_style;  # Returns: 'plain'

--- a/lib/Genesis/Log.pod
+++ b/lib/Genesis/Log.pod
@@ -434,13 +434,39 @@ B<Examples:>
   $logger->output($format, @args);
 
 Emits a log entry using the given format string and arguments. This method
-is the basis for all the per-level logging shortcut methods. Each shortcut
-delegates to the internal C<_log> method with the corresponding level name
-and style definition from C<log_styles>.
+is the basis for all the per-level logging shortcut methods listed below.
 
 C<$format> is a C<sprintf>-style format string. If only one argument is
 given it is treated as a literal string (a C<"%s"> format is prepended
 automatically).
+
+The following shortcut methods are all defined in the same way; each
+delegates to the internal C<_log> method with the corresponding level name
+and style definition from C<log_styles>:
+
+=over 4
+
+=item * C<output> -- level C<OUTPUT>; goes to STDOUT on terminal, no prefix/colors
+
+=item * C<info> -- level C<INFO>; goes to STDERR; no prefix/colors on terminal
+
+=item * C<debug> -- level C<DEBUG>; visible at C<DEBUG> or C<TRACE> threshold
+
+=item * C<notice> -- level C<NOTICE>
+
+=item * C<warning> -- level C<WARNING>
+
+=item * C<error> -- level C<ERROR>
+
+=item * C<fatal> -- level C<FATAL>; does not terminate the process on its own
+
+=item * C<trace> -- level C<TRACE>; automatically appends current call location
+(C<show_stack> is C<'current'> for this style)
+
+=item * C<qtrace> -- level C<TRACE>; like C<trace> but without the automatic
+stack annotation
+
+=back
 
 C<output>-level messages go to STDOUT on the terminal; all other levels go
 to STDERR.
@@ -452,117 +478,40 @@ B<Examples:>
   $logger->output("Deployment complete.\n");
   # Returns: nothing (prints to STDOUT)
 
-=head2 info
-
-  $logger->info($message);
-  $logger->info($format, @args);
-
-Shortcut for logging at INFO level. See L</output>.
-
-B<Examples:>
-
   $logger->info("Environment %s is ready\n", $env_name);
   # Returns: nothing (prints to STDERR)
-
-=head2 debug
-
-  $logger->debug($message);
-  $logger->debug($format, @args);
-
-Shortcut for logging at DEBUG level. See L</output>. Visible only when the
-terminal target is at C<DEBUG> or C<TRACE> threshold.
-
-B<Examples:>
 
   $logger->debug("Vault path resolved to: %s", $path);
   # Returns: nothing (printed only if terminal is at DEBUG or TRACE level)
 
-=head2 notice
-
-  $logger->notice($message);
-  $logger->notice($format, @args);
-
-Shortcut for logging at NOTICE level. See L</output>.
-
-=head2 warning
-
-  $logger->warning($message);
-  $logger->warning($format, @args);
-
-Shortcut for logging at WARNING level. See L</output>.
-
-B<Examples:>
-
   $logger->warning("Certificate expires in %d days", $days);
   # Returns: nothing (prints to STDERR)
-
-=head2 error
-
-  $logger->error($message);
-  $logger->error($format, @args);
-
-Shortcut for logging at ERROR level. See L</output>.
-
-B<Examples:>
 
   $logger->error("Could not connect to vault at %s", $url);
   # Returns: nothing (prints to STDERR)
 
-=head2 fatal
-
-  $logger->fatal($message);
-  $logger->fatal($format, @args);
-
-Shortcut for logging at FATAL level. See L</output>. Does not terminate
-the process on its own; the caller must exit.
-
-B<Examples:>
-
   $logger->fatal("Unrecoverable error: %s", $msg);
   # Returns: nothing (prints to STDERR; caller must exit)
-
-=head2 trace
-
-  $logger->trace($message);
-  $logger->trace($format, @args);
-
-Shortcut for logging at TRACE level. See L</output>. Automatically appends
-the current call location (C<show_stack> is C<'current'> for this style).
-
-B<Examples:>
 
   $logger->trace("Entering %s with args: %s", $method, join(', ', @args));
   # Returns: nothing (prints to STDERR with call location appended)
 
-=head2 qtrace
-
-  $logger->qtrace($message);
-  $logger->qtrace($format, @args);
-
-Shortcut for logging at TRACE level without the automatic stack annotation.
-See L</output>.
-
-B<Examples:>
-
   $logger->qtrace("Loop iteration %d: value=%s", $i, $val);
   # Returns: nothing (prints to STDERR at TRACE level, no location appended)
 
-=head2 dump_var
+In addition to the shortcut methods above, the C<output> code block in the
+source also defines C<dump_var>:
 
   $logger->dump_var(%vars);
   $logger->dump_var(\%options, %vars);
   $logger->dump_var($scope_offset, %vars);
 
-Dumps one or more named variables to the log at C<VALUE> level using
-Data::Dumper. Each key/value pair in C<%vars> produces a separate log
-entry formatted as C<name = value>. An optional leading hashref
-C<\%options> is merged into the log entry options. An optional leading
-integer C<$scope_offset> (absolute value used) adjusts the stack depth
-for scope reporting.
-
-B<Returns:> Nothing.
-
-B<Examples:>
+C<dump_var> dumps one or more named variables to the log at C<VALUE> level
+using Data::Dumper. Each key/value pair in C<%vars> produces a separate log
+entry formatted as C<name = value>. An optional leading hashref C<\%options>
+is merged into the log entry options. An optional leading integer
+C<$scope_offset> (absolute value used) adjusts the stack depth for scope
+reporting. Returns nothing.
 
   $logger->dump_var(my_hash => \%config, my_list => \@items);
   # Returns: nothing (prints each variable's Data::Dumper output to STDERR)

--- a/lib/Genesis/Log.pod
+++ b/lib/Genesis/Log.pod
@@ -434,39 +434,13 @@ B<Examples:>
   $logger->output($format, @args);
 
 Emits a log entry using the given format string and arguments. This method
-is the basis for all the per-level logging shortcut methods listed below.
+is the basis for all the per-level logging shortcut methods. Each shortcut
+delegates to the internal C<_log> method with the corresponding level name
+and style definition from C<log_styles>.
 
 C<$format> is a C<sprintf>-style format string. If only one argument is
 given it is treated as a literal string (a C<"%s"> format is prepended
 automatically).
-
-The following shortcut methods are all defined in the same way; each
-delegates to the internal C<_log> method with the corresponding level name
-and style definition from C<log_styles>:
-
-=over 4
-
-=item * C<output> -- level C<OUTPUT>; goes to STDOUT on terminal, no prefix/colors
-
-=item * C<info> -- level C<INFO>; goes to STDERR; no prefix/colors on terminal
-
-=item * C<debug> -- level C<DEBUG>; visible at C<DEBUG> or C<TRACE> threshold
-
-=item * C<notice> -- level C<NOTICE>
-
-=item * C<warning> -- level C<WARNING>
-
-=item * C<error> -- level C<ERROR>
-
-=item * C<fatal> -- level C<FATAL>; does not terminate the process on its own
-
-=item * C<trace> -- level C<TRACE>; automatically appends current call location
-(C<show_stack> is C<'current'> for this style)
-
-=item * C<qtrace> -- level C<TRACE>; like C<trace> but without the automatic
-stack annotation
-
-=back
 
 C<output>-level messages go to STDOUT on the terminal; all other levels go
 to STDERR.
@@ -478,40 +452,117 @@ B<Examples:>
   $logger->output("Deployment complete.\n");
   # Returns: nothing (prints to STDOUT)
 
+=head2 info
+
+  $logger->info($message);
+  $logger->info($format, @args);
+
+Shortcut for logging at INFO level. See L</output>.
+
+B<Examples:>
+
   $logger->info("Environment %s is ready\n", $env_name);
   # Returns: nothing (prints to STDERR)
+
+=head2 debug
+
+  $logger->debug($message);
+  $logger->debug($format, @args);
+
+Shortcut for logging at DEBUG level. See L</output>. Visible only when the
+terminal target is at C<DEBUG> or C<TRACE> threshold.
+
+B<Examples:>
 
   $logger->debug("Vault path resolved to: %s", $path);
   # Returns: nothing (printed only if terminal is at DEBUG or TRACE level)
 
+=head2 notice
+
+  $logger->notice($message);
+  $logger->notice($format, @args);
+
+Shortcut for logging at NOTICE level. See L</output>.
+
+=head2 warning
+
+  $logger->warning($message);
+  $logger->warning($format, @args);
+
+Shortcut for logging at WARNING level. See L</output>.
+
+B<Examples:>
+
   $logger->warning("Certificate expires in %d days", $days);
   # Returns: nothing (prints to STDERR)
+
+=head2 error
+
+  $logger->error($message);
+  $logger->error($format, @args);
+
+Shortcut for logging at ERROR level. See L</output>.
+
+B<Examples:>
 
   $logger->error("Could not connect to vault at %s", $url);
   # Returns: nothing (prints to STDERR)
 
+=head2 fatal
+
+  $logger->fatal($message);
+  $logger->fatal($format, @args);
+
+Shortcut for logging at FATAL level. See L</output>. Does not terminate
+the process on its own; the caller must exit.
+
+B<Examples:>
+
   $logger->fatal("Unrecoverable error: %s", $msg);
   # Returns: nothing (prints to STDERR; caller must exit)
+
+=head2 trace
+
+  $logger->trace($message);
+  $logger->trace($format, @args);
+
+Shortcut for logging at TRACE level. See L</output>. Automatically appends
+the current call location (C<show_stack> is C<'current'> for this style).
+
+B<Examples:>
 
   $logger->trace("Entering %s with args: %s", $method, join(', ', @args));
   # Returns: nothing (prints to STDERR with call location appended)
 
+=head2 qtrace
+
+  $logger->qtrace($message);
+  $logger->qtrace($format, @args);
+
+Shortcut for logging at TRACE level without the automatic stack annotation.
+See L</output>.
+
+B<Examples:>
+
   $logger->qtrace("Loop iteration %d: value=%s", $i, $val);
   # Returns: nothing (prints to STDERR at TRACE level, no location appended)
 
-In addition to the shortcut methods above, the C<output> code block in the
-source also defines C<dump_var>:
+=head2 dump_var
 
   $logger->dump_var(%vars);
   $logger->dump_var(\%options, %vars);
   $logger->dump_var($scope_offset, %vars);
 
-C<dump_var> dumps one or more named variables to the log at C<VALUE> level
-using Data::Dumper. Each key/value pair in C<%vars> produces a separate log
-entry formatted as C<name = value>. An optional leading hashref C<\%options>
-is merged into the log entry options. An optional leading integer
-C<$scope_offset> (absolute value used) adjusts the stack depth for scope
-reporting. Returns nothing.
+Dumps one or more named variables to the log at C<VALUE> level using
+Data::Dumper. Each key/value pair in C<%vars> produces a separate log
+entry formatted as C<name = value>. An optional leading hashref
+C<\%options> is merged into the log entry options. An optional leading
+integer C<$scope_offset> (absolute value used) adjusts the stack depth
+for scope reporting.
+
+B<Returns:> Nothing.
+
+B<Examples:>
 
   $logger->dump_var(my_hash => \%config, my_list => \@items);
   # Returns: nothing (prints each variable's Data::Dumper output to STDERR)
@@ -562,6 +613,7 @@ B<Examples:>
 
   $logger->flush_logs;
 
+Normally called automatically by C<_log> after each log entry; rarely called directly.
 Flushes all buffered log entries to every configured target. Entries are
 filtered by each target's level before being written. Re-entrant calls
 return immediately (guarded by an internal C<$flushing> flag).
@@ -590,7 +642,6 @@ B<Returns:> Nothing.
 
 B<Examples:>
 
-  # Normally called automatically by _log; rarely called directly.
   $logger->flush_logs;
   # Returns: nothing (flushes buffered entries to all targets)
 
@@ -669,6 +720,8 @@ C<_get_stack>, a private function that does not exist in this module. The
 public equivalent C<get_stack> exists and is the intended callee. As a
 result, C<get_scope> will raise a runtime error when called. This defect
 is tracked for a future fix.
+
+Until this is resolved, callers should use C<get_stack> directly.
 
 B<Parameters:>
 

--- a/lib/Genesis/Log.pod
+++ b/lib/Genesis/Log.pod
@@ -1,0 +1,885 @@
+=encoding utf8
+
+=head1 NAME
+
+Genesis::Log - Genesis logging subsystem providing structured, leveled, multi-target output
+
+=head1 SYNOPSIS
+
+  use Genesis::Log;
+
+  # Access the singleton logger (created on first use)
+  my $logger = Genesis::Log->new;
+
+  # Configure the terminal output
+  $logger->configure_log(level => 'DEBUG');
+
+  # Configure a log file
+  $logger->configure_log('/var/log/genesis/run.log', level => 'TRACE', timestamp => 1);
+
+  # Configure log files from a config array (typically from genesis.conf)
+  Genesis::Log->setup_from_configs([
+    { file => '{env}/{command}/{timestamp}.log', path => '~/.genesis/logs', level => 'TRACE' },
+  ]);
+
+  # Emit log messages at various levels
+  $logger->info("Deploying environment %s", $env_name);
+  $logger->debug("Vault path: %s", $vault_path);
+  $logger->warning("Certificate expires in %d days", $days);
+  $logger->error("Failed to connect to %s", $target);
+
+  # Dump a variable for debugging
+  $logger->dump_var({ offset => 1 }, my_var => $some_value);
+
+  # Dump the current call stack
+  $logger->dump_stack();
+
+  # Check whether a level is active on a log target
+  if ($logger->is_logging('DEBUG')) {
+    $logger->debug("Expensive debug detail: %s", expensive_call());
+  }
+
+  # Access the exported singleton and helpers
+  $Logger->info("Using the exported singleton");
+  my $valid_level = find_log_level('trac');  # Returns 'TRACE'
+  my $ok = meets_level('DEBUG', 'INFO');     # Returns true (1)
+
+=head1 DESCRIPTION
+
+C<Genesis::Log> provides the entire logging infrastructure for the Genesis
+CLI. All Genesis output -- informational messages, debug traces, warnings,
+errors, and structured diagnostics -- flows through this module.
+
+The module maintains a single global logger singleton (C<$Logger>) that
+buffers log entries and flushes them to one or more configured targets.
+Targets may be the terminal (referred to as C<'E<lt>terminalE<gt>'>) or
+named log files. Each target has its own level filter, output style,
+timestamp setting, and other options.
+
+Log output is formatted in one of four styles: C<pointer> (the default
+terminal style with colored level arrows), C<plain> (bracketed level
+labels), C<fun> (emoji-prefixed labels), and C<rfc-5424> (syslog-compliant
+structured format).
+
+The module is used as a singleton -- C<new()> returns the existing instance
+if one has already been created. Normal callers use the exported C<$Logger>
+variable rather than constructing instances directly.
+
+Exported symbols (via C<use Genesis::Log>):
+
+=over 4
+
+=item * C<$Logger> -- the global logger singleton
+
+=item * C<find_log_level> -- resolve and validate a log level string
+
+=item * C<meets_level> -- test whether a level meets or exceeds a threshold
+
+=item * C<get_stack> -- capture the current call stack as an array of frames
+
+=item * C<get_scope> -- format the current call location as a display string
+
+=item * C<log_levels> -- return the list of valid log level names
+
+=item * C<log_styles> -- return the style definition hash for a named style
+
+=back
+
+=head1 METHODS
+
+=head2 new
+
+  my $logger = Genesis::Log->new;
+
+Returns the global logger singleton, creating it if it does not yet exist.
+Subsequent calls return the same instance. On creation, the logger captures
+the current username (via C<whoami>), hostname (via C<hostname>), and PID.
+
+If C<$Genesis::VERSION> equals C<"(development)">, the version stored in the
+logger is set to C<"0.0.0-rc.0">; otherwise the actual C<$Genesis::VERSION>
+string is used.
+
+B<Returns:> The C<Genesis::Log> singleton blessed object, stored in
+C<$Genesis::Log::Logger>.
+
+B<Examples:>
+
+  my $logger = Genesis::Log->new;
+  print ref($logger);  # Returns: 'Genesis::Log'
+
+  # A second call returns the same object
+  my $same = Genesis::Log->new;
+  print($logger == $same ? 'same' : 'different');  # Returns: 'same'
+
+=head2 configure_log
+
+  $logger->configure_log();
+  $logger->configure_log(%options);
+  $logger->configure_log($log_path, %options);
+
+Configures a log target. If C<$log_path> is omitted, the target is the
+terminal (C<'E<lt>terminalE<gt>'>). If C<$log_path> contains template
+variables (C<{command}>, C<{timestamp}>, C<{date}>, C<{time}>, C<{pid}>,
+or C<{env}>), the path is stored as a template and the actual log file is
+created on first flush via C<expand_log_template>.
+
+When configuring a file target, if the target directory does not exist it
+is created automatically and a notice is printed to STDERR.
+
+If the target has not been configured before, it is initialized with these
+defaults:
+
+=over 4
+
+=item * C<level> -- C<ERROR> if C<$QUIET> is set, C<TRACE> if
+C<$GENESIS_TRACE> is set, C<DEBUG> if C<$GENESIS_DEBUG> is set, otherwise
+C<INFO>
+
+=item * C<show_stack> -- C<'none'>
+
+=item * C<timestamp> -- C<0> for the terminal, C<1> for file targets
+
+=item * C<style> -- value of C<$GENESIS_LOG_STYLE> if set, otherwise the
+C<output_style> from the Genesis RC file (defaulting to C<'plain'>)
+
+=back
+
+Accepted options:
+
+=over 4
+
+=item * C<level> -- log level string; passed through C<find_log_level> for
+validation and normalization
+
+=item * C<show_stack> -- stack display mode: C<'none'>, C<'current'>,
+C<'full'>, or C<'fatal'>
+
+=item * C<timestamp> -- boolean; prefix each entry with an ISO-8601 timestamp
+
+=item * C<truncate> -- if true, sets the log's starting entry to the current
+buffer position, discarding older buffered content for this target
+
+=item * C<style> -- output style: C<'pointer'>, C<'plain'>, C<'fun'>, or
+C<'rfc-5424'>
+
+=item * C<no_color> -- if defined, overrides C<$NOCOLOR> for this target
+
+=item * C<no_utf8> -- if defined, overrides C<$GENESIS_NO_UTF8> for this
+target
+
+=item * C<lifespan> -- if C<'current'>, truncates the log file to zero bytes
+when the log is first configured (only for file targets outside of callbacks)
+
+=item * C<skip_commands> -- arrayref of Genesis command names that should not
+produce a log file for this template; the C<'help'> command is always added
+to this list automatically
+
+=back
+
+B<Returns:> C<$self>, for chaining.
+
+B<Examples:>
+
+  # Configure terminal to show DEBUG and above
+  $logger->configure_log(level => 'DEBUG');
+  # Returns: $logger
+
+  # Configure a log file with timestamps and full stack on FATAL
+  $logger->configure_log('/var/log/genesis.log',
+    level      => 'TRACE',
+    timestamp  => 1,
+    show_stack => 'fatal',
+  );
+  # Returns: $logger
+
+=head2 setup_from_configs
+
+  Genesis::Log->setup_from_configs(\@log_configs);
+
+Class method. Configures one or more log targets from an array of
+configuration hashrefs, as typically loaded from a C<genesis.conf> C<logs>
+block.
+
+Each hashref may contain:
+
+=over 4
+
+=item * C<path> -- base directory for the log file (expanded via
+Genesis::expand_path)
+
+=item * C<file> -- filename or template relative to C<path>; if C<path> is
+given but C<file> is omitted, the default template
+C<{env}/{command}/{timestamp}.log> is used; if neither is given, defaults
+to C<~/.genesis/last-trace>
+
+=item * Any option accepted by C<configure_log> (e.g., C<level>,
+C<timestamp>, C<style>)
+
+=back
+
+When both C<path> and C<file> are present, they are combined into an
+absolute path. The C<path> and C<file> keys are removed before the
+remaining options are passed to C<configure_log>.
+
+B<Returns:> Nothing (returns implicitly after configuring all targets).
+
+B<Errors:>
+
+Calls Genesis::bail with C<"Configuration error - logs entry must be an array">
+if C<\@log_configs> is not an array reference.
+
+B<Examples:>
+
+  Genesis::Log->setup_from_configs([
+    {
+      path      => '~/.genesis/logs',
+      file      => '{env}/{command}/{timestamp}.log',
+      level     => 'TRACE',
+      timestamp => 1,
+    },
+  ]);
+  # Returns: nothing (configures logger as a side effect)
+
+=head2 expand_log_template
+
+  my $path = $logger->expand_log_template($template);
+
+Expands template variables in C<$template> to produce a concrete log file
+path. The following variables are recognized:
+
+=over 4
+
+=item * C<{command}> -- replaced with C<$GENESIS_COMMAND>, or C<'unknown'>
+if not set
+
+=item * C<{timestamp}> -- replaced with a UTC timestamp in the form
+C<YYYYMMDDTHHMMSSsss.mmmZ>
+
+=item * C<{date}> -- replaced with the UTC date as C<YYYYMMDD>
+
+=item * C<{time}> -- replaced with the UTC time as C<HHMMSS>
+
+=item * C<{pid}> -- replaced with the current process ID
+
+=item * C<{env}> -- replaced with C<$GENESIS_ENVIRONMENT>; if that variable
+is not set, the C<{env}> component and any surrounding path separators are
+removed to avoid double slashes in the resulting path
+
+=back
+
+Any resulting double slashes are collapsed to a single slash.
+
+B<Returns:> The expanded path string.
+
+B<Examples:>
+
+  # With GENESIS_ENVIRONMENT=prod and GENESIS_COMMAND=deploy set:
+  my $path = $logger->expand_log_template(
+    '~/.genesis/logs/{env}/{command}/{timestamp}.log'
+  );
+  # Returns: '~/.genesis/logs/prod/deploy/20240101T120000000.123Z.log'
+
+  # Without GENESIS_ENVIRONMENT set, the {env}/ component is dropped:
+  my $path2 = $logger->expand_log_template(
+    '~/.genesis/logs/{env}/{command}/{timestamp}.log'
+  );
+  # Returns: '~/.genesis/logs/deploy/20240101T120000000.123Z.log'
+
+=head2 is_logging
+
+  my $bool = $logger->is_logging($level [, $log_path]);
+
+Returns true if the given C<$level> meets or exceeds the configured level
+for C<$log_path>. If C<$log_path> is omitted, the terminal target
+(C<'E<lt>terminalE<gt>'>) is checked.
+
+Returns false (C<0>) if the target has not been configured or has no level
+set.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$level> -- the log level name to test (e.g., C<'DEBUG'>, C<'TRACE'>)
+
+=item * C<$log_path> -- optional; the log target path to check; defaults to
+C<'E<lt>terminalE<gt>'>
+
+=back
+
+B<Returns:> Boolean (true or C<0>).
+
+B<Examples:>
+
+  if ($logger->is_logging('DEBUG')) {
+    $logger->debug("Expensive detail: %s", compute());
+  }
+  # Returns: 1 if DEBUG is enabled on the terminal, 0 otherwise
+
+  if ($logger->is_logging('TRACE', '/var/log/genesis.log')) {
+    $logger->trace("Trace output also going to file");
+  }
+  # Returns: 1 if TRACE is enabled on the file target, 0 otherwise
+
+=head2 style
+
+  my $style = $logger->style;
+  my $style = $logger->style($log_path);
+
+Returns the output style string for the given log target. If C<$log_path>
+is omitted, the terminal target (C<'E<lt>terminalE<gt>'>) is used.
+
+Valid style values are C<'pointer'>, C<'plain'>, C<'fun'>, and C<'rfc-5424'>.
+
+B<Errors:>
+
+Dies with C<"invalid log: $log\n"> if the target C<$log_path> has not been
+configured.
+
+B<Returns:> The style string for the target.
+
+B<Examples:>
+
+  my $s = $logger->style;
+  print $s;  # Returns: 'pointer' (the default)
+
+  my $file_style = $logger->style('/var/log/genesis.log');
+  print $file_style;  # Returns: 'plain'
+
+=head2 set_level
+
+  $logger->set_level($level [, $log_path]);
+
+Sets the minimum log level for the given target. If C<$log_path> is
+omitted, the terminal target (C<'E<lt>terminalE<gt>'>) is updated. The
+level string is passed through C<find_log_level> for validation and
+normalization before being stored.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$level> -- the new log level name (e.g., C<'DEBUG'>, C<'TRACE'>)
+
+=item * C<$log_path> -- optional; the log target path to update; defaults to
+C<'E<lt>terminalE<gt>'>
+
+=back
+
+B<Errors:>
+
+Dies with C<"invalid log: $log\n"> if the target C<$log_path> has not been
+configured.
+
+B<Returns:> C<$self>, for chaining.
+
+B<Examples:>
+
+  $logger->set_level('DEBUG');
+  # Returns: $logger (terminal level set to DEBUG)
+
+  $logger->set_level('TRACE', '/var/log/genesis.log');
+  # Returns: $logger (file target level set to TRACE)
+
+  $logger->set_level('INFO')->configure_log(timestamp => 1);
+  # Returns: $logger (chained calls)
+
+=head2 log_styles
+
+  my $style_def = log_styles($style_name);
+
+Returns the style definition hashref for the named log style, or C<undef>
+if the name is not recognized. This is a package-level function exported
+as C<log_styles>.
+
+The returned hashref may contain the following keys:
+
+=over 4
+
+=item * C<colors> -- a two-character color code string used for formatting
+(background and foreground)
+
+=item * C<pri> -- numeric syslog-style priority for use in C<rfc-5424> output
+
+=item * C<emoji> -- emoji name string for use in C<fun> output style
+
+=item * C<show_stack> -- stack display mode for this style (e.g., C<'current'>
+for C<trace>)
+
+=item * C<show_scope> -- scope display mode (e.g., C<'current'> for C<dumpvar>)
+
+=item * C<raw> -- if true, output is not wrapped at the terminal width
+
+=back
+
+Recognized style names: C<output>, C<info>, C<debug>, C<warning>,
+C<notice>, C<error>, C<fatal>, C<trace>, C<qtrace>, C<dumpvar>,
+C<dumpstack>.
+
+B<Returns:> A hashref of style attributes, or C<undef> for unrecognized names.
+
+B<Examples:>
+
+  my $def = log_styles('error');
+  print $def->{colors};  # Returns: 'RW'
+  print $def->{emoji};   # Returns: 'collision'
+
+  my $undef = log_styles('bogus');
+  print defined($undef) ? 'defined' : 'undef';  # Returns: 'undef'
+
+=head2 output
+
+  $logger->output();
+  $logger->output($message);
+  $logger->output($format, @args);
+
+Emits a log entry using the given format string and arguments. This method
+is the basis for all the per-level logging shortcut methods listed below.
+
+C<$format> is a C<sprintf>-style format string. If only one argument is
+given it is treated as a literal string (a C<"%s"> format is prepended
+automatically).
+
+The following shortcut methods are all defined in the same way; each
+delegates to the internal C<_log> method with the corresponding level name
+and style definition from C<log_styles>:
+
+=over 4
+
+=item * C<output> -- level C<OUTPUT>; goes to STDOUT on terminal, no prefix/colors
+
+=item * C<info> -- level C<INFO>; goes to STDERR; no prefix/colors on terminal
+
+=item * C<debug> -- level C<DEBUG>; visible at C<DEBUG> or C<TRACE> threshold
+
+=item * C<notice> -- level C<NOTICE>
+
+=item * C<warning> -- level C<WARNING>
+
+=item * C<error> -- level C<ERROR>
+
+=item * C<fatal> -- level C<FATAL>; does not terminate the process on its own
+
+=item * C<trace> -- level C<TRACE>; automatically appends current call location
+(C<show_stack> is C<'current'> for this style)
+
+=item * C<qtrace> -- level C<TRACE>; like C<trace> but without the automatic
+stack annotation
+
+=back
+
+C<output>-level messages go to STDOUT on the terminal; all other levels go
+to STDERR.
+
+B<Returns:> Nothing.
+
+B<Examples:>
+
+  $logger->output("Deployment complete.\n");
+  # Returns: nothing (prints to STDOUT)
+
+  $logger->info("Environment %s is ready\n", $env_name);
+  # Returns: nothing (prints to STDERR)
+
+  $logger->debug("Vault path resolved to: %s", $path);
+  # Returns: nothing (printed only if terminal is at DEBUG or TRACE level)
+
+  $logger->warning("Certificate expires in %d days", $days);
+  # Returns: nothing (prints to STDERR)
+
+  $logger->error("Could not connect to vault at %s", $url);
+  # Returns: nothing (prints to STDERR)
+
+  $logger->fatal("Unrecoverable error: %s", $msg);
+  # Returns: nothing (prints to STDERR; caller must exit)
+
+  $logger->trace("Entering %s with args: %s", $method, join(', ', @args));
+  # Returns: nothing (prints to STDERR with call location appended)
+
+  $logger->qtrace("Loop iteration %d: value=%s", $i, $val);
+  # Returns: nothing (prints to STDERR at TRACE level, no location appended)
+
+In addition to the shortcut methods above, the C<output> code block in the
+source also defines C<dump_var>:
+
+  $logger->dump_var(%vars);
+  $logger->dump_var(\%options, %vars);
+  $logger->dump_var($scope_offset, %vars);
+
+C<dump_var> dumps one or more named variables to the log at C<VALUE> level
+using Data::Dumper. Each key/value pair in C<%vars> produces a separate log
+entry formatted as C<name = value>. An optional leading hashref C<\%options>
+is merged into the log entry options. An optional leading integer
+C<$scope_offset> (absolute value used) adjusts the stack depth for scope
+reporting. Returns nothing.
+
+  $logger->dump_var(my_hash => \%config, my_list => \@items);
+  # Returns: nothing (prints each variable's Data::Dumper output to STDERR)
+
+  $logger->dump_var(1, result => $value);
+  # Returns: nothing (scope offset shifted up one level)
+
+=head2 dump_stack
+
+  $logger->dump_stack;
+  $logger->dump_stack(\%options);
+  $logger->dump_stack($scope_offset);
+
+Captures the current call stack and emits it at C<STACK> level as a
+formatted table showing line number, subroutine name, and file for each
+frame. Column widths are auto-sized to the longest value in each column.
+
+An optional leading hashref C<\%options> (C<$more_options>) is merged into
+the log entry options. An optional leading integer C<$scope_offset> adjusts
+the starting depth of the stack capture.
+
+A blank line is printed to STDERR before the table to ensure the header
+aligns correctly.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<\%options> (C<$more_options>) -- optional hashref of log entry
+options (e.g., C<offset>); may be given multiple times and they are merged
+
+=item * C<$scope_offset> -- optional integer; number of additional frames to
+skip from the capture starting point
+
+=back
+
+B<Returns:> Nothing.
+
+B<Examples:>
+
+  $logger->dump_stack;
+  # Returns: nothing (prints stack table to STDERR)
+
+  $logger->dump_stack(1);
+  # Returns: nothing (skips one extra frame)
+
+=head2 flush_logs
+
+  $logger->flush_logs;
+
+Flushes all buffered log entries to every configured target. Entries are
+filtered by each target's level before being written. Re-entrant calls
+return immediately (guarded by an internal C<$flushing> flag).
+
+Before flushing entries, any pending log templates are resolved to actual
+file paths via C<expand_log_template> and then configured. Templates whose
+C<skip_commands> list matches the current C<$GENESIS_COMMAND> are marked as
+C<'E<lt>skippedE<gt>'> and no file is created.
+
+For file targets, if C<$GENESIS_FULL_CALL> is set and the file is newly
+created (zero bytes), the full command line is prepended as
+C<"Command: $GENESIS_FULL_CALL\n\n">.
+
+Output style is applied per target: C<pointer>, C<plain>, C<fun>, or
+C<rfc-5424>. Stack frames are appended when the entry's C<show_stack>
+setting (or the target's C<show_stack> setting) indicates C<'current'>
+or C<'full'>.
+
+B<Errors:>
+
+Dies with C<"Could not open $log for writing logs: $!\n"> if a file target
+cannot be opened for appending (where C<$log> is the file path and C<$!>
+is the OS error message).
+
+B<Returns:> Nothing.
+
+B<Examples:>
+
+  # Normally called automatically by _log; rarely called directly.
+  $logger->flush_logs;
+  # Returns: nothing (flushes buffered entries to all targets)
+
+=head2 replay
+
+  $logger->replay($level [, $log_path]);
+
+Replays all buffered log entries through the given target by resetting its
+read position to the beginning of the buffer and calling C<flush_logs>.
+
+If C<$level> is provided, the target's log level is temporarily changed to
+C<$level> for the duration of the replay, then restored to its original
+value afterward.
+
+If C<$log_path> is omitted, the terminal (C<'E<lt>terminalE<gt>'>) is
+replayed.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$level> -- optional; the log level to use during replay; pass
+C<undef> to replay at the currently configured level
+
+=item * C<$log_path> -- optional; the log target to replay; defaults to
+C<'E<lt>terminalE<gt>'>
+
+=back
+
+B<Returns:> Nothing.
+
+B<Examples:>
+
+  $logger->replay('TRACE');
+  # Returns: nothing (replays all buffered entries at TRACE level on terminal)
+
+  $logger->replay(undef, '/var/log/genesis.log');
+  # Returns: nothing (replays at the file target's current level)
+
+=head2 log_levels
+
+  my @levels = log_levels();
+
+Returns the ordered list of valid user-facing log level names. This is a
+package-level function exported as C<log_levels>.
+
+The returned list is:
+
+  NONE OUTPUT ERROR WARNING INFO DEBUG TRACE
+
+Note that C<FATAL>, C<NOTICE>, C<VALUE>, and C<STACK> are used internally
+but are not included in this list because they are not valid configuration
+level names for log targets.
+
+B<Returns:> A list of level name strings.
+
+B<Examples:>
+
+  my @levels = log_levels();
+  print join(', ', @levels);
+  # Returns: 'NONE, OUTPUT, ERROR, WARNING, INFO, DEBUG, TRACE'
+
+=head2 get_scope
+
+  my $scope_str = get_scope($scope_offset);
+
+Returns a formatted string representing the current call location,
+suitable for display in log output. The string shows the file name, line
+number, and optionally the subroutine name, styled with terminal color codes.
+
+If the C<GENESIS_STACK_TRACE> environment variable is set, additional frames
+are included (one per line); otherwise only the immediate caller is shown.
+
+B<Note: this function has a known bug.> The implementation calls
+C<_get_stack>, a private function that does not exist in this module. The
+public equivalent C<get_stack> exists and is the intended callee. As a
+result, C<get_scope> will raise a runtime error when called. This defect
+is tracked for a future fix.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$scope_offset> -- integer; number of additional stack frames to
+skip above the caller (0 = immediate caller)
+
+=back
+
+B<Returns:> A formatted string of the call location with color markup.
+
+B<Examples:>
+
+  # Intended usage (currently broken due to the _get_stack bug):
+  my $loc = get_scope(0);
+  # Returns: a string like '^- lib/Genesis/Secret.pm:L42 (in Genesis::Secret::new)'
+
+=head2 get_stack
+
+  my @frames = get_stack($scope_offset);
+
+Captures the current call stack starting C<$scope_offset> frames above the
+immediate caller. Returns a list of frame hashrefs, each containing:
+
+=over 4
+
+=item * C<file> -- the source file, humanized via Genesis::humanize_path
+
+=item * C<line> -- the line number
+
+=item * C<sub> -- the subroutine name (absent for the outermost frame)
+
+=back
+
+Frames are ordered from most recent caller to the outermost frame.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$scope_offset> -- integer; number of stack frames to skip from the
+call site (0 means start at the direct caller of C<get_stack>)
+
+=back
+
+B<Returns:> A list of frame hashrefs.
+
+B<Examples:>
+
+  my @stack = get_stack(0);
+  for my $frame (@stack) {
+    printf "%s line %d\n", $frame->{file}, $frame->{line};
+    # Returns: e.g., 'lib/Genesis/Log.pm line 300'
+  }
+
+=head2 find_log_level
+
+  my $level = find_log_level($input);
+
+Validates and normalizes a log level string. The input is uppercased and
+checked against the known levels. If the input is an unambiguous prefix of
+exactly one valid level, that level is returned.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$input> -- a log level name or prefix (case-insensitive)
+
+=back
+
+B<Errors:>
+
+Calls Genesis::bail with
+C<"Ambiguous log level $log_level: please specify one of ...">
+if the input matches more than one valid level as a prefix (where
+C<$log_level> is the uppercased input and the suffix lists the matching levels).
+
+Calls Genesis::bail with
+C<"Not a valid log level '$log_level': please specify one of ...">
+if the input does not match any valid level (where C<$log_level> is the
+uppercased input and the suffix lists all valid levels).
+
+B<Returns:> The canonical uppercase level name string.
+
+B<Examples:>
+
+  my $level = find_log_level('trac');
+  print $level;  # Returns: 'TRACE'
+
+  my $level2 = find_log_level('DEBUG');
+  print $level2;  # Returns: 'DEBUG'
+
+=head2 meets_level
+
+  my $bool = meets_level($level, $target);
+
+Returns true if C<$level> meets or exceeds C<$target> in severity. Both
+arguments may be level name strings (e.g., C<'DEBUG'>) or numeric
+ordinal integers as returned by C<level_ord>.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$level> -- the level to test
+
+=item * C<$target> -- the minimum required level
+
+=back
+
+B<Returns:> Boolean (true if C<$level E<gt>= $target> numerically, false otherwise).
+
+B<Examples:>
+
+  print meets_level('DEBUG', 'INFO')  ? 'yes' : 'no';  # Returns: 'yes'
+  print meets_level('INFO',  'DEBUG') ? 'yes' : 'no';  # Returns: 'no'
+  print meets_level('INFO',  'INFO')  ? 'yes' : 'no';  # Returns: 'yes'
+
+=head2 level_ord
+
+  my $ordinal = level_ord($level);
+
+Returns the numeric ordinal for the given log level name. Higher ordinals
+represent more verbose levels. Returns C<undef> for unrecognized level names.
+
+The ordinal mapping is:
+
+  NONE    => 0
+  OUTPUT  => 1
+  FATAL   => 2
+  ERROR   => 2
+  WARNING => 3
+  NOTICE  => 3
+  INFO    => 4
+  DEBUG   => 5
+  VALUE   => 6
+  TRACE   => 6
+  STACK   => 6
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$level> -- a log level name string (uppercased internally before
+lookup)
+
+=back
+
+B<Returns:> Integer ordinal, or C<undef> for unknown levels.
+
+B<Examples:>
+
+  print level_ord('INFO');   # Returns: 4
+  print level_ord('trace');  # Returns: 6
+  print defined(level_ord('BOGUS')) ? 'defined' : 'undef';  # Returns: 'undef'
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _log
+
+  $logger->_log($level, @contents);
+  $logger->_log($level, \%options, @contents);
+
+Core method that creates a log buffer entry and triggers C<flush_logs>.
+All public log-level methods (C<info>, C<debug>, etc.) delegate here.
+
+C<@contents> is a list where the first element is a C<sprintf> format
+string and subsequent elements are values. If only one non-hashref element
+is present, a C<"%s"> format is prepended automatically.
+
+Leading hashrefs in C<@contents> are extracted as option overrides. The
+C<offset> key in any such hashref accumulates to determine the stack depth
+used when capturing the call stack.
+
+The buffer entry includes: C<level>, C<label>, C<colors>, C<emoji>,
+C<priority>, C<timestamp>, C<contents>, C<pending>, C<reset>,
+C<show_stack>, C<stack>, C<raw>, C<prefix>, and C<style>.
+
+Stack frames are captured for all entries whose level meets
+C<capture_stack_min_level> (ordinal 2, i.e., C<FATAL>/C<ERROR> and above),
+except for C<STACK>-level entries which do not capture stack frames.
+
+B<Examples:>
+
+  # Called by public methods; not normally called directly.
+  $logger->_log('INFO', 'Hello %s', 'world');
+  # Returns: nothing (appends buffer entry and flushes)
+
+=head2 _log_item_level_map
+
+  my $map = _log_item_level_map();
+
+Returns a hashref mapping every recognized log level name (including
+internal levels) to its numeric ordinal. Used by C<level_ord> and
+C<meets_level>.
+
+The map includes both user-facing levels (C<NONE>, C<OUTPUT>, C<ERROR>,
+C<WARNING>, C<INFO>, C<DEBUG>, C<TRACE>) and internal levels (C<FATAL>,
+C<NOTICE>, C<VALUE>, C<STACK>).
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Term.pod
+++ b/lib/Genesis/Term.pod
@@ -99,7 +99,8 @@ C<"\e[u"> — Restore the previously saved cursor position.
 
 Returns 1 if the C<TERM> environment variable is set and the C<tput> command is available
 on the system path, or 0 otherwise. Used internally before invoking C<tput> for terminal
-dimension queries. Not exported by default; call as C<Genesis::Term::has_tput()>.
+dimension queries. Not exported by default; use the fully-qualified name or import it
+explicitly.
 
 B<Returns:>
 
@@ -141,7 +142,8 @@ B<Examples:>
 
   my $rows = terminal_height();
 
-Returns the terminal height in rows. Not exported by default; call as C<Genesis::Term::terminal_height()>. Checks, in order:
+Returns the terminal height in rows. Not exported by default; use the fully-qualified name
+or import it explicitly. Checks, in order:
 
 =over 4
 

--- a/lib/Genesis/Term.pod
+++ b/lib/Genesis/Term.pod
@@ -1,0 +1,1329 @@
+=encoding utf8
+
+=head1 NAME
+
+Genesis::Term - Terminal detection, ANSI color formatting, text wrapping, and Markdown rendering
+
+=head1 SYNOPSIS
+
+  use Genesis::Term;
+
+  # Check terminal capabilities
+  my $width = terminal_width();
+  my $height = terminal_height();
+  if (in_controlling_terminal()) {
+    print "Running interactively\n";
+  }
+
+  # Format text with color markup
+  my $colored = csprintf("#G{Success}: %s items processed", 42);
+  print decolorize($colored);  # prints 'Success: 42 items processed'
+
+  # Wrap text to terminal width
+  my $wrapped = wrap($long_text, terminal_width(), '  ');
+  print $wrapped;
+
+  # Render a Markdown document
+  print render_markdown($md_content);
+
+  # ANSI cursor controls
+  print $ansi_hide_cursor;
+  # ... do animated output ...
+  print $ansi_show_cursor;
+
+=head1 DESCRIPTION
+
+C<Genesis::Term> provides terminal-aware text formatting, ANSI color and glyph markup,
+intelligent text wrapping, and Markdown rendering for the Genesis CLI.
+
+The module exports a set of functions and ANSI control variables by default. Functions
+handle terminal dimension detection, color formatting via a compact markup syntax,
+word-wrapping with support for inline prefix markers, boxed-table drawing with Unicode
+box-drawing characters, and a full Markdown-to-terminal renderer.
+
+Color markup uses a C<#CODE{text}> syntax where the code letters choose foreground and
+background colors, italics (C<i>), and underline (C<u>). Glyph markers use C<#CODE@{glyph}>
+to substitute Unicode symbols. Emoji shortcuts use C<#E{name}>. All markup is stripped or
+converted by C<csprintf()> at render time. The C<NOCOLOR> environment variable suppresses
+all color output.
+
+The exported ANSI control variables (C<$ansi_reset_line>, C<$ansi_clear_to_eol>, etc.)
+are raw escape sequences suitable for direct inclusion in print statements to move the
+cursor, show or hide it, or clear lines.
+
+=head1 EXPORTED VARIABLES
+
+The following package-global ANSI escape sequence variables are exported by default:
+
+=over 4
+
+=item C<$ansi_reset_line>
+
+C<"\r\e[2K"> — Move cursor to column 0 and erase the entire line.
+
+=item C<$ansi_clear_to_eol>
+
+C<"\e[0K"> — Erase from the cursor position to the end of the line.
+
+=item C<$ansi_cursor_up>
+
+C<"\e[A"> — Move cursor up one line.
+
+=item C<$ansi_cursor_down>
+
+C<"\e[B"> — Move cursor down one line.
+
+=item C<$ansi_hide_cursor>
+
+C<"\e[?25l"> — Hide the terminal cursor.
+
+=item C<$ansi_show_cursor>
+
+C<"\e[?25h"> — Show the terminal cursor.
+
+=item C<$ansi_save_cursor>
+
+C<"\e[s"> — Save the current cursor position.
+
+=item C<$ansi_restore_cursor>
+
+C<"\e[u"> — Restore the previously saved cursor position.
+
+=back
+
+=head1 METHODS
+
+=head2 has_tput
+
+  my $bool = has_tput();
+
+Returns 1 if the C<TERM> environment variable is set and the C<tput> command is available
+on the system path, or 0 otherwise. Used internally before invoking C<tput> for terminal
+dimension queries.
+
+B<Returns:>
+
+0 if C<$ENV{TERM}> is not set. 1 if C<tput> is found on the path, 0 if not.
+
+B<Examples:>
+
+  if (has_tput()) {
+    print "tput is available\n";  # prints 'tput is available'
+  }
+
+=head2 terminal_width
+
+  my $cols = terminal_width();
+
+Returns the terminal width in columns. Checks, in order:
+
+=over 4
+
+=item 1. C<$ENV{GENESIS_OUTPUT_COLUMNS}> if set
+
+=item 2. C<tput cols> if C<tput> is available
+
+=item 3. Falls back to 80
+
+=back
+
+B<Returns:>
+
+A positive integer column count.
+
+B<Examples:>
+
+  my $width = terminal_width();
+  print "Terminal is $width columns wide\n";
+  # prints 'Terminal is 80 columns wide' when no tput or env override
+
+=head2 terminal_height
+
+  my $rows = terminal_height();
+
+Returns the terminal height in rows. Checks, in order:
+
+=over 4
+
+=item 1. C<$ENV{GENESIS_OUTPUT_LINES}> if set
+
+=item 2. C<tput lines> if C<tput> is available
+
+=item 3. Falls back to 24
+
+=back
+
+B<Returns:>
+
+A positive integer row count.
+
+B<Examples:>
+
+  my $height = terminal_height();
+  print "Terminal is $height rows tall\n";
+  # prints 'Terminal is 24 rows tall' when no tput or env override
+
+=head2 boxify
+
+  my $glyph = boxify($line, $position);
+
+Returns a single Unicode box-drawing character (or ASCII fallback) for the given
+line type and position within a box structure. Used by C<build_markdown_table()> to
+assemble bordered tables.
+
+When C<GENESIS_NO_UTF8> or C<GENESIS_NO_BOXES> is set, ASCII characters are used instead
+of Unicode box-drawing characters.
+
+Returns an empty string if C<$line> or C<$position> is not a recognized value.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$line>
+
+The row type: C<"top">, C<"line">, C<"mid">, or C<"bot">.
+
+=item C<$position>
+
+The column position: C<"left">, C<"right">, C<"span">, or C<"div">.
+
+=back
+
+B<Returns:>
+
+A single character string, or C<""> for unrecognized inputs.
+
+B<Examples:>
+
+  print boxify('top', 'left');   # prints '┏' (or '+' in ASCII mode)
+  print boxify('line', 'div');   # prints '┃' (or '|' in ASCII mode)
+  print boxify('bot', 'right');  # prints '┛' (or '+' in ASCII mode)
+
+=head2 csprintf
+
+  my $str = csprintf($fmt, @args);
+
+A color-aware replacement for C<sprintf>. Processes C<$fmt> with C<sprintf> using C<@args>,
+then applies the Genesis color markup language to the result:
+
+=over 4
+
+=item * C<#CODE{text}> — colorize C<text> with the given color code
+
+=item * C<#CODE@{glyph}> — substitute a named glyph symbol, then colorize it
+
+=item * C<#E{name}> — substitute a named emoji character
+
+=back
+
+Color codes are one to four characters from the set C<[-IUKRGYBMPCW*]>. Letter case
+controls brightness: uppercase gives the bright/bold variant, lowercase gives the
+standard variant. C<I> and C<U> add italic and underline formatting respectively.
+C<*> cycles through rainbow colors.
+
+Fatal sprintf warnings (missing or redundant arguments, uninitialized values) are
+propagated as exceptions via C<confess> from the C<Carp> module. Non-fatal sprintf
+warnings are logged via C<Genesis::Log> when in dev or testing mode.
+
+Returns an empty string if C<$fmt> is false.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$fmt>
+
+A C<sprintf>-style format string, optionally containing Genesis color markup.
+
+=item C<@args>
+
+Arguments to pass to C<sprintf>.
+
+=back
+
+B<Returns:>
+
+The formatted and color-processed string, or C<""> if C<$fmt> is false.
+
+B<Examples:>
+
+  my $msg = csprintf("#G{OK}: processed %d items", 5);
+  # Returns: colorized "OK: processed 5 items" (green "OK")
+
+  my $glyph = csprintf("#R@{-} Error occurred");
+  # Returns: colorized red checkmark glyph followed by " Error occurred"
+
+  my $empty = csprintf('');
+  # Returns: ''
+
+=head2 decolorize
+
+  my $plain = decolorize($str);
+
+Strips all Genesis color markup and ANSI escape sequences from C<$str>, returning
+plain text. Glyph markers are converted to their plain-text glyph equivalents. Emoji
+markers are removed entirely. Already-converted ANSI color sequences are also stripped.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$str>
+
+A string that may contain Genesis color markup (C<#CODE{...}>), glyph markup
+(C<#CODE@{...}>), emoji markup (C<#E{...}>), or raw ANSI escape sequences.
+
+=back
+
+B<Returns:>
+
+The input string with all color and escape sequences removed.
+
+B<Examples:>
+
+  my $plain = decolorize("#G{Hello}, #R{world}!");
+  # Returns: 'Hello, world!'
+
+  my $no_emoji = decolorize("Status: #E{fire} critical");
+  # Returns: 'Status:  critical'
+
+=head2 csize
+
+  my $len = csize($str);
+
+Returns the display width of C<$str> as it would appear on the terminal — that is,
+the character count after stripping all color markup and adding back the rendered
+width of any emoji characters (which expand to their Unicode codepoint representations).
+
+B<Parameters:>
+
+=over 4
+
+=item C<$str>
+
+A string optionally containing Genesis color markup or emoji markers.
+
+=back
+
+B<Returns:>
+
+An integer display width.
+
+B<Examples:>
+
+  my $len = csize("#G{Hello}");
+  print $len;  # prints '5' (color markup does not add to display width)
+
+  my $len2 = csize("plain text");
+  print $len2; # prints '10'
+
+=head2 wrap
+
+  my $wrapped = wrap($str, $width, $prefix, $indent, $continue_prefix, $init_col);
+
+Wraps C<$str> to C<$width> columns, respecting color markup for accurate display-width
+calculations. Supports a leading C<$prefix> on the first line, a numeric C<$indent>
+for continuation lines, and an optional C<$continue_prefix> string prepended to
+wrapped lines.
+
+A negative C<$width> enables raw mode: lines are indented but never word-wrapped.
+
+Supports an internal marker syntax C<[[prefix>>text> to add per-block sub-indentation
+inline within the string.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$str>
+
+The text to wrap. May contain newlines; each line is wrapped independently.
+
+=item C<$width>
+
+Maximum column width. A negative value disables wrapping (raw indent mode).
+
+=item C<$prefix>
+
+Optional prefix string for the first line. Defaults to C<"">.
+
+=item C<$indent>
+
+Optional numeric indent for continuation lines. Defaults to the display width of
+C<$prefix>.
+
+=item C<$continue_prefix>
+
+Optional prefix string prepended to each continuation line after a wrap. Defaults
+to C<"">.
+
+=item C<$init_col>
+
+Optional starting column offset. When set, the first-line output is trimmed to
+remove the first C<$init_col> characters (for use when the cursor is already
+partway across a line).
+
+=back
+
+B<Returns:>
+
+The wrapped string. Trailing newline is not included.
+
+B<Examples:>
+
+  my $out = wrap("The quick brown fox", 15, '  ');
+  # Returns:
+  #   "  The quick\n  brown fox"
+
+  my $raw = wrap("line one\nline two", -1, '> ');
+  # Returns: "> line one\n  line two"
+
+=head2 fix_wrap
+
+  my $msg = fix_wrap(@msg);
+  my $msg = fix_wrap($fmt, @args);
+
+Preprocesses a message for display by normalizing whitespace produced by Perl
+heredocs or multi-line string formatting. Leading and trailing newlines are stripped.
+When a single-argument form is used, the argument is treated as the message directly.
+When multiple arguments are given, the first is used as a C<sprintf> format string.
+
+If the message begins with a Genesis color-markup label of the form
+C<#CODE{[LABEL]}>, the label is extracted and continuation-line indentation in the
+body is collapsed so the message renders cleanly when passed to C<wrap()>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@msg>
+
+Either a single message string, or a C<sprintf> format string followed by arguments.
+
+=back
+
+B<Returns:>
+
+The normalized message string.
+
+B<Examples:>
+
+  my $msg = fix_wrap("  text  \n");
+  # Returns: 'text'
+
+  my $msg2 = fix_wrap("#W{[NOTE]} Some\n             long text");
+  # Returns: 'Some long text'
+
+=head2 colored_block
+
+  my $block = colored_block($text, $fg, $bg);
+
+Wraps each line of C<$text> with the ANSI color codes for the given foreground
+(C<$fg>) and background (C<$bg>) colors, erasing to end-of-line on each line so the
+background fill extends to the terminal margin.
+
+Returns C<$text> unchanged if the C<NOCOLOR> environment variable is set.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$text>
+
+The text to colorize. May contain embedded newlines; each line is processed separately.
+
+=item C<$fg>
+
+Foreground color letter (e.g., C<"G"> for bright green, C<"g"> for green). Uses
+the same color code alphabet as C<csprintf()>.
+
+=item C<$bg>
+
+Background color letter (e.g., C<"k"> for black, C<"K"> for dark grey). Uses the
+same color code alphabet as C<csprintf()>.
+
+=back
+
+B<Returns:>
+
+The text with ANSI color codes applied to each line, or the original text if
+C<NOCOLOR> is set.
+
+B<Examples:>
+
+  my $block = colored_block("alert!", 'R', 'k');
+  print $block;  # prints "alert!" with red text on black background
+
+=head2 bullet
+
+  my $str = bullet($msg, %opts);
+  my $str = bullet($type, $msg, %opts);
+
+Formats a bullet point line. The first argument is the bullet type if there is an
+odd number of remaining arguments (after the first), or the message if the remaining
+arguments are all key-value pairs.
+
+Type values and their defaults:
+
+=over 4
+
+=item C<"good"> — green check mark (C<✔ >)
+
+=item C<"bad"> — red cross (C<✘ >)
+
+=item C<"warn"> — yellow warning sign (C<⚠ >)
+
+=item C<"empty"> — two spaces
+
+=item any other value or empty string — bullet (C<•>)
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item C<$type> (optional)
+
+Bullet type: C<"good">, C<"bad">, C<"warn">, C<"empty">, or any other string. When
+present, determines default symbol and color. Defaults to empty (bullet style).
+
+=item C<$msg>
+
+The message text to place after the bullet.
+
+=item C<%opts>
+
+Optional key-value pairs:
+
+=over 8
+
+=item C<symbol>
+
+Override the bullet symbol. Supports glyph markup (C<#@{glyph}>).
+
+=item C<color>
+
+Override the bullet color code. Defaults to C<G>, C<R>, C<Y>, or C<-> based on type.
+
+=item C<indent>
+
+Left-pad width. Defaults to 2.
+
+=item C<box>
+
+If true, wraps the symbol in C<[> and C<]>. If an array reference, uses the two
+elements as the left and right box characters.
+
+=back
+
+=back
+
+B<Returns:>
+
+A formatted string with the indented, optionally boxed bullet symbol and message.
+
+B<Examples:>
+
+  print bullet('good', 'All checks passed');
+  # Returns: '  ✔  All checks passed'
+
+  print bullet('bad', 'Connection failed', indent => 0);
+  # Returns: '✘  Connection failed'
+
+  print bullet('Test item');
+  # Returns: '  •  Test item'
+
+=head2 checkbox
+
+  my $str = checkbox($state);
+
+Returns a boxed checkbox symbol: a filled square for C<"good"> states, an outlined
+square for C<"bad"> states (including empty string and C<"error">), and a warning
+symbol for C<"warn">. Equivalent to calling C<bullet()> with C<box =E<gt> 1>,
+C<indent =E<gt> 0>, and an empty message.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$state>
+
+A string. C<"warn"> produces a warning checkbox. Any truthy value other than
+C<"error"> produces a checked (good) checkbox. A false value or C<"error"> produces
+an unchecked (bad) checkbox.
+
+=back
+
+B<Returns:>
+
+A formatted checkbox string (no trailing message text).
+
+B<Examples:>
+
+  print checkbox('good');  # Returns: '[✔ ]'
+  print checkbox('bad');   # Returns: '[✘ ]'
+  print checkbox('warn');  # Returns: '[⚠ ]'
+  print checkbox('');      # Returns: '[✘ ]'
+
+=head2 in_controlling_terminal
+
+  my $bool = in_controlling_terminal();
+
+Returns true if both STDIN and STDOUT are connected to a terminal (i.e., the process
+is running interactively rather than piped or redirected).
+
+B<Returns:>
+
+True if both C<-t STDIN> and C<-t STDOUT> are true, false otherwise.
+
+B<Examples:>
+
+  if (in_controlling_terminal()) {
+    print "Interactive session\n";
+  } else {
+    print "Non-interactive session\n";
+  }
+
+=head2 get_io_target
+
+  my $target_desc = get_io_target($fh);
+
+Identifies the I/O target for a filehandle. Defaults to C<STDOUT> if no argument
+is given.
+
+Returns one of:
+
+=over 4
+
+=item C<"terminal"> — the filehandle is connected to a terminal
+
+=item C<"pipe"> — the filehandle is a named pipe
+
+=item The resolved file path — if the filehandle is a regular file and C</proc/self/fd>
+is available to resolve the inode
+
+=item C<"file"> — if the filehandle is a regular file but the path cannot be resolved
+
+=item C<"unknown device"> — for any other filehandle type
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item C<$fh> (optional)
+
+A filehandle or glob reference. Defaults to C<\*STDOUT>.
+
+=back
+
+B<Returns:>
+
+A string describing the I/O target.
+
+B<Examples:>
+
+  my $type = get_io_target(\*STDOUT);
+  print $type;  # prints 'terminal' when running interactively
+
+  open my $fh, '>', '/tmp/test.txt' or die $!;
+  my $type = get_io_target($fh);
+  print $type;  # prints '/tmp/test.txt' on Linux, 'file' elsewhere
+
+=head2 build_markdown_table
+
+  my $rendered = build_markdown_table($table, %opts);
+
+Converts a Markdown table string into a terminal-rendered table with Unicode
+box-drawing borders, auto-computed column widths, and column alignment derived
+from the Markdown separator row.
+
+Alignment is determined by the separator row (C<--->, C<:--->, C<---:>, C<:---:>):
+left-aligned, left-aligned, right-aligned, and center-aligned respectively.
+
+Column widths are calculated to fit within the terminal width (or C<$opts{width}>),
+distributing available space proportionally to each column's natural width. With
+C<expand =E<gt> 1>, columns are expanded to fill the full available width.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$table>
+
+A Markdown table string with a header row, a separator row, and zero or more data
+rows. Each row must be pipe-delimited.
+
+=item C<%opts>
+
+Optional key-value pairs:
+
+=over 8
+
+=item C<width>
+
+Override the total render width. Defaults to C<terminal_width()>.
+
+=item C<expand>
+
+If true, expand columns to fill the full available width even when content is
+narrower.
+
+=back
+
+=back
+
+B<Returns:>
+
+A multi-line string containing the rendered table with box borders.
+
+B<Examples:>
+
+  my $md = "| Name | Age |\n|------|-----|\n| Alice | 30 |\n| Bob | 25 |";
+  print build_markdown_table($md);
+  # Prints a Unicode-bordered table with Name and Age columns
+
+=head2 process_markdown_block
+
+  my $rendered = process_markdown_block($block, %opts);
+
+Renders a single Markdown block (paragraph, header, list, code block, blockquote,
+or table) to a terminal-formatted string. Handles inline formatting (bold, italic,
+inline code, strikethrough) and link extraction.
+
+This is called by C<render_markdown()> for each block in a Markdown document.
+Link references within the block are accumulated into C<$opts{links}> (an array ref
+that must be provided by the caller when processing a document).
+
+Returns an empty string for blocks that consist entirely of link reference
+definitions with no displayable content.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$block>
+
+A single Markdown block string (content between blank lines).
+
+=item C<%opts>
+
+Optional key-value pairs:
+
+=over 8
+
+=item C<width>
+
+Render width. Defaults to C<terminal_width()>.
+
+=item C<links>
+
+An array reference to accumulate extracted link targets. Required when rendering
+documents with links; pass the same reference to all blocks in a document.
+
+=back
+
+=back
+
+B<Returns:>
+
+The rendered terminal string for this block, or C<""> if the block contains only
+link definitions.
+
+B<Examples:>
+
+  my $links = [];
+  my $out = process_markdown_block("## Hello World", links => $links);
+  print $out;  # prints green underlined "Hello World" header
+
+  my $para = process_markdown_block("Some **bold** text.", links => $links);
+  print $para; # prints the paragraph with bold formatting applied
+
+=head2 render_markdown
+
+  my $output = render_markdown($md, %opts);
+
+Renders a complete Markdown document to a terminal-formatted string. Splits the
+document into blocks on double newlines, reassembles fractured code blocks and
+blockquotes, separates headers from adjacent content, then passes each block to
+C<process_markdown_block()>.
+
+If the document contains any hyperlinks, a C<"### Links"> section listing numbered
+link targets is appended to the output.
+
+Normalizes Windows-style CRLF line endings before processing.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$md>
+
+The full Markdown document string.
+
+=item C<%opts>
+
+Optional key-value pairs:
+
+=over 8
+
+=item C<width>
+
+Render width. Defaults to C<terminal_width()>.
+
+=back
+
+=back
+
+B<Returns:>
+
+A formatted, terminal-ready string rendering of the Markdown document.
+
+B<Examples:>
+
+  my $doc = "# Title\n\nSome **bold** text.\n\n- item one\n- item two\n";
+  print render_markdown($doc);
+  # Prints formatted title, paragraph, and bullet list
+
+=head2 superscript
+
+  my $str = superscript($num);
+
+Converts an integer (given as a string of digits) to a Unicode superscript string.
+Each digit 0-9 is replaced with its Unicode superscript equivalent.
+
+When C<GENESIS_NO_UTF8> is set, returns C<"[*N]"> in italic markup instead.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$num>
+
+A string of one or more digits to convert.
+
+=back
+
+B<Returns:>
+
+A Unicode superscript string, or a fallback italic-markup representation when
+UTF-8 is disabled.
+
+B<Examples:>
+
+  print superscript(3);   # prints '³'
+  print superscript(12);  # prints '¹²'
+
+=head2 elipses
+
+  my $truncated = elipses($str, $len);
+
+Truncates C<$str> to C<$len> characters, appending C<"..."> if truncation occurred.
+Returns C<$str> unchanged if its length is already within C<$len>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$str>
+
+The string to potentially truncate.
+
+=item C<$len>
+
+Maximum allowed length including the C<"..."> suffix.
+
+=back
+
+B<Returns:>
+
+The original string if its length is within C<$len>, otherwise the first
+C<$len - 3> characters followed by C<"...">.
+
+B<Examples:>
+
+  print elipses("Hello, world!", 10);  # prints 'Hello, ...'
+  print elipses("Short", 10);          # prints 'Short'
+
+=head2 get_control_picture
+
+  my $str = get_control_picture($byte);
+
+Returns a terminal-displayable representation of a single byte value. Control
+characters (0-31) are rendered as yellow Unicode control pictures. Printable ASCII
+(32-126) is returned as-is. DEL (127) is rendered as a yellow-dim symbol. All
+other bytes (128+) are rendered in red.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$byte>
+
+An integer byte value (0-255).
+
+=back
+
+B<Returns:>
+
+A formatted string representation of the byte value.
+
+B<Examples:>
+
+  print get_control_picture(65);   # prints 'A'
+  print get_control_picture(0);    # prints yellow NUL control picture
+
+=head2 string_to_hex
+
+  string_to_hex($str);
+
+Prints a hex dump of C<$str> to STDOUT in the style of C<hexdump -C>. Output
+is formatted as 16-byte rows with a hex offset, space-separated hex byte values,
+and a printable-character column using C<get_control_picture()> for non-printable
+bytes.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$str>
+
+The string to dump.
+
+=back
+
+B<Returns:>
+
+Nothing. Output is written directly to STDOUT via C<printf>.
+
+B<Examples:>
+
+  string_to_hex("Hello\x00\n");
+  # Prints:
+  # 0000  48 65 6c 6c 6f 00 0a                             |Hello␀↵|
+
+=head2 set_stdin
+
+  set_stdin($input);
+
+Redirects STDIN to read from C<$input>. The original STDIN handle is preserved and
+can be restored with C<reset_stdin()>. If STDIN has already been redirected, the
+previous pipe is closed before creating a new one.
+
+Intended for testing code that reads from STDIN.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$input>
+
+A string to inject as STDIN content.
+
+=back
+
+B<Returns:>
+
+Nothing.
+
+B<Errors:>
+
+=over 4
+
+=item C<"can't dup STDIN: $!"> if saving the original STDIN handle fails.
+
+=item C<"can't create pipe: $!"> if creating the replacement pipe fails.
+
+=item C<"can't dup pipe to STDIN: $!"> if redirecting STDIN to the pipe fails.
+
+=back
+
+B<Examples:>
+
+  set_stdin("yes\n");
+  my $answer = <STDIN>;
+  print $answer;  # prints 'yes'
+  reset_stdin();
+
+=head2 reset_stdin
+
+  reset_stdin();
+
+Restores STDIN to the original file descriptor saved by a previous call to
+C<set_stdin()>. Does nothing if STDIN has not been redirected.
+
+B<Returns:>
+
+Nothing.
+
+B<Errors:>
+
+=over 4
+
+=item C<"can't restore STDIN: $!"> if restoring the original STDIN handle fails.
+
+=back
+
+B<Examples:>
+
+  set_stdin("test input\n");
+  my $line = <STDIN>;
+  reset_stdin();
+  print $line;  # prints 'test input'
+
+=head1 METHODS (RENDERING HELPERS)
+
+The following methods render individual Markdown block types. They are called by
+C<process_markdown_block()> and C<render_markdown()>, but may also be used directly
+to render specific Markdown constructs.
+
+=head2 build_markdown_list
+
+  my $rendered = build_markdown_list($type, $block, %opts);
+
+Renders a Markdown ordered or unordered list block to a terminal-wrapped string.
+Handles nested indentation, continuation lines, and embedded code blocks within
+list items. Maintains list state in package-level variables so that
+C<process_markdown_block()> can track list continuation across blocks.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$type>
+
+C<"list"> for an unordered list, C<"numbered_list"> for an ordered list.
+
+=item C<$block>
+
+The raw Markdown list block text.
+
+=item C<%opts>
+
+Passed through to C<wrap()> and C<build_markdown_codeblock()>. Supports C<width>
+(default: C<terminal_width()>).
+
+=back
+
+B<Returns:>
+
+The formatted, word-wrapped list as a string.
+
+B<Examples:>
+
+  my $out = build_markdown_list('list', "- one\n- two\n- three");
+  print $out;
+  # Prints:
+  #   * one
+  #   * two
+  #   * three
+
+  my $num = build_markdown_list('numbered_list', " 1. first\n 2. second");
+  print $num;
+  # Prints:
+  #  1. first
+  #  2. second
+
+=head2 build_markdown_codeblock
+
+  my $rendered = build_markdown_codeblock($block, %opts);
+
+Renders a Markdown fenced code block (triple-backtick) to a terminal-formatted
+string. Each line is padded with left indent and padding spaces, colorized using
+the C<ui.colors.code> setting from C<$Genesis::RC>, and truncated with C<elipses()>
+if it exceeds the computed code width.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$block>
+
+The raw code block text including the opening and closing fence lines.
+
+=item C<%opts>
+
+Supports C<width> (default: C<terminal_width()>), C<indent> (default: 0),
+and C<padding> (default: 4).
+
+=back
+
+B<Returns:>
+
+The formatted code block as a string (multiple lines joined with C<"\n">).
+
+B<Examples:>
+
+  my $out = build_markdown_codeblock("```\nmy \$x = 1;\n```");
+  print $out;
+  # Prints the code line colorized with 4-space padding on each side
+
+  my $indented = build_markdown_codeblock("```\ncode\n```", indent => 2);
+  print $indented;
+  # Prints the code line with 2 spaces of left indent before the padding
+
+=head2 build_markdown_paragraph
+
+  my $rendered = build_markdown_paragraph($block, %opts);
+
+Renders a Markdown paragraph to a terminal-wrapped string. Infers the left
+prefix from C<$opts{indent}>, C<$opts{prefix}>, or leading whitespace in the block.
+Multiple sub-paragraphs separated by two or more blank lines within the block are
+joined with a blank prefix line between them.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$block>
+
+The raw paragraph text.
+
+=item C<%opts>
+
+Supports C<width>, C<indent> (numeric), and C<prefix> (string).
+
+=back
+
+B<Returns:>
+
+The word-wrapped paragraph as a string.
+
+B<Examples:>
+
+  my $out = build_markdown_paragraph("Hello world", width => 40);
+  print $out;
+  # Prints: 'Hello world'
+
+  my $indented = build_markdown_paragraph("Some text here", prefix => '  ');
+  print $indented;
+  # Prints: '  Some text here'
+
+=head2 build_markdown_blockquote
+
+  my $rendered = build_markdown_blockquote($block, %opts);
+
+Renders a Markdown blockquote block to a terminal-wrapped string. Strips the
+leading C<E<gt>> characters and indents the content by two spaces (or C<$opts{indent}>
+spaces).
+
+B<Parameters:>
+
+=over 4
+
+=item C<$block>
+
+The raw blockquote text including C<E<gt>> prefixes.
+
+=item C<%opts>
+
+Supports C<width> (default: C<terminal_width()>) and C<indent> (default: 2).
+
+=back
+
+B<Returns:>
+
+The wrapped, indented blockquote as a string.
+
+B<Examples:>
+
+  my $out = build_markdown_blockquote("> Be excellent to each other.", width => 40);
+  print $out;
+  # Prints: '  Be excellent to each other.'
+
+  my $custom = build_markdown_blockquote("> Note", indent => 4);
+  print $custom;
+  # Prints: '    Note'
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without notice
+and should not be called directly.
+
+=head2 _color
+
+  my $ansi = _color($fg, $bg);
+
+Generates a raw ANSI color escape sequence for the given foreground and background
+color letter codes. On 256-color terminals (detected via C<$ENV{TERM}> containing
+C<"256color">), uses extended color codes (38;5;N / 48;5;N). On standard terminals,
+uses basic SGR codes with bold for uppercase letters.
+
+Color letters map to: C<K>/C<k> (dark grey/black), C<R>/C<r> (light red/red),
+C<G>/C<g> (light green/green), C<Y>/C<y> (yellow/amber), C<B>/C<b> (light blue/blue),
+C<M>/C<m>/C<P>/C<p> (magenta/purple), C<C>/C<c> (light cyan/dark cyan),
+C<W>/C<w> (light grey/white). Uppercase gives the bright variant.
+
+B<Parameters:>
+
+C<$fg> — foreground color letter, or undef for no foreground change.
+
+C<$bg> — background color letter, or undef for no background change.
+
+B<Returns:>
+
+A raw ANSI escape sequence string, or C<""> if neither color letter is recognized.
+
+B<Examples:>
+
+  my $seq = _color('G', undef);
+  # Returns: ANSI escape sequence for green foreground
+
+  my $none = _color('z', undef);
+  # Returns: '' (unrecognized color letter)
+
+=head2 _colorize
+
+  my $colored = _colorize($c, $msg);
+
+Applies ANSI color formatting to C<$msg> using the color code string C<$c>. Handles
+italic (C<i>), underline (C<u>), foreground, and background color letters. When the
+foreground or background is C<"*">, cycles through rainbow colors per non-whitespace
+character.
+
+Returns C<""> if C<$msg> is empty. Returns C<$msg> unchanged if C<NOCOLOR> is set.
+
+B<Parameters:>
+
+C<$c> — a color code string (one to four characters from C<[-IUKRGYBMPCWiuk*]>).
+
+C<$msg> — the text to colorize.
+
+B<Returns:>
+
+The ANSI-colored string, or the original message if color is disabled or message is empty.
+
+B<Examples:>
+
+  my $green = _colorize('G', 'hello');
+  # Returns: 'hello' wrapped in green ANSI codes
+
+  my $empty = _colorize('G', '');
+  # Returns: ''
+
+=head2 _glyphize
+
+  my $glyph = _glyphize($c, $glyph);
+
+Substitutes C<$glyph> with its Unicode equivalent when C<GENESIS_NO_UTF8> is not set.
+If C<$c> is provided, colorizes the resulting glyph via C<_colorize()>.
+
+Recognized glyph keys: C<"-">, C<"+">, C<"*">, C<" ">, C<">">, C<"!">, C<"x">,
+C<"^-">, C<"O">, C<"@">, C<"[ ]">, C<"[x]">, C<"X">, C<"_">.
+
+B<Parameters:>
+
+C<$c> — color code string, or empty string for no colorization.
+
+C<$glyph> — the glyph key to look up.
+
+B<Returns:>
+
+The Unicode glyph (or original key if UTF-8 is disabled), optionally colorized.
+
+B<Examples:>
+
+  my $check = _glyphize('G', '+');
+  # Returns: green-colored checkmark glyph (U+2714)
+
+  my $plain = _glyphize('', '*');
+  # Returns: bullet glyph (U+2022) with no color
+
+=head2 _emojify
+
+  my $emoji = _emojify($name);
+
+Returns the Unicode emoji character for the given name key. Returns C<""> if
+C<GENESIS_NO_UTF8> is set or the name is not recognized.
+
+Recognized names: C<"crystal-ball">, C<"stop-sign">, C<"collision">,
+C<"information">, C<"fire">, C<"magnifying-glass">, C<"detective">,
+C<"warning">, C<"pancakes">, C<"tap">, C<"memo">, C<"notes">, C<"printer">,
+C<"tada">, C<"tmyn">, C<"notice">, C<"megaphone">, C<"noentry">.
+
+B<Parameters:>
+
+C<$name> — the emoji name key.
+
+B<Returns:>
+
+A Unicode emoji string, or C<""> if not found or UTF-8 is disabled.
+
+B<Examples:>
+
+  my $fire = _emojify('fire');
+  # Returns: the fire emoji character (U+1F525)
+
+  my $unknown = _emojify('nonexistent');
+  # Returns: ''
+
+=head2 _align
+
+  my $padded = _align($str, $width, $align);
+
+Pads C<$str> to C<$width> characters according to C<$align> (C<"l"> for left,
+C<"r"> for right, any other value for center). Returns C<$str> unchanged if it
+is already at least C<$width> characters wide. Used by C<build_markdown_table()>
+for cell alignment.
+
+B<Parameters:>
+
+C<$str> — the string to align.
+
+C<$width> — the target display width.
+
+C<$align> — alignment: C<"l"> (left), C<"r"> (right), or anything else (center).
+
+B<Returns:>
+
+The padded string.
+
+B<Examples:>
+
+  my $left = _align('hi', 6, 'l');
+  # Returns: 'hi    ' (padded to 6 with spaces on the right)
+
+  my $right = _align('hi', 6, 'r');
+  # Returns: '    hi' (padded to 6 with spaces on the left)
+
+  my $center = _align('hi', 6, 'c');
+  # Returns: '  hi  ' (padded to 6, centered)
+
+=head2 _multiline_row
+
+  my $rendered = _multiline_row($row, $col_widths, $col_align);
+
+Renders a single data row for a Markdown table, handling cells whose wrapped
+content spans multiple lines. Each cell is wrapped to its column width and split
+on newlines or C<< <br> >> tags. The method then emits one box-bordered output
+line per row height, padding shorter cells with spaces.
+
+B<Parameters:>
+
+C<$row> — an array reference of cell content strings.
+
+C<$col_widths> — an array reference of integer column widths.
+
+C<$col_align> — an array reference of alignment characters (C<"l">, C<"r">, C<"c">).
+
+B<Returns:>
+
+A multi-line string for the rendered row including box-drawing characters.
+
+B<Examples:>
+
+  my $row = _multiline_row(['Alice', '30'], [10, 5], ['l', 'r']);
+  # Returns one or more lines of box-bordered text for the row
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Term.pod
+++ b/lib/Genesis/Term.pod
@@ -226,7 +226,8 @@ C<*> cycles through rainbow colors.
 
 Fatal sprintf warnings (missing or redundant arguments, uninitialized values) are
 propagated as exceptions via C<confess> from the C<Carp> module. Non-fatal sprintf
-warnings are logged via C<Genesis::Log> when in dev or testing mode.
+warnings are logged via C<Genesis::Log> (subject to configured log level), with
+additional stack traces via C<Carp::cluck> only in dev or testing mode.
 
 B<Note:> Italic formatting (C<I>/C<i>) is suppressed when running inside C<tmux>
 (C<$ENV{TMUX}> is set).
@@ -257,7 +258,7 @@ B<Examples:>
   # Returns: colorized "OK: processed 5 items" (green "OK")
 
   my $glyph = csprintf("#R@{-} Error occurred");
-  # Returns: colorized red checkmark glyph followed by " Error occurred"
+  # Returns: colorized red cross glyph (✘) followed by " Error occurred"
 
   my $empty = csprintf('');
   # Returns: ''

--- a/lib/Genesis/Term.pod
+++ b/lib/Genesis/Term.pod
@@ -99,7 +99,7 @@ C<"\e[u"> — Restore the previously saved cursor position.
 
 Returns 1 if the C<TERM> environment variable is set and the C<tput> command is available
 on the system path, or 0 otherwise. Used internally before invoking C<tput> for terminal
-dimension queries.
+dimension queries. Not exported by default; call as C<Genesis::Term::has_tput()>.
 
 B<Returns:>
 
@@ -141,7 +141,7 @@ B<Examples:>
 
   my $rows = terminal_height();
 
-Returns the terminal height in rows. Checks, in order:
+Returns the terminal height in rows. Not exported by default; call as C<Genesis::Term::terminal_height()>. Checks, in order:
 
 =over 4
 
@@ -225,6 +225,9 @@ C<*> cycles through rainbow colors.
 Fatal sprintf warnings (missing or redundant arguments, uninitialized values) are
 propagated as exceptions via C<confess> from the C<Carp> module. Non-fatal sprintf
 warnings are logged via C<Genesis::Log> when in dev or testing mode.
+
+B<Note:> Italic formatting (C<I>/C<i>) is suppressed when running inside C<tmux>
+(C<$ENV{TMUX}> is set).
 
 Returns an empty string if C<$fmt> is false.
 
@@ -721,8 +724,9 @@ Render width. Defaults to C<terminal_width()>.
 
 =item C<links>
 
-An array reference to accumulate extracted link targets. Required when rendering
-documents with links; pass the same reference to all blocks in a document.
+Required for any block that may contain Markdown links. If omitted and a link
+pattern is found, the function will die. Pass the same array reference to all
+blocks in a document to maintain consistent link numbering.
 
 =back
 

--- a/lib/Genesis/UI.pod
+++ b/lib/Genesis/UI.pod
@@ -1,227 +1,632 @@
 =head1 NAME
 
-Genesis::UI
+Genesis::UI - Interactive text user interface prompts for Genesis and kit hooks
+
+=head1 SYNOPSIS
+
+    use Genesis::UI;
+
+    # Boolean prompt
+    my $answer = prompt_for_boolean("Enable feature?", "y");
+    # Returns JSON::PP::true or JSON::PP::false
+
+    # Single choice from a list
+    my $env = prompt_for_choice(
+        "Select an environment:",
+        [qw(dev staging prod)],
+        "dev"
+    );
+
+    # Free-form line input with validation
+    my $ip = prompt_for_line(
+        "Enter the IP address of your BOSH director",
+        "IP address",
+        undef,
+        "ip"
+    );
 
 =head1 DESCRIPTION
 
 This module provides utilities for the text user interfaces used by C<Genesis>
-and its C<hooks/*> scripts.
+and its C<hooks/*> scripts. It exports interactive prompt functions that read
+from C<STDIN> and write to C<STDERR> (or C<STDOUT> for some formatted output).
 
-=head1 FUNCTIONS
+All exported functions loop until the user provides a valid response, printing
+an error and re-prompting on invalid input.
 
-=head2 prompt_for_boolean($prompt,$default,$invert);
+=head1 METHODS
 
-Provides the user with the given C<$prompt> on one line, then a `[y|n] >`
-prompt on the following line.  If the given prompt contains `[y|n]` in it,
-then just the given prompt will be diplayed on a single line.
+=head2 prompt_for_boolean
 
-Whether provided or appended, the [y|n] will be modified to make the default
-value capitalized and colored green, if a default was given.
+    my $result = prompt_for_boolean($prompt, $default, $invert);
 
-It will accept yes, no, true, or false as valid input, or just the initial
-characters of each, and case is ignored.
+Displays C<$prompt> on one line, then a C<[y|n] E<gt>> prompt on the following
+line. If C<$prompt> already contains C<[y|n]>, the entire prompt is shown on a
+single line.
 
-If the C<$invert> flag is true, it will return the inverted value of the
-response given.  This is useful when the question is easier to pose in the
-positive, but is stored in the negative.
+When C<$default> is provided, the matching option in C<[y|n]> is capitalized
+and colored green. Accepts C<y>, C<yes>, C<true>, C<n>, C<no>, or C<false> as
+input (case-insensitive); single initial characters are also accepted.
 
-Reads the contents of C<$path>, interprets it as YAML, and parses it into a
-Perl hashref structure.  This leverages C<spruce>, so it can only be used on
-YAML documents with top-level maps.  In practice, this limitation is hardly
-a problem.
+If C<$invert> is true, the logical sense of the response is reversed before
+returning. This is useful when the question is more natural to ask in the
+positive but the stored value is negative.
 
-=head2 prompt_for_choices($prompt, $choices, $min, $max, $labels, $err_msg)
-
-Provides the user with a numerical list of choices to choose from, a preample
-prompt above it and accepts a variable number of selections.  The user will
-select the number corresponding to their desired choices, and enter a blank
-line when they're finished (or it will auto-conclude if the maximum number of
-selections has been reached).
-
-Required arguments are the prompt and a reference to a list of choices that
-can be chosen.  By default, the labels for the choices will the same as the
-value of the choices, the minimum selection is 0 and the maximum is all of
-them.
-
-If your C<$choices> are not strings, or if you want to provide the user with
-more human-friendly representation (colors, additional details, etc), you can
-provide alternative label strings for each choice in C<$labels>, associated by
-corresponding index number.  Furthermore, you can provide each label as an
-array of two labels: first one is the one displayed on the choice list, and
-the second one is what gets displayed on the select line after the user has
-entered a value.  This is useful for when you are displaying complex strings
-(ie tabular data) that you don't want displayed on the select line.
-
-Specifying C<$min> and or C<$max> can allow you to present choices for
-scenarios such as optionally picking one of a selection ($max = 1), or
-choosing at least one but allowing for additional selection ($min = 1).
-
-By default, if you choose an invalid value, a generic message of "Invalid
-choice - enter a number between 1 and $max" will be displayed.  You can
-customize this by providing C<$err_msg>.
-
-=head2 prompt_for_choice($prompt, $choices, $default, $labels, $err_msg)
-
-Similar to C<prompt_for_choices>, but limited to a single choice.  For that
-trade-off, it gains the ability to specify a default value on the user
-entering a blank choice.
-
-If your C<$choices> are not strings, or if you want to provide the user with
-more human-friendly representation (colors, additional details, etc), you can
-provide alternative label strings for each choice in C<$labels>, associated by
-corresponding index number.  Furthermore, you can provide each label as an
-array of two labels: first one is the one displayed on the choice list, and
-the second one is what gets displayed on the select line after the user has
-entered a value.  This is useful for when you are displaying complex strings
-(ie tabular data) that you don't want displayed on the select line.
-
-The C<$default> value is specified as the choice, not the label, so if you're
-specifying alternative labels, be wary of that distinction.  The label of the
-default will have a green '(default)' appended to it.
-
-=head2 prompt_for_line($prompt,$label,$default,$validation,$err_msg)
-
-Provides a way to prompt your users for a line can can be validated before
-returning an acceptable value, reprompting on error.
-
-The output text is comprised of the C<$prompt> and the C<$label> contents.
-The prompt is printed once at the top, but the label is printed inline at each
-user entry.  This allows you to facilitate either a large explanatory prompt
-with a simple '> ' on the user entry line (C<$label> is C<undef>), or a short
-prompt that is repeated each time (C<$prompt> is C<undef>).
-
-If a default value is desired, it will be returned if the user enters a blank
-line.  The default will be displayed to the user at the end of the prompt if
-one was given, or otherwise at the end of the label if it was given.  The user
-entering a blank line would be reprompted to enter a value if C<$default> is
-undefined. If default is empty string, the default prompt will not be
-displayed, but will allow an empty response as valid.
-
-The most powerful aspect of this function is the ability to validate the input
-against several known formats:
+B<Parameters:>
 
 =over
 
-=item C<ip>
+=item C<$prompt>
 
-Ensures that the entry is a valid IP address: 4-octets between 0-255,
-non-zero-padded joined by periods.
+The question to display to the user.
 
-=item C<url>
+=item C<$default>
 
-Ensures that the entry is a valid URL.
+Optional. The default answer used when the user presses Enter without input.
+May be C<"y">, C<"yes">, C<"true">, C<"n">, C<"no">, C<"false">, C<1>, or
+C<0>. Numeric C<0>/C<1> values are normalized to C<"n">/C<"y">.
 
-=item C<port>
+=item C<$invert>
 
-Ensures that the entry is a numeric value between 0 and 65535.
-Deprecated: use bounded numeric value validation of "0-65535".
-
-=item bounded numeric value
-
-Ensures that the entry is numeric and falls under optional bounded ranges:
-"n-m": value must be between n and m
-"n+":  value must be n or greater
-
-n and m can either be integer or floating-point values and can be positive or
-negative.
-
-=item regular expression
-
-Ensures that the entry matches (or doesn't match) a given regular expression.
-This uses a string format of a perl-style regular expression, and supports
-C<i>, C<m> and C<s> flags.  To indicate exclusion of match, prefix with a
-C<!>.  For example, "!/(apple|orange)s?/i" would exclude any value that
-contains singular or plural apples and oranges.
-
-=item explicit list
-
-Ensures that the entry is (or isn't) in a list of known values.  This takes
-the form of a comma-separated list of values, enclosed in brackets, with an
-optional C<!> in front to negate (similar to regular expression validation
-above).
-
-Examples:
-
-"[fire,earth,air,water]"          - only allow classic Grecian elements
-"![password,123456,qwerty,admin]" - don't allow the worst passwords
-
-=item C<vault_path>
-
-Ensure that the entry is a valid vault path.
-
-=item C<vault_path_and_key>
-
-Ensure that the entry is a valid vault path and that the key exists under that
-path.
-
-=item code
-
-This is the last resort and should only be used if another validation type
-cannot be.  Unlike the others that are all strings, you can actually pass in a
-function ref to be run against the entry to check if it's valid.  The function
-takes the value as the first argument, and an optional error message as the
-second argument.
-
-The reason that code is not preferred even though it is much more flexable is
-that the primary source of the validation is being passed in by data file or
-bash script calls, so in those cases it is not viable.
+Optional. If true, the returned boolean value is the logical inverse of the
+user's answer.
 
 =back
 
-=head2 prompt_for_block($prompt)
+B<Returns:> A JSON boolean object. Yes-responses return the JSON true constant;
+no-responses return the JSON false constant (reversed when C<$invert> is true).
+The returned values are suitable for direct use in JSON serialization.
 
-Prompts user to enter a block of text that may contain numerous newlines.
-Entry is completed by pressing C<Ctrl-D>. (This information is appended to the
-end of the prompt).
+B<Examples:>
 
-=head2 prompt_for_list($type,$prompt,$label,$min,$max,$validation, $err_msg, $end_prompt)
+    my $enabled = prompt_for_boolean("Enable debug mode? [y|n]", "n");
+    # Returns: JSON false if user enters 'n' or presses Enter
 
-This is basically a wrapper for C<prompt_for_line> for collecting multiple
-entries, with support for specifying C<$min> and C<$max> entry counts.
+    my $disabled = prompt_for_boolean("Skip certificate validation?", "n", 1);
+    # Returns: JSON false if user enters 'y' (inverted)
 
-The entry C<$type> can be either 'line', or 'block' -- see above for details
-on those prompt_for_* functionality. Lists are completed either automatically
-when the max entries are met, or by the user entering a blank line for
-line-type lists, or by entering C<Ctrl-D> in an empty block in block-type
-lists.  (This information is provided to the user at the end of each label).
+=head2 prompt_for_choices
 
-Validation is only applicable to line-type lists, and uses the same validation
-as C<prompt_for_line>.
+    my $selected = prompt_for_choices($prompt, $choices, $min, $max, $labels, $err_msg);
 
-=head2 bullet([type,] msg, [%options])
+Displays a numbered list of choices preceded by C<$prompt>, then prompts the
+user to enter selection numbers one at a time. The user enters a blank line to
+finish (or selection ends automatically when C<$max> is reached).
 
-Provides a bulleted or checkbox line item
-
-Called with just a message, this will result in a the message being indented
-by two spaces, a bullet character and another space.
-
-The build-in bullet types are good and bad, which changes the bullet to a
-green checkbox or a red X respectively.  There is also an empty type, but this
-is only used with the box option (see below).
-
-Advanced funtionality provided through an option hash allows the user to
-over-ride the color, symbol, indention level and conversion to a checkbox.
-
-Options:
+B<Parameters:>
 
 =over
 
-=item symbol
+=item C<$prompt>
 
-Specify the symbol to use for the bullet. Defaults to unicode C<2022> (bullet), but automaticaly switches to C<2714> (check) and a space for C<good> type, C<2718> (X) and a space for C<bad> type, and two spaces for C<empty> type.
+Preamble text displayed above the numbered list.
 
-=item color
+=item C<$choices>
 
-Specify the color for the bullet -- uses C<csprintf> color codes.  Defaults to green for C<good> type and red for C<bad> type, unspecified for anything else.
+Required. An array reference of choice values.
 
-=item indent
+=item C<$min>
 
-Specify the number of characters to indent the line.  Defaults to 2
+Optional. Minimum number of selections required. Defaults to C<0>.
 
-=item box
+=item C<$max>
 
-Set to true to place a [  ] around the symbol - used to represent checkbox bullets
+Optional. Maximum number of selections allowed. Defaults to the total number
+of choices.
+
+=item C<$labels>
+
+Optional. An array reference of display labels, indexed to match C<$choices>.
+Each label may be either a plain string or an array reference of two strings:
+the first is shown in the numbered list, the second is shown on the
+confirmation line after the user selects that item. Defaults to using the
+choice values as labels.
+
+=item C<$err_msg>
+
+Optional. Custom error message shown when the user enters an invalid selection
+number. Defaults to C<"Invalid choice - enter a number between 1 and $max">.
 
 =back
+
+B<Returns:> An array reference of the selected choice values, in the order
+they were selected.
+
+B<Errors:>
+
+Dies with C<"Illegal list maximum count specified. Please contact your kit author for a fix.\n">
+if C<$max> is less than C<$min>.
+
+B<Examples:>
+
+    my $picks = prompt_for_choices(
+        "Select deployment targets:",
+        [qw(us-east-1 us-west-2 eu-west-1)],
+        1,   # at least 1
+        2,   # at most 2
+    );
+    # Returns: e.g. ['us-east-1', 'eu-west-1']
+
+=head2 prompt_for_choice
+
+    my $chosen = prompt_for_choice($prompt, $choices, $default, $labels, $err_msg, $object_description);
+
+Similar to C<prompt_for_choices>, but limited to exactly one selection. In
+exchange for this limitation, the function supports a C<$default> value that
+is returned when the user presses Enter without input.
+
+If C<$labels> are provided, they follow the same format as in
+C<prompt_for_choices>: plain strings or two-element array references. Labels
+matching the pattern C<---text---"> are treated as section headers displayed
+without a selection number; the label C<"---"> inserts a blank separator line.
+
+The C<$default> is matched against the choice values (not the labels). The
+matching choice's label has a green C<(default)> suffix appended when
+displayed.
+
+B<Parameters:>
+
+=over
+
+=item C<$prompt>
+
+Text displayed above the numbered list.
+
+=item C<$choices>
+
+Required. An array reference of choice values.
+
+=item C<$default>
+
+Optional. The value from C<$choices> to pre-select. The user can accept it by
+pressing Enter.
+
+=item C<$labels>
+
+Optional. Display labels for the choices; see description above.
+
+=item C<$err_msg>
+
+Optional. Custom error message shown on invalid input. Defaults to
+C<"enter a number between 1 and $num_choices">.
+
+=item C<$object_description>
+
+Optional. The noun used in the selection prompt line (e.g., C<"environment">
+produces C<"Select environment E<gt>">). Defaults to C<"choice">.
+
+=back
+
+B<Returns:> The selected element from C<$choices>.
+
+B<Examples:>
+
+    my $env = prompt_for_choice(
+        "Which environment?",
+        [qw(dev staging prod)],
+        "dev",
+    );
+    # Returns: e.g. 'staging'
+
+    my $region = prompt_for_choice(
+        "Select a region:",
+        [qw(us-east-1 us-west-2 eu-west-1)],
+        undef,
+        undef,
+        undef,
+        "region",
+    );
+    # Prompt reads: "Select region >"
+
+=head2 prompt_for_line
+
+    my $value = prompt_for_line($prompt, $label, $default, $validation, $err_msg);
+
+Prompts the user for a single line of text, optionally validating the input
+and reprompting on invalid entries.
+
+The display is split between C<$prompt> and C<$label>. C<$prompt> is printed
+once above the input, while C<$label> appears on each reprompt line inline
+with the C<E<gt>> cursor. Either may be C<undef>: pass C<undef> for C<$prompt>
+to use label-only mode (label repeats each attempt), or C<undef> for C<$label>
+to use a bare C<E<gt>> cursor.
+
+When C<$default> is defined and non-empty, it is shown in green next to the
+prompt or label. Pressing Enter accepts the default. If C<$default> is an
+empty string C<"">, the empty response is accepted silently without displaying
+a default hint.
+
+B<Parameters:>
+
+=over
+
+=item C<$prompt>
+
+Optional. One-time explanatory text printed before the input line.
+
+=item C<$label>
+
+Optional. Label repeated on each input attempt. Appended with C<E<gt>> to
+form the cursor.
+
+=item C<$default>
+
+Optional. Default value returned when the user presses Enter on a blank line.
+Pass C<undef> to require a non-empty response. Pass C<""> to allow blank
+without displaying a default hint.
+
+=item C<$validation>
+
+Optional. A validation specifier. Supported values:
+
+=over
+
+=item C<"ip">
+
+Requires a valid IPv4 address: four dot-separated octets in the range 0-255,
+with no zero-padding.
+
+=item C<"url">
+
+Requires a valid URL.
+
+=item C<"port">
+
+Requires a numeric value between 0 and 65535. Deprecated: prefer the
+C<"0-65535"> bounded numeric form.
+
+=item C<"n-m"> or C<"n+">
+
+Bounded numeric validation. C<"n-m"> requires a value between C<n> and C<m>
+inclusive; C<"n+"> requires a value of at least C<n>. Both C<n> and C<m> may
+be integers or floating-point values and may be negative.
+
+=item C<"/pattern/flags"> or C<"!/pattern/flags">
+
+Regular expression validation. Supports C<i>, C<m>, and C<s> flags. A leading
+C<!> negates the match (entry must I<not> match the pattern).
+
+=item C<"[val1,val2,...]"> or C<"![val1,val2,...]">
+
+Explicit list validation. Entry must be (or, with C<!>, must not be) one of
+the comma-separated values in the brackets.
+
+=item C<"vault_path">
+
+Requires a path that exists in the currently targeted Vault. Skips the
+existence check when not connected to a Vault.
+
+=item C<"vault_path_and_key">
+
+Requires a C<path:key> pair where both the path and key exist in the currently
+targeted Vault. Skips the existence check when not connected to a Vault.
+
+=item code reference
+
+A subroutine C<sub { my ($value, $err_msg) = @_; ... }> that returns an empty
+string on success or an error message string on failure.
+
+=back
+
+=item C<$err_msg>
+
+Optional. Custom error message passed to the validation function when
+validation fails.
+
+=back
+
+B<Returns:> The validated input string, or a numeric value if the input
+parses as a number.
+
+B<Examples:>
+
+    my $ip = prompt_for_line(
+        "Enter the BOSH director IP",
+        "Director IP",
+        "10.0.0.6",
+        "ip",
+    );
+    # Returns: e.g. '10.0.0.6'
+
+    my $port = prompt_for_line(undef, "Port number", "443", "0-65535");
+    # Returns: e.g. 443  (numeric)
+
+=head2 prompt_for_list
+
+    my $items = prompt_for_list($type, $prompt, $label, $min, $max, $validation, $err_msg, $end_prompt);
+
+Collects multiple entries from the user, returning them as an array reference.
+Each entry is prompted with an ordinal label (C<"1st value E<gt>">,
+C<"2nd value E<gt>">, etc.). The loop ends when the user submits a blank entry
+(line mode) or presses Ctrl-D on an empty block (block mode), or when C<$max>
+entries have been collected.
+
+B<Parameters:>
+
+=over
+
+=item C<$type>
+
+Required. Either C<"line"> to collect single-line entries via
+C<prompt_for_line>, or C<"block"> to collect multi-line entries via
+C<prompt_for_block>.
+
+=item C<$prompt>
+
+Text printed once above the first prompt.
+
+=item C<$label>
+
+Optional. Noun used in each ordinal prompt. Defaults to C<"value">.
+
+=item C<$min>
+
+Optional. Minimum number of entries required. Defaults to C<0>.
+
+=item C<$max>
+
+Optional. Maximum number of entries allowed. When reached, the loop ends
+automatically. Must be at least C<1> when provided.
+
+=item C<$validation>
+
+Optional. Validation specifier for C<"line"> type entries; uses the same
+format as C<prompt_for_line>. Ignored for C<"block"> type.
+
+=item C<$err_msg>
+
+Optional. Custom error message passed to the validation function on failure.
+
+=item C<$end_prompt>
+
+Optional. Text appended to C<$prompt> to inform the user how to end input.
+Defaults to C<"(leave $label empty to end)">.
+
+=back
+
+B<Returns:> An array reference of the collected entry strings, in the order
+they were entered.
+
+B<Errors:>
+
+Dies with C<"Illegal list maximum count specified. Please contact your kit author for a fix.\n">
+if C<$max> is defined and less than C<1>.
+
+B<Examples:>
+
+    my $ips = prompt_for_list(
+        "line",
+        "Enter the IP addresses of your NTP servers",
+        "NTP IP",
+        1,    # at least 1
+        undef,
+        "ip",
+    );
+    # Returns: e.g. ['10.0.0.1', '10.0.0.2']
+
+    my $certs = prompt_for_list("block", "Paste each CA certificate", "CA cert", 1);
+    # Returns: array ref of PEM certificate strings
+
+=head2 prompt_for_block
+
+    my $text = prompt_for_block($prompt);
+
+Prompts the user to enter a multi-line block of text. The prompt is displayed
+with a dashed underline, and the user signals end-of-input by pressing
+C<Ctrl-D> on an empty line. The C<(Enter E<lt>CTRL-DE<gt> to end)> note is
+appended to the prompt automatically.
+
+B<Parameters:>
+
+=over
+
+=item C<$prompt>
+
+Text displayed above the input area.
+
+=back
+
+B<Returns:> The full block of text entered by the user as a single string,
+with all newlines preserved.
+
+B<Examples:>
+
+    my $notes = prompt_for_block("Paste your deployment notes:");
+    # Returns: e.g. "Line one\nLine two\n"
+
+=head2 new_prompt_for_choice
+
+    my $value = new_prompt_for_choice(%options);
+
+A modernized single-choice selector that accepts a named-parameter hash. It
+supports compact multi-column display, optional pagination, section headers,
+and separators within the choice list.
+
+Can also be called in the legacy positional argument style for backwards
+compatibility: C<new_prompt_for_choice($prompt, $choices, $default, $labels, $err_msg, $object_description)>.
+When the second argument is an array reference, the legacy code path is taken
+and the positional arguments are converted to named options internally.
+
+B<Parameters:>
+
+=over
+
+=item C<choices>
+
+Required. An array reference of choice items. Each item is either a plain
+scalar (used as both value and label) or a hash reference with the following
+optional keys:
+
+=over
+
+=item C<value>
+
+The value returned when this item is selected (required for selectable items).
+
+=item C<label>
+
+Display text shown in the numbered list. Defaults to C<value>.
+
+=item C<summary>
+
+Text shown on the confirmation line after the user selects this item.
+Defaults to C<label>.
+
+=item C<section>
+
+A string that causes this entry to be rendered as a section header (bold,
+underlined) rather than a numbered choice.
+
+=item C<separator>
+
+A boolean that causes this entry to render as a blank separator line rather
+than a numbered choice.
+
+=back
+
+=item C<header>
+
+Optional. Heading text displayed above the choice list. Defaults to
+C<"Select one of the following choices:"> (noun from C<description> is
+substituted).
+
+=item C<default>
+
+Optional. The default selection. May be the choice's C<value> string, a
+positive 1-based index, or a negative index counting from the end (e.g.,
+C<-1> selects the last choice).
+
+=item C<description>
+
+Optional. The noun used in the C<"Select E<lt>descriptionE<gt> E<gt>"> prompt
+line. Defaults to C<"choice">.
+
+=item C<error>
+
+Optional. Custom error message shown when the user enters an invalid number.
+Defaults to C<"Enter a number between 1 and $num_choices">.
+
+=item C<compact>
+
+Optional. When true, choices are displayed in multiple columns calculated to
+fit the terminal width. Defaults to C<0>.
+
+=item C<paginate>
+
+Optional. When true, navigation commands C<N> (next page) and C<P> (previous
+page) are accepted in addition to selection numbers. Pagination is partially
+implemented. Defaults to C<0>.
+
+=back
+
+B<Returns:> The C<value> of the selected choice.
+
+B<Errors:>
+
+Calls C<bug()> with C<"Invalid options passed to prompt_for_choice: %s"> if
+unknown keys are present in the options hash, where C<%s> is a comma-separated
+list of the unknown key names.
+
+Calls C<bug()> with C<"prompt_for_choice requires 'choices' parameter and it must be an arrayref">
+if C<choices> is missing or not an array reference.
+
+Calls C<bug()> with C<"Invalid default choice: %s"> if the C<default> value
+does not match any choice's value or a valid index, where C<%s> is the
+provided default value.
+
+B<Examples:>
+
+    my $region = new_prompt_for_choice(
+        header      => "Which AWS region?",
+        choices     => [qw(us-east-1 us-west-2 eu-west-1)],
+        default     => "us-east-1",
+        description => "region",
+    );
+    # Returns: e.g. 'us-west-2'
+
+    my $env = new_prompt_for_choice(
+        header  => "Select deployment environment:",
+        choices => [
+            { value => "dev",     label => "Development" },
+            { value => "staging", label => "Staging" },
+            { value => "prod",    label => "Production" },
+        ],
+        default => "dev",
+    );
+    # Returns: e.g. 'staging'
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 __prompt_for_line
+
+    __prompt_for_line($prompt, $validation, $err_msg, $default, $allow_blank)
+
+Core line-input loop used by all public prompt functions. Displays the prompt
+with a trailing C<E<gt>>, reads from C<STDIN>, applies the optional validation
+specifier, and loops until the input passes or the blank-allowed condition is
+met.
+
+When C<$default> is defined and the user presses Enter, the default is
+substituted and echoed back. When C<$allow_blank> is true and the input is
+empty, returns C<""> immediately. Numeric inputs are detainted and returned as
+numbers.
+
+Dies with C<"Error compiling param regex: $!"> if the C<$validation> string is
+a regex-format specifier and the pattern fails to compile.
+
+B<Examples:>
+
+    # Used internally by prompt_for_line and prompt_for_choices
+    my $val = __prompt_for_line("Enter IP", "ip", undef, "10.0.0.1", undef);
+    # Returns: user input or '10.0.0.1' if Enter pressed
+
+=head2 __prompt_for_block
+
+    __prompt_for_block($prompt)
+
+Core block-input reader used by C<prompt_for_block> and C<prompt_for_list> in
+block mode. Displays the prompt with a dashed underline and appends
+C<(Enter E<lt>CTRL-DE<gt> to end)>, then reads all lines from C<STDIN> until
+EOF. Returns the collected text as a single joined string.
+
+B<Examples:>
+
+    # Used internally by prompt_for_block and prompt_for_list
+    my $text = __prompt_for_block("Paste certificate");
+    # Returns: multi-line string ending with final newline
+
+=head2 __process_legacy_prompt_for_choice_args
+
+    __process_legacy_prompt_for_choice_args($prompt, $old_choices, $old_default, $labels, $err_msg, $object_description)
+
+Converts the positional argument style of the original C<prompt_for_choice>
+into the named-option hash expected by C<new_prompt_for_choice>. Called
+automatically when C<new_prompt_for_choice> detects legacy-style arguments
+(second argument is an array reference).
+
+Section headers (labels matching C<---text--->)  and separators (labels equal
+to C<--->) in C<$labels> are converted to C<{section =E<gt> ...}> and
+C<{separator =E<gt> 1}> hash entries in the resulting choices array.
+
+Returns a flat key-value list suitable for assignment to a C<%options> hash.
+
+B<Examples:>
+
+    # Used internally by new_prompt_for_choice when legacy args are detected
+    my %opts = __process_legacy_prompt_for_choice_args(
+        "Select env:", [qw(dev staging prod)], "dev", undef, undef, undef
+    );
+    # Returns: (header => 'Select env:', choices => [...], default => 'dev', ...)
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
 
 =cut

--- a/lib/Genesis/UI.pod
+++ b/lib/Genesis/UI.pod
@@ -93,6 +93,9 @@ Displays a numbered list of choices preceded by C<$prompt>, then prompts the
 user to enter selection numbers one at a time. The user enters a blank line to
 finish (or selection ends automatically when C<$max> is reached).
 
+B<Note:> Unlike C<prompt_for_choice>, this function does not support
+section-header labels (C<---text--->) or separator labels (C<--->).
+
 B<Parameters:>
 
 =over
@@ -157,7 +160,7 @@ is returned when the user presses Enter without input.
 
 If C<$labels> are provided, they follow the same format as in
 C<prompt_for_choices>: plain strings or two-element array references. Labels
-matching the pattern C<---text---"> are treated as section headers displayed
+matching the pattern C<---text---> are treated as section headers displayed
 without a selection number; the label C<"---"> inserts a blank separator line.
 
 The C<$default> is matched against the choice values (not the labels). The
@@ -513,9 +516,8 @@ fit the terminal width. Defaults to C<0>.
 
 =item C<paginate>
 
-Optional. When true, navigation commands C<N> (next page) and C<P> (previous
-page) are accepted in addition to selection numbers. Pagination is partially
-implemented. Defaults to C<0>.
+Optional. Setting C<paginate =E<gt> 1> currently has no effect; pagination is
+not yet implemented. Defaults to C<0>.
 
 =back
 

--- a/lib/Genesis/UI.pod
+++ b/lib/Genesis/UI.pod
@@ -281,8 +281,8 @@ C<"0-65535"> bounded numeric form.
 =item C<"n-m"> or C<"n+">
 
 Bounded numeric validation. C<"n-m"> requires a value between C<n> and C<m>
-inclusive; C<"n+"> requires a value of at least C<n>. Both C<n> and C<m> may
-be integers or floating-point values and may be negative.
+inclusive; C<"n+"> requires a value of at least C<n>. Both C<n> and C<m> must
+be non-negative integers (matching C</^\d+$/>).
 
 =item C<"/pattern/flags"> or C<"!/pattern/flags">
 


### PR DESCRIPTION
## Summary

- Add companion `.pod` documentation for `Genesis::Log` (887 lines) and `Genesis::Term` (1335 lines)
- Rewrite and complete `Genesis::UI.pod` with full method coverage (7 public, 3 internal)
- All 3 modules pass mechanical validation with 0 failures (506/506 checks)

## Modules

| Module | Lines | Methods | Validation |
|--------|-------|---------|------------|
| Genesis::Log | 640 | 18 public, 2 internal | 164/164 |
| Genesis::Term | 959 | 22 public, 8 internal + 8 ANSI vars | 256/256 |
| Genesis::UI | 661 | 7 public, 3 internal | 86/86 |

## Notes

- No inline POD remains in any `.pm` file
- Code defects discovered during documentation tracked in FWT-701
- Deferred quality review items documented in FWT-650 comments

Resolves [FWT-650](https://fivetwenty.atlassian.net/browse/FWT-650)

## Test plan

- [ ] `podchecker lib/Genesis/Log.pod` — no errors
- [ ] `podchecker lib/Genesis/Term.pod` — no errors
- [ ] `podchecker lib/Genesis/UI.pod` — no errors
- [ ] `perldoc lib/Genesis/Log.pod` renders correctly
- [ ] `perldoc lib/Genesis/Term.pod` renders correctly
- [ ] `perldoc lib/Genesis/UI.pod` renders correctly
- [ ] No inline POD in `.pm` files: `grep -c '^=head' lib/Genesis/{Log,Term,UI}.pm` all return 0