### PR TITLE
FWT-702: Fix code defects in Log/Term/UI

### DIFF
--- a/lib/Genesis/Log.pm
+++ b/lib/Genesis/Log.pm
@@ -584,7 +584,7 @@ sub log_levels {
 sub get_scope {
 	my ($scope) = @_;
 	my $out = "";
-	for (_get_stack($scope+1)) {
+	for (get_stack($scope+1)) {
 		$out .= csprintf("#K\@{^-}#Ki{ %s:L%d%s\n}", $_->{file}, $_->{line}, $_->{sub} ? " (in $_->{sub})" : '');
 		last unless envset ("GENESIS_STACK_TRACE");
 	}

--- a/lib/Genesis/Log.pod
+++ b/lib/Genesis/Log.pod
@@ -665,13 +665,7 @@ number, and optionally the subroutine name, styled with terminal color codes.
 If the C<GENESIS_STACK_TRACE> environment variable is set, additional frames
 are included (one per line); otherwise only the immediate caller is shown.
 
-B<Note: this function has a known bug.> The implementation calls
-C<_get_stack>, a private function that does not exist in this module. The
-public equivalent C<get_stack> exists and is the intended callee. As a
-result, C<get_scope> will raise a runtime error when called. This defect
-is tracked for a future fix.
-
-Until this is resolved, callers should use C<get_stack> directly.
+Internally delegates to C<get_stack> for stack frame retrieval.
 
 B<Parameters:>
 
@@ -686,7 +680,7 @@ B<Returns:> A formatted string of the call location with color markup.
 
 B<Examples:>
 
-  # Intended usage (currently broken due to the _get_stack bug):
+  # Example usage:
   my $loc = get_scope(0);
   # Returns: a string like '^- lib/Genesis/Secret.pm:L42 (in Genesis::Secret::new)'
 

--- a/lib/Genesis/Term.pm
+++ b/lib/Genesis/Term.pm
@@ -243,7 +243,7 @@ sub decolorize {
 
 sub csize {
 	my $str = shift;
-	my $size = length(decolorize($str)) + length(join('', (map {csprintf($_)} $str =~ m/#E\{[^\}]+}/g)));
+	return length(decolorize($str)) + length(join('', (map {csprintf($_)} $str =~ m/#E\{[^\}]+}/g)));
 }
 
 sub wrap {

--- a/lib/Genesis/Term.pm
+++ b/lib/Genesis/Term.pm
@@ -613,7 +613,6 @@ sub build_markdown_blockquote {
 	$block =~ s/^\s*>\s*//;
 	$block =~ s/\n\s*>\s*//g;
 	return wrap($block, $width, ' ' x $indent, $indent);
-	return wrap($block =~ s/^\s*>\s*//gmr, $width, boxify('line', 'left').' ');
 }
 
 sub process_markdown_block {

--- a/lib/Genesis/Term.pm
+++ b/lib/Genesis/Term.pm
@@ -857,7 +857,6 @@ sub get_control_picture {
 
 sub string_to_hex {
 	my ($str) = @_;
-	my $printable = '';
 
 	my $offset = 0;
 	while ($str) {

--- a/lib/Genesis/UI.pm
+++ b/lib/Genesis/UI.pm
@@ -628,10 +628,9 @@ sub __process_legacy_prompt_for_choice_args {
 	);
 	
 	# Convert old choices and labels format to new choices format
-	$choices = [];
+	my $choices = [];
 	my $label_offset = 0;
 	for my $i (0 .. $#{$old_choices}) {
-		my $j = $i + $label_offset;
 		my $choice = {
 			value => $old_choices->[$i],
 		};

--- a/lib/Genesis/UI.pm
+++ b/lib/Genesis/UI.pm
@@ -381,6 +381,8 @@ sub new_prompt_for_choice {
 	$options{description} //= "choice";
 	$options{header} //= sprintf("Select one of the following %s:", count_nouns(2, $options{description}, suppress_count => 1));
 	$options{compact} //= 0;
+	bug("prompt_for_choice compact mode is not yet implemented")
+		if $options{compact};
 	$options{paginate} //= 0;
 	
 	# Deal with default choice

--- a/t/unit-tests/genesis_log-get_scope.t
+++ b/t/unit-tests/genesis_log-get_scope.t
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use lib 't';
+use helper;
+
+use_ok 'Genesis::Log';
+
+subtest 'get_scope returns formatted scope string' => sub {
+	my $scope;
+	lives_ok { $scope = get_scope(0) } 'get_scope(0) does not die';
+	ok(defined $scope, 'returns a defined value');
+	like($scope, qr/genesis_log-get_scope\.t/, 'scope contains caller filename');
+	like($scope, qr/L\d+/, 'scope contains line number');
+};
+
+done_testing;

--- a/t/unit-tests/genesis_term-csize.t
+++ b/t/unit-tests/genesis_term-csize.t
@@ -1,0 +1,15 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use lib 't';
+use helper;
+
+use_ok 'Genesis::Term';
+
+subtest 'csize returns display width of colored strings' => sub {
+	is(csize("hello"), 5, 'plain text returns character count');
+	is(csize(""), 0, 'empty string returns 0');
+	is(csize("ab"), 2, 'short string works');
+};
+
+done_testing;

--- a/t/unit-tests/genesis_term-csize.t
+++ b/t/unit-tests/genesis_term-csize.t
@@ -10,6 +10,7 @@ subtest 'csize returns display width of colored strings' => sub {
 	is(csize("hello"), 5, 'plain text returns character count');
 	is(csize(""), 0, 'empty string returns 0');
 	is(csize("ab"), 2, 'short string works');
+	is(csize("#G{hi}"), 2, 'colored string width ignores color markup');
 };
 
 done_testing;


### PR DESCRIPTION
## Summary

- Fix `get_scope` calling nonexistent `_get_stack` (Log.pm) — high severity runtime error
- Fix undeclared `$choices` variable and remove unused `$j` (UI.pm)
- Gate unimplemented compact mode with early `bug()` call (UI.pm)
- Remove dead return in `build_markdown_blockquote` (Term.pm)
- Remove shadowed `$printable` variable in `string_to_hex` (Term.pm)
- Add explicit `return` to `csize` (Term.pm)

## Test plan

- [x] `prove -lv t/unit-tests/genesis_log-get_scope.t` — passes
- [x] `prove -lv t/unit-tests/genesis_term-csize.t` — passes
- [x] `podchecker` on Log.pod, Term.pod, UI.pod — all clean