### PR TITLE
FWT-701: Document compact mode as unimplemented

### DIFF
--- a/lib/Genesis/UI.pod
+++ b/lib/Genesis/UI.pod
@@ -511,8 +511,9 @@ Defaults to C<"Enter a number between 1 and $num_choices">.
 
 =item C<compact>
 
-Optional. When true, choices are displayed in multiple columns calculated to
-fit the terminal width. Defaults to C<0>.
+Optional. Intended to display choices in multiple columns calculated to fit
+the terminal width. B<Not yet implemented:> setting C<compact =E<gt> 1>
+will currently abort with a C<bug()> error. Defaults to C<0>.
 
 =item C<paginate>
 

--- a/lib/Genesis/UI.pod
+++ b/lib/Genesis/UI.pod
@@ -512,8 +512,9 @@ Defaults to C<"Enter a number between 1 and $num_choices">.
 =item C<compact>
 
 Optional. Intended to display choices in multiple columns calculated to fit
-the terminal width. B<Not yet implemented:> setting C<compact =E<gt> 1>
-will currently abort with a C<bug()> error. Defaults to C<0>.
+the terminal width. B<Not yet implemented:> enabling C<compact> (any true
+value) is currently broken and will cause the program to abort with a fatal
+error. Defaults to C<0>.
 
 =item C<paginate>
 


### PR DESCRIPTION
## Summary

- Update UI.pod `compact` parameter documentation to note it is not yet implemented and will abort with `bug()` at runtime
- Matches the existing `paginate` documentation style ("currently has no effect")
- Verified Log.pod `get_scope` known-bug note is already accurate (no changes needed)
- Created child ticket FWT-702 for the actual code fixes

## Jira

- https://fivetwenty.atlassian.net/browse/FWT-701
- https://fivetwenty.atlassian.net/browse/FWT-702 (child: code fixes)

## Validation

- `podchecker`: 3/3 .pod files pass
- `pod-validate Genesis::Log`: 164/164 checks passed
- `pod-validate Genesis::Term`: 255/256 passed (1 pre-existing Carp::cluck cross-ref)
- `pod-validate Genesis::UI`: 86/86 checks passed

## Test Plan

- [x] podchecker passes on all 3 .pod files
- [x] pod-validate shows 0 new failures
- [x] UI.pod compact parameter accurately reflects runtime behavior
- [x] Log.pod get_scope bug note verified against code