### PR TITLE
FWT-588: Fix Service::Vault POD review gaps

### DIFF
--- a/lib/Service/Vault.pm
+++ b/lib/Service/Vault.pm
@@ -250,13 +250,30 @@ sub parse_vault_descriptor {
 
 ### Instance Methods {{{
 
-# public accessors: url, name, verify, tls {{{
-sub url        { $_[0]->{url};       }
-sub name       { $_[0]->{name};      }
-sub verify     { $_[0]->{verify};    }
-sub namespace  { $_[0]->{namespace}; }
-sub strongbox  { $_[0]->{strongbox}; }
-sub tls        { $_[0]->{url} =~ "^https://"; }
+# public accessors: url, name, verify, namespace, strongbox, tls {{{
+sub url {
+	$_[0]->{url};
+}
+
+sub name {
+	$_[0]->{name};
+}
+
+sub verify {
+	$_[0]->{verify};
+}
+
+sub namespace {
+	$_[0]->{namespace};
+}
+
+sub strongbox {
+	$_[0]->{strongbox};
+}
+
+sub tls {
+	$_[0]->{url} =~ "^https://";
+}
 
 #}}}
 # connect_and_validate - connect to the vault and validate that its connected {{{

--- a/lib/Service/Vault.pod
+++ b/lib/Service/Vault.pod
@@ -89,6 +89,14 @@ B<Errors:>
 Raises C<"Expected %s to provide 'connect_and_validate' method, but it did
 not (or called SUPER)"> when called on the base class. C<%s> is the class name.
 
+B<Returns:> Defined by subclass implementation.
+
+B<Examples:>
+
+  # Subclasses call connect_and_validate internally during target/attach
+  my $vault = Service::Vault::Remote->target('prod-vault');
+  # Returns: subclass-defined (target() calls connect_and_validate internally)
+
 =head2 authenticate
 
   $vault->authenticate();
@@ -477,33 +485,77 @@ B<Examples:>
 Returns the URL of the Vault target in the form C<scheme://host:port>. The
 port is optional; it is implied as C<80> for C<http> and C<443> for C<https>.
 
-The C<name>, C<verify>, C<namespace>, C<strongbox>, and C<tls> accessors are
-defined alongside this method and follow the same calling convention.
-
 B<Returns:> A string such as C<'https://vault.example.com:8200'>.
-
-B<Errors:>
-
-Raises C<"Expected %s to provide 'connect_and_validate' method, but it did
-not (or called SUPER)"> when C<connect_and_validate> is called on the base
-class directly. C<%s> is the class name.
 
 B<Examples:>
 
   print $vault->url();
   # Returns: 'https://vault.example.com:8200'
 
+=head2 name
+
+  my $name = $vault->name();
+
+Returns the target alias as registered in C<~/.saferc>.
+
+B<Returns:> A string (the target alias, e.g. C<'prod-vault'>).
+
+B<Examples:>
+
   print $vault->name();
   # Returns: 'prod-vault'
+
+=head2 verify
+
+  my $verify = $vault->verify();
+
+Returns whether TLS certificate verification is enabled for this vault.
+
+B<Returns:> C<1> if verification is enabled, C<0> if disabled.
+
+B<Examples:>
 
   print $vault->verify();
   # Returns: 1
 
+=head2 namespace
+
+  my $ns = $vault->namespace();
+
+Returns the Vault namespace string configured for this vault.
+
+B<Returns:> A string, or C<''> if no namespace is set.
+
+B<Examples:>
+
   print $vault->namespace();
-  # Returns: '' or 'admin'
+  # Returns: ''
+
+=head2 strongbox
+
+  my $sb = $vault->strongbox();
+
+Returns whether strongbox mode is enabled. Defaults to true when not
+explicitly configured.
+
+B<Returns:> C<1> if enabled, C<0> if disabled.
+
+B<Examples:>
 
   print $vault->strongbox();
   # Returns: 1
+
+=head2 tls
+
+  my $is_tls = $vault->tls();
+
+Returns whether the vault URL uses HTTPS. This is computed from the URL
+rather than stored as a separate property.
+
+B<Returns:> True (C<1>) if the URL starts with C<https://>, false (empty
+string) otherwise.
+
+B<Examples:>
 
   print $vault->tls() ? 'TLS' : 'plaintext';
   # Returns: 'TLS'

--- a/lib/Service/Vault.pod
+++ b/lib/Service/Vault.pod
@@ -531,6 +531,10 @@ B<Examples:>
   print $vault->namespace();
   # Returns: ''
 
+  # When the vault URL includes a namespace path
+  print $vault->namespace();
+  # Returns: 'admin'
+
 =head2 strongbox
 
   my $sb = $vault->strongbox();

--- a/lib/Service/Vault/None.pm
+++ b/lib/Service/Vault/None.pm
@@ -19,11 +19,17 @@ sub new {
 
 ### Instance Methods {{{
 
-sub DESTROY {} # Prevents AUTOLOAD from causing a problem
+sub DESTROY {
+	# Prevents AUTOLOAD from causing a problem
+}
 
-sub name {return ''}
+sub name {
+	return '';
+}
 
-sub status {return 'absent'}
+sub status {
+	return 'absent';
+}
 
 # AUTOLOAD - errors out when a normal vault method is called {{{
 our $AUTOLOAD;

--- a/lib/Service/Vault/None.pod
+++ b/lib/Service/Vault/None.pod
@@ -64,6 +64,42 @@ B<Examples:>
   my $vault = Service::Vault::None->new();
   # returns a Service::Vault::None object
 
+=head2 name
+
+  my $name = $vault->name();
+
+Returns an empty string. The null vault has no name because it represents the
+absence of a vault connection.
+
+B<Returns:> An empty string C<''>.
+
+B<Examples:>
+
+  my $vault = Service::Vault::None->new();
+  print $vault->name();
+  # prints ''
+
+=head2 status
+
+  my $status = $vault->status();
+
+Returns C<'absent'>. This sentinel value distinguishes the null vault from real
+vault objects, which return status strings such as C<'ok'>, C<'sealed'>, or
+C<'unreachable'>.
+
+B<Returns:> The string C<'absent'>.
+
+B<Examples:>
+
+  my $vault = Service::Vault::None->new();
+  print $vault->status();
+  # prints 'absent'
+
+  if ($vault->status eq 'absent') {
+    print "No vault configured\n";
+  }
+  # prints 'No vault configured'
+
 =head1 AUTHORS
 
 Written by the Genesis team.


### PR DESCRIPTION
## Summary

- Add missing `=head2` sections for 5 Vault accessors (`name`, `verify`, `namespace`, `strongbox`, `tls`)
- Add `B<Returns:>` and `B<Examples:>` to `connect_and_validate`
- Add `=head2 name` and `=head2 status` to `Service::Vault::None`
- Expand one-liner subs to multi-line format for POD validator compatibility

## Context

Dennis reviewed [FWT-588](https://fivetwenty.atlassian.net/browse/FWT-588) and found 9 validation failures across `Service::Vault` (7) and `Service::Vault::None` (2). All gaps have been addressed.

## Validation

All 6 Service::Vault modules pass mechanical validation with 0 failures:

| Module | Checks |
|--------|--------|
| Service::Vault | 366/366 |
| Service::Vault::Remote | 71/71 |
| Service::Vault::Admin | 101/101 |
| Service::Vault::Local | 94/94 |
| Service::Vault::None | 31/31 |
| Service::Vault::Admin::AppRole | 58/58 |
| **Total** | **721/721** |

## Test plan

- [ ] Verify all 6 modules pass `skill.py validate` with 0 failures
- [ ] Confirm `.pm` formatting changes are whitespace-only (no behavioral change)
- [ ] Review new `=head2` accessor sections match actual method behavior