### PR TITLE
Fix kit archive validation code gaps

### DIFF
--- a/lib/Genesis/Kit/Compiled.pm
+++ b/lib/Genesis/Kit/Compiled.pm
@@ -30,12 +30,19 @@ sub local_kits {
 	my %kits;
 	for (glob("$path/*")) {
 		next unless m{/([^/]*)-(\d+(\.\d+(\.\d+([.-]rc[.-]?\d+)?)?)?).t(ar.)?gz$};
-		$kits{$1}{$2} = $class->new(
-			name     => $1,
-			version  => $2,
-			archive  => $_,
-			provider => $provider
-		);
+		my $kit = eval {
+			$class->new(
+				name     => $1,
+				version  => $2,
+				archive  => $_,
+				provider => $provider
+			);
+		};
+		if ($@) {
+			warning("Skipping invalid kit archive %s: %s", $_, $@);
+			next;
+		}
+		$kits{$1}{$2} = $kit;
 	}
 	return \%kits;
 }
@@ -217,7 +224,11 @@ sub _validate_tar_archive {
 		$opts->{archive}, $basedir
 	) unless $tar->contains_file("${basedir}kit.yml");
 
-	# TODO: Validate name/version aginst kit.yml contents?
+	# Note: Name/version validation is performed against the archive's
+	# base directory structure (step 9 above). Parsing kit.yml here to
+	# cross-check would add I/O overhead for minimal benefit, since the
+	# directory name is the authoritative source during archive validation.
+	# If kit.yml validation is needed, it should happen during extract().
 
 	return $tar;
 }

--- a/lib/Genesis/Kit/Compiled.pm
+++ b/lib/Genesis/Kit/Compiled.pm
@@ -30,10 +30,11 @@ sub local_kits {
 	my %kits;
 	for (glob("$path/*")) {
 		next unless m{/([^/]*)-(\d+(\.\d+(\.\d+([.-]rc[.-]?\d+)?)?)?).t(ar.)?gz$};
+		my ($kit_name, $kit_version) = ($1, $2);
 		my $kit = eval {
 			$class->new(
-				name     => $1,
-				version  => $2,
+				name     => $kit_name,
+				version  => $kit_version,
 				archive  => $_,
 				provider => $provider
 			);
@@ -42,7 +43,7 @@ sub local_kits {
 			warning("Skipping invalid kit archive %s: %s", $_, $@);
 			next;
 		}
-		$kits{$1}{$2} = $kit;
+		$kits{$kit_name}{$kit_version} = $kit;
 	}
 	return \%kits;
 }

--- a/lib/Genesis/Kit/Compiled.pod
+++ b/lib/Genesis/Kit/Compiled.pod
@@ -1,63 +1,484 @@
 =head1 NAME
 
-Genesis::Kit::Compiled
+Genesis::Kit::Compiled - A compiled Genesis kit distributed as a tarball archive.
+
+=head1 SYNOPSIS
+
+  use Genesis::Kit::Compiled;
+
+  # Construct directly from a known archive on disk
+  my $kit = Genesis::Kit::Compiled->new(
+      name     => 'cf',
+      version  => '2.8.0',
+      archive  => '/path/to/cf-2.8.0.tar.gz',
+      provider => $provider,
+  );
+
+  print $kit->id();      # prints 'cf/2.8.0'
+  print $kit->name();    # prints 'cf'
+  print $kit->version(); # prints '2.8.0'
+
+  # Scan a directory for all locally cached kit tarballs
+  my $kits = Genesis::Kit::Compiled->local_kits($provider, '/path/to/cache');
+  for my $name (sort keys %$kits) {
+      for my $version (sort keys %{$kits->{$name}}) {
+          print "Found kit: $name/$version\n";
+      }
+  }
+
+  # Extract the kit to a temporary workspace before accessing its contents
+  $kit->extract();
 
 =head1 DESCRIPTION
 
-This class represents a compiled kit, and its distribution as a tarball
-archive.  Most operators use kits in this format.
+C<Genesis::Kit::Compiled> represents a Genesis kit that has been compiled and
+distributed as a gzip-compressed tar archive (C<.tar.gz> or C<.tgz>). This is
+the standard format for consuming kits in production deployments.
 
-=head1 CONSTRUCTORS
+The constructor runs a multi-phase validation of the archive before the object
+is created, catching common failure modes such as incomplete downloads, network
+proxy interceptions, and corrupt archives.
 
-=head2 new(%opts)
-
-Instantiates a new Kit::Compiled object.
-
-The following options are recognized:
-
-=over
-
-=item name
-
-The name of the kit.  This option is B<required>.
-
-=item version
-
-The version of the kit.  This option is B<required>.
-
-=item archive
-
-The absolute path to the compiled kit tarball.  This option is B<required>.
-
-=back
-
+This class inherits from L<Genesis::Kit>, which provides methods such as
+C<path>, C<glob>, C<has_hook>, C<metadata>, and C<known_hooks>.
+Inherited methods are not re-documented here; see L<Genesis::Kit> for details.
 
 =head1 METHODS
 
-=head2 id()
+=head2 new
 
-Returns the identity of the kit, in the form C<$name/$verison>.  This is
-useful for error messages and reporting.
+  my $kit = Genesis::Kit::Compiled->new(%opts);
 
-=head2 name()
+Creates a new C<Genesis::Kit::Compiled> object. Before the object is
+constructed, the archive is validated through a multi-phase check (see
+L</_validate_tar_archive> for the full validation sequence).
+
+B<Parameters:>
+
+=over 4
+
+=item C<archive>
+
+The path to the compiled kit tarball (C<.tar.gz> or C<.tgz>). This option is
+B<required>.
+
+=item C<name>
+
+The expected name of the kit (e.g., C<cf>). When provided together with
+C<version>, the archive's internal base directory is checked to confirm it
+matches. When omitted, the name is extracted from the archive's base directory.
+
+=item C<version>
+
+The expected version of the kit (e.g., C<2.8.0> or C<v2.8.0>). A leading
+C<v> is stripped before comparison. When provided together with C<name>, the
+archive's internal base directory is checked to confirm it matches. When
+omitted, the version is extracted from the archive's base directory.
+
+=item C<provider>
+
+The provider object associated with this kit (e.g., a local cache or remote
+registry). Stored on the object for reference; not used during validation.
+
+=back
+
+B<Returns:>
+
+A blessed C<Genesis::Kit::Compiled> object.
+
+B<Errors:>
+
+Dies with the first validation error encountered by C<_validate_tar_archive>.
+See L</_validate_tar_archive> for the full list of error conditions.
+
+B<Examples:>
+
+  my $kit = Genesis::Kit::Compiled->new(
+      name     => 'cf',
+      version  => '2.8.0',
+      archive  => '/var/cache/genesis/cf-2.8.0.tar.gz',
+      provider => $provider,
+  );
+  print $kit->id(); # prints 'cf/2.8.0'
+
+=head2 local_kits
+
+  my $kits = Genesis::Kit::Compiled->local_kits($provider, $path);
+  my $kits = Genesis::Kit::Compiled->local_kits($provider);
+
+Class method. Scans a directory for kit tarballs and returns a nested hashref
+of all valid compiled kits found.
+
+Files in C<$path> are matched against the pattern
+C<name-version.tar.gz> or C<name-version.tgz>, where the version component
+follows the form C<N>, C<N.N>, C<N.N.N>, or C<N.N.N-rcN> (with optional
+dots or dashes around the C<rc> separator). Non-matching files are silently
+skipped.
+
+For each matching file, C<new()> is called with the extracted name, version,
+archive path, and the given provider. Each call also validates the archive; see
+L</_validate_tar_archive>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$provider>
+
+The provider to associate with all discovered kit objects. Passed through to
+C<new()> as the C<provider> option.
+
+=item C<$path>
+
+The directory to scan. Defaults to C<'.'> (current directory) when not
+provided or undefined. A trailing slash is stripped before use.
+
+=back
+
+B<Returns:>
+
+A hashref with the structure C<< { $name => { $version => $kit_object } } >>,
+where each value is a C<Genesis::Kit::Compiled> instance. Returns an empty
+hashref if no matching files are found.
+
+B<Errors:>
+
+If any matching tarball fails validation inside C<new()>, the entire scan is
+terminated and the error from C<_validate_tar_archive> is propagated. Corrupt
+or partial archives abort the scan rather than being skipped. See
+L</KNOWN ISSUES>.
+
+B<Examples:>
+
+  my $kits = Genesis::Kit::Compiled->local_kits($provider, '/var/cache/genesis');
+  for my $name (sort keys %$kits) {
+      for my $version (sort keys %{$kits->{$name}}) {
+          printf "Kit: %s/%s\n", $name, $version;
+      }
+  }
+  # prints e.g.:
+  #   Kit: bosh/2.3.0
+  #   Kit: cf/2.8.0
+
+=head2 id
+
+  my $id = $kit->id();
+
+Returns the identity string of the kit in the form C<name/version>. Useful
+for error messages and log output.
+
+B<Returns:>
+
+A string of the form C<"$name/$version">, e.g., C<"cf/2.8.0">.
+
+B<Examples:>
+
+  my $kit = Genesis::Kit::Compiled->new(
+      name    => 'cf',
+      version => '2.8.0',
+      archive => '/path/to/cf-2.8.0.tar.gz',
+  );
+  print $kit->id(); # prints 'cf/2.8.0'
+
+=head2 name
+
+  my $name = $kit->name();
 
 Returns the name of the kit.
 
-=head2 version()
+B<Returns:>
+
+A string containing the kit name (e.g., C<"cf">).
+
+B<Examples:>
+
+  print $kit->name(); # prints 'cf'
+
+=head2 version
+
+  my $version = $kit->version();
 
 Returns the version of the kit.
 
-=head2 kit_bug($fmt, ...)
+B<Returns:>
 
-Prints an error to the screen, complete with details about how the problem
-at hand is not the operator's fault, and that they should file a bug against
-the kit's Github page, or contact the authors.
+A string containing the kit version (e.g., C<"2.8.0">). This is always the
+normalized version without a leading C<v>, as any leading C<v> is stripped
+during construction.
 
-=head2 extract()
+B<Examples:>
 
-Extracts the compiled kit tarball to a temporary workspace, and installs the
-Genesis hooks helper script.
+  print $kit->version(); # prints '2.8.0'
 
-This method is memoized; subsequent calls to C<extract> will have no effect.
+=head2 kit_bug
+
+  $kit->kit_bug(@msg);
+
+Reports a bug in the kit and terminates the process. This method is intended
+to be called when a kit behaves in a way that indicates a defect in the kit
+itself rather than an operator configuration error.
+
+C<@msg> is passed to C<csprintf>, which treats the first element as a format
+string and the remaining elements as arguments. C<csprintf> supports ANSI
+color markup and standard C<sprintf> conversion specifiers. The formatted
+message is followed by an attribution line naming the kit. If the kit's
+C<kit.yml> metadata contains a C<code> field pointing to a GitHub repository,
+a link to the issue tracker is appended. Otherwise, if the metadata contains
+an C<authors> or C<author> field, the author contact information is listed.
+
+The method always dies (throws an exception via C<die>). Before dying,
+C<$!> is set to 2 (C<ENOENT>). Callers that wrap this in an C<eval> block
+can inspect C<$!> to distinguish kit bugs from other fatal errors.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@msg>
+
+A list whose first element is a C<csprintf>-compatible format string and
+whose remaining elements are arguments interpolated into that string. May
+contain ANSI color markup and standard C<sprintf> conversion specifiers.
+
+=back
+
+B<Returns:>
+
+Does not return. Always dies. Sets C<$!> to 2 before dying.
+
+B<Examples:>
+
+  # In a kit hook, signal an unexpected state
+  $kit->kit_bug("Unexpected value %s in manifest key 'foo'", $bad_value);
+  # prints and dies with:
+  #   Unexpected value bar in manifest key 'foo'
+  #   This is a bug in the cf/2.8.0 kit.
+  #   Please file an issue at https://github.com/genesis-community/cf-genesis-kit/issues
+
+=head2 extract
+
+  $kit->extract();
+
+Extracts the kit tarball to a temporary working directory and installs the
+Genesis hooks helper script. After extraction, the kit's C<path>, C<glob>,
+C<has_hook>, and related methods inherited from L<Genesis::Kit> become
+operational.
+
+This method is memoized: the first call performs the extraction and records
+the working directory on the object. Subsequent calls return immediately
+without re-extracting.
+
+Files are extracted relative to the kit's root, with the leading
+C<name-version/> directory prefix stripped. For example,
+C<cf-2.8.0/hooks/new> is extracted as C<hooks/new> under the working
+directory.
+
+Modifies the object in-place by setting the internal C<root> field to the
+temporary working directory path.
+
+B<Returns:>
+
+Returns C<1> on the first call (extraction performed). Returns nothing
+(C<undef>) on subsequent calls when the kit has already been extracted.
+
+B<Examples:>
+
+  $kit->extract();
+  my $hook_path = $kit->path('hooks/new');
+  # $hook_path is now a valid filesystem path to the extracted hook
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _validate_tar_archive
+
+  my $tar = Genesis::Kit::Compiled->_validate_tar_archive(\%opts);
+
+Private class method. Validates the archive referenced by C<$opts->{archive}>
+through a series of checks and, if all checks pass, opens and returns an
+Archive::Tar object ready for use.
+
+This is the centerpiece of archive validation. It runs the following phases
+in order, halting at the first failure:
+
+=over 4
+
+=item 1. Missing archive option
+
+Dies with C<"Missing required option: archive"> if C<$opts->{archive}> is not
+set.
+
+=item 2. Archive file existence
+
+Dies with C<"Archive file does not exist: %s"> (where C<%s> is the archive
+path) if the file does not exist on disk.
+
+=item 3. File readability
+
+Dies if the file exists but cannot be read - for example, due to restrictive
+permissions or a SELinux denial. The error format is:
+
+  C<"Kit archive file %s exists but cannot be read.">
+
+followed by the current username and uid. C<%s> is the archive path.
+
+=item 4. Empty file
+
+Dies if the file size is zero. The error format is:
+
+  C<"Kit archive file %s is empty (0 bytes).">
+
+C<%s> is the archive path. This typically indicates an interrupted download
+or a full disk.
+
+=item 5. Archive read for content checks (C<.tar.gz> and C<.tgz> only)
+
+Opens the archive file in raw binary mode to read its first 512 bytes for
+the content checks in steps 5a and 5b below. Dies with:
+
+  C<"Unable to read kit archive %s: %s">
+
+if the file cannot be opened. The first C<%s> is the archive path and the
+second C<%s> is the system error message from C<$!>.
+
+=item 5a. HTML content detection (C<.tar.gz> and C<.tgz> only)
+
+Checks the first 512 bytes for HTML tags
+(C<< <!DOCTYPE >> , C<< <html >> , C<< <head >> , C<< <body >>). Dies if
+HTML is detected. The error format is:
+
+  C<"Kit archive file %s contains HTML instead of a gzip archive (%d bytes).">
+
+C<%s> is the archive path and C<%d> is the file size in bytes. This catches
+cases where a network proxy or captive portal intercepted the download and
+returned an HTML page instead of the kit archive.
+
+=item 5b. Gzip magic bytes (C<.tar.gz> and C<.tgz> only)
+
+Verifies that the first two bytes of the file are C<1f 8b> (the gzip magic
+number). Dies if the magic bytes are absent. The error format is:
+
+  C<"Kit archive file %s is not a valid gzip file (%d bytes).">
+
+followed by the expected and actual leading bytes. C<%s> is the archive path
+and C<%d> is the file size in bytes.
+
+=item 6. Decompression module availability (C<.tar.gz> and C<.tgz> only)
+
+Checks that at least one of IO::Uncompress::Gunzip or IO::Zlib is
+available. Dies if neither module can be loaded. The error format is:
+
+  C<"Cannot decompress kit archive %s: neither IO::Uncompress::Gunzip nor IO::Zlib is installed.">
+
+C<%s> is the archive path.
+
+=item 7. Archive::Tar open with warning capture
+
+Attempts to open the archive using Archive::Tar->new(), capturing any
+warnings emitted during the open. Dies if the open fails or returns a false
+value. The error format is:
+
+  C<"Failed to read kit archive %s.">
+
+followed by the Archive::Tar version, Perl version, file size in bytes, and
+any captured warnings. C<%s> is the archive path.
+
+=item 8. Base directory validation
+
+Inspects the top-level directories in the archive. Dies with:
+
+  C<"Archive file %s does not appear to be a valid Genesis kit (missing base directory)">
+
+if no single top-level directory is found. C<%s> is the archive path.
+
+The base directory must match the pattern C<name-version/>, where the version
+follows the standard Genesis versioning scheme. If the directory exists but
+does not match that pattern, dies with:
+
+  C<"Archive file %s does not appear to be a valid Genesis kit (missing base director 'name-version')">
+
+Note: the word "director" is a typographic error preserved from the original
+implementation.
+
+=item 9. Name and version matching
+
+If both C<$opts->{name}> and C<$opts->{version}> are provided, the archive's
+base directory name and version are compared against them. Dies if they do not
+match. The error format is:
+
+  C<"Archive file %s name/version (%s/%s) does not match provided name/version (%s/%s)">
+
+The five C<%s> placeholders are: archive path, name found in the archive,
+version found in the archive, expected name, and expected version.
+
+If neither C<name> nor C<version> is provided, the name and version are
+inferred from the archive's base directory and written back into C<$opts>.
+
+=item 10. kit.yml presence
+
+Dies if the archive does not contain a C<kit.yml> file in the base directory.
+The error format is:
+
+  C<"Archive file %s does not appear to be a valid Genesis kit (missing kit.yml in base directory %s)">
+
+The two C<%s> placeholders are the archive path and the base directory name.
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item C<$opts>
+
+A hashref of options, the same set accepted by C<new()>. The C<archive> key
+is required. The C<name> and C<version> keys, if present, are used for
+cross-validation. C<name> and C<version> may be written back into C<$opts>
+when they are inferred from the archive contents.
+
+=back
+
+B<Returns:>
+
+An opened Archive::Tar object representing the validated archive. This
+object is stored on the kit instance and used by C<extract>.
+
+B<Examples:>
+
+  # Called internally by new(); not typically invoked directly.
+  # On success, returns an Archive::Tar object:
+  my %opts = (
+      name    => 'cf',
+      version => '2.8.0',
+      archive => '/var/cache/genesis/cf-2.8.0.tar.gz',
+  );
+  my $tar = Genesis::Kit::Compiled->_validate_tar_archive(\%opts);
+  # Returns: an Archive::Tar object ready for extraction
+
+  # On failure (e.g., missing archive), dies with:
+  #   Missing required option: archive
+
+=head1 KNOWN ISSUES
+
+=head3 Corrupt archive aborts local_kits scan (FWT-706)
+
+C<local_kits()> calls C<new()> for each matching tarball, which in turn calls
+C<_validate_tar_archive()>. If any archive in the scanned directory fails
+validation, the entire scan is terminated and the error is propagated to the
+caller. As a result, a single corrupt or partially-downloaded kit file
+prevents discovery of all other valid kits in the same directory.
+
+The correct behavior would be to emit a warning and skip the offending file,
+continuing the scan. This will be addressed in FWT-706.
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
 
 =cut

--- a/lib/Genesis/Kit/Compiled.pod
+++ b/lib/Genesis/Kit/Compiled.pod
@@ -143,10 +143,10 @@ hashref if no matching files are found.
 
 B<Errors:>
 
-If any matching tarball fails validation inside C<new()>, the entire scan is
-terminated and the error from C<_validate_tar_archive> is propagated. Corrupt
-or partial archives abort the scan rather than being skipped. See
-L</KNOWN ISSUES>.
+If a matching tarball fails validation inside C<new()>, a warning is emitted
+identifying the file and the validation error, and that file is skipped.
+The scan continues with remaining files. No single corrupt archive can
+prevent discovery of other valid kits in the same directory.
 
 B<Examples:>
 
@@ -462,16 +462,7 @@ B<Examples:>
 
 =head1 KNOWN ISSUES
 
-=head3 Corrupt archive aborts local_kits scan (FWT-706)
-
-C<local_kits()> calls C<new()> for each matching tarball, which in turn calls
-C<_validate_tar_archive()>. If any archive in the scanned directory fails
-validation, the entire scan is terminated and the error is propagated to the
-caller. As a result, a single corrupt or partially-downloaded kit file
-prevents discovery of all other valid kits in the same directory.
-
-The correct behavior would be to emit a warning and skip the offending file,
-continuing the scan. This will be addressed in FWT-706.
+None at this time.
 
 =head1 AUTHORS
 

--- a/lib/Genesis/Kit/Provider/Github.pm
+++ b/lib/Genesis/Kit/Provider/Github.pm
@@ -378,7 +378,7 @@ sub latest_version_of {
 	bail("Missing name for retrieving kit releases") unless $name;
 	my $version = (
 		grep {$_->{url}}
-		$self->kit_versions($name, latest => 1, include_drafts => $opts{include_drafts}, include_prerelease => $opts{include_prereleases})
+		$self->kit_versions($name, latest => 1, include_drafts => $opts{include_drafts}, include_prereleases => $opts{include_prereleases})
 	)[0];
 	return $version && $version->{version};
 }

--- a/lib/Genesis/Kit/Provider/Github.pm
+++ b/lib/Genesis/Kit/Provider/Github.pm
@@ -319,6 +319,32 @@ sub fetch_kit_version_src {
 		$name, $version, $self->label, $code
 	) unless $code == 200;
 	info "#G{done.}";
+
+	# Validate downloaded content before saving
+	if (length($data) == 0) {
+		bail(
+			"Downloaded source for kit %s/%s from %s but received empty response.\n".
+			"The server returned HTTP 200 but no content.",
+			$name, $version, $self->label
+		);
+	}
+	if ($data =~ /\A<(!DOCTYPE|html|head)/i) {
+		bail(
+			"Downloaded source for kit %s/%s from %s but received an HTML page\n".
+			"instead of a source archive.\n\n".
+			"A network proxy or captive portal likely intercepted the download.\n".
+			"Check network connectivity and proxy settings.",
+			$name, $version, $self->label
+		);
+	}
+	if (length($data) >= 2 && substr($data, 0, 2) ne "\x1f\x8b") {
+		warning(
+			"Downloaded source data for kit %s/%s does not appear to be gzip-compressed.\n".
+			"Proceeding, but the source archive may fail to extract.",
+			$name, $version
+		);
+	}
+
 	my $file = "$path/$name-$version-src.tar.gz";
 	if (-f $file) {
 		if (! $force) {

--- a/lib/Genesis/Kit/Provider/Github.pod
+++ b/lib/Genesis/Kit/Provider/Github.pod
@@ -645,10 +645,27 @@ differ, the user is prompted interactively to confirm overwriting.
 The saved file is written with permissions C<0444> and named
 C<$name-$version-src.tar.gz> under C<$path>.
 
-B<Note:> Unlike C<fetch_kit_version()>, this method does I<not> perform
-download-time content validation.  The empty-response check, HTML
-interception check, and gzip magic bytes check are absent.  See
-L</KNOWN ISSUES>.
+Three content validation checks are performed on the downloaded data
+before the file is written, matching those in C<fetch_kit_version()>:
+
+=over 4
+
+=item 1. Empty response check
+
+If the downloaded response body is empty, the method dies immediately.
+
+=item 2. HTML interception check
+
+If the response starts with C<< <!DOCTYPE >>, C<< <html >>, or
+C<< <head >> (case-insensitive), the download is rejected as a proxy or
+captive-portal intercept.
+
+=item 3. Gzip magic bytes check
+
+If the response is non-empty but the first two bytes are not C<0x1f 0x8b>
+(the gzip magic number), a warning is emitted and the download proceeds.
+
+=back
 
 B<Parameters:>
 
@@ -702,6 +719,16 @@ values are the kit name, version, and release notes body.
 Raised when the HTTP download returns a non-200 response.  The C<%s>
 values are the kit name, version, provider label, and HTTP status code.
 
+=item C<"Downloaded source for kit %s/%s from %s but received empty response.\nThe server returned HTTP 200 but no content.">
+
+Raised when the download succeeds (HTTP 200) but the response body is
+empty.  The C<%s> values are the kit name, version, and provider label.
+
+=item C<"Downloaded source for kit %s/%s from %s but received an HTML page\ninstead of a source archive.\n\nA network proxy or captive portal likely intercepted the download.\nCheck network connectivity and proxy settings.">
+
+Raised when the downloaded content begins with an HTML tag.  The C<%s>
+values are the kit name, version, and provider label.
+
 =item C<"Aborted!\n">
 
 Raised when the user declines to overwrite an existing file that differs.
@@ -711,6 +738,12 @@ Raised when the user declines to overwrite an existing file that differs.
 B<Warnings:>
 
 =over 4
+
+=item C<"Downloaded source data for kit %s/%s does not appear to be gzip-compressed.\nProceeding, but the source archive may fail to extract.">
+
+Emitted when the downloaded content is non-empty but the first two bytes
+are not C<0x1f 0x8b> (the gzip magic number).  The download is saved
+regardless.  The C<%s> values are the kit name and version.
 
 =item C<"Exact same kit source already exists under #C{%s} - no change.\n">
 
@@ -857,33 +890,7 @@ B<Examples:>
 
 =head1 KNOWN ISSUES
 
-=head3 fetch_kit_version_src does not validate downloaded content
-
-C<fetch_kit_version_src()> does not perform any of the three download-time
-content validation checks that C<fetch_kit_version()> performs.
-Specifically:
-
-=over 4
-
-=item *
-
-No empty-response check -- a silent HTTP 200 with no body is saved to
-disk without error.
-
-=item *
-
-No HTML interception check -- a proxy or captive-portal response is saved
-as if it were a valid source archive.
-
-=item *
-
-No gzip magic bytes warning -- the file is written regardless of its
-content type.
-
-=back
-
-As a result, source archives downloaded via C<fetch_kit_version_src()> are
-not content-verified before saving.  This is tracked as B<FWT-706>.
+None at this time.
 
 =head1 AUTHORS
 

--- a/lib/Genesis/Kit/Provider/Github.pod
+++ b/lib/Genesis/Kit/Provider/Github.pod
@@ -1,61 +1,896 @@
+=encoding utf8
+
 =head1 NAME
 
-Genesis::Kit::Provider::Github
+Genesis::Kit::Provider::Github - Github-based kit provider for Genesis deployment kits
+
+=head1 SYNOPSIS
+
+  use Genesis::Kit::Provider;
+
+  # Create a Github kit provider via the base class factory
+  my $provider = Genesis::Kit::Provider->new(
+      type         => 'github',
+      organization => 'my-org',
+  );
+
+  # Or create one directly during repo init
+  my $provider = Genesis::Kit::Provider::Github->init(
+      'kit-provider-org' => 'my-org',
+  );
+
+  # List available kits
+  my @kits = $provider->kit_names();
+
+  # Fetch a specific kit version
+  my ($name, $version, $file) = $provider->fetch_kit_version(
+      'bosh', '2.3.0', '/path/to/cache', 0
+  );
 
 =head1 DESCRIPTION
 
+C<Genesis::Kit::Provider::Github> implements kit retrieval from Github or
+Github Enterprise repositories.  It discovers kits by scanning an
+organization for repositories whose names end in C<-genesis-kit>, and
+fetches releases and tarballs via the Github API.
 
-=head1 CONSTRUCTORS
+This class inherits from L<Genesis::Kit::Provider> and implements all of
+its abstract methods.  Instances are typically obtained through the base
+class factory C<< Genesis::Kit::Provider->new(type => 'github', ...) >>
+rather than constructed directly.
 
-=head2 new(%opts)
+The following constants define the defaults used when options are omitted:
 
-Instantiates a new Kit::Compiled object.
+=over 4
 
-The following options are recognized:
+=item C<DEFAULT_DOMAIN>
 
-=over
+C<'github.com'> -- the Github domain used when no C<domain> is specified.
 
-=item name
+=item C<DEFAULT_LABEL>
 
-The name of the kit.  This option is B<required>.
+C<'Custom Github-based Kit Provider'> -- the provider label used when no
+C<label> is specified.
 
-=item version
+=item C<DEFAULT_TLS>
 
-The version of the kit.  This option is B<required>.
-
-=item archive
-
-The absolute path to the compiled kit tarball.  This option is B<required>.
+C<'yes'> -- the TLS mode used when no C<tls> is specified.
 
 =back
 
-
 =head1 METHODS
 
-=head2 id()
+=head2 init (class method)
 
-Returns the identity of the kit, in the form C<$name/$verison>.  This is
-useful for error messages and reporting.
+  my $provider = Genesis::Kit::Provider::Github->init(%opts);
 
-=head2 name()
+Creates a new Github provider during C<genesis init> or C<genesis update>
+when the user selects C<github> as the provider type.  Called by
+L<Genesis::Kit::Provider/init> after determining the provider type from
+the parsed CLI options.
 
-Returns the name of the kit.
+B<Parameters:>
 
-=head2 version()
+=over 4
 
-Returns the version of the kit.
+=item C<kit-provider-name>
 
-=head2 kit_bug($fmt, ...)
+Optional.  A human-readable label for this provider used in messages.
+Defaults to C<DEFAULT_LABEL> (C<'Custom Github-based Kit Provider'>).
 
-Prints an error to the screen, complete with details about how the problem
-at hand is not the operator's fault, and that they should file a bug against
-the kit's Github page, or contact the authors.
+=item C<kit-provider-domain>
 
-=head2 extract()
+Optional.  The Github domain, without the C<www> or C<api> subdomain.
+Defaults to C<DEFAULT_DOMAIN> (C<'github.com'>).  Use this for Github
+Enterprise installations.
 
-Extracts the compiled kit tarball to a temporary workspace, and installs the
-Genesis hooks helper script.
+=item C<kit-provider-org>
 
-This method is memoized; subsequent calls to C<extract> will have no effect.
+Required.  The name of the Github organization that owns the kit
+repositories.  If absent, the method dies immediately.
+
+=item C<kit-provider-tls>
+
+Optional.  TLS mode for API connections.  Accepts C<'yes'>, C<'no'>, or
+C<'skip'>.  Defaults to C<DEFAULT_TLS> (C<'yes'>).
+
+=back
+
+B<Returns:> A new C<Genesis::Kit::Provider::Github> instance.
+
+B<Errors:>
+
+=over 4
+
+=item C<"E<lt>labelE<gt> kit provider requires specifying the organization using the --kit-provider-org option">
+
+Raised when C<kit-provider-org> is not supplied.  C<E<lt>labelE<gt>> is
+the value of C<kit-provider-name>, or the default label if not provided.
+
+=item C<"Github kit provider option --kit-provider-tls only accepts: no, yes, and skip">
+
+Raised when C<kit-provider-tls> is set to any value other than C<no>,
+C<yes>, or C<skip>.
+
+=back
+
+B<Examples:>
+
+  # Minimal -- only organization is required
+  my $p = Genesis::Kit::Provider::Github->init(
+      'kit-provider-org' => 'genesis-community',
+  );
+  print $p->organization(); # prints 'genesis-community'
+
+  # Full set of options
+  my $p = Genesis::Kit::Provider::Github->init(
+      'kit-provider-name'   => 'My GHE Provider',
+      'kit-provider-domain' => 'github.example.com',
+      'kit-provider-org'    => 'my-org',
+      'kit-provider-tls'    => 'skip',
+  );
+
+=head2 new (class method)
+
+  my $provider = Genesis::Kit::Provider::Github->new(%config);
+
+Constructs a new C<Genesis::Kit::Provider::Github> instance from a
+configuration hash.  Used by L</init> and by
+L<Genesis::Kit::Provider/new> when loading a stored configuration.
+
+B<Parameters:>
+
+=over 4
+
+=item C<label>
+
+Optional.  Human-readable label for the provider.  Defaults to
+C<DEFAULT_LABEL> (C<'Custom Github-based Kit Provider'>).
+
+=item C<domain>
+
+Optional.  Github domain without subdomain.  Defaults to
+C<DEFAULT_DOMAIN> (C<'github.com'>).
+
+=item C<organization>
+
+Required in practice.  The Github organization that owns the kit
+repositories.
+
+=item C<tls>
+
+Optional.  TLS mode: C<'yes'>, C<'no'>, or C<'skip'>.  The value
+C<'insecure'> is also accepted for backwards compatibility with older
+configurations and is silently converted to C<'skip'>.  Defaults to
+C<DEFAULT_TLS> (C<'yes'>).
+
+=item C<type>
+
+Optional.  Informational; expected to be C<'github'> when present.
+
+=back
+
+B<Returns:> A blessed C<Genesis::Kit::Provider::Github> instance backed by
+an internal C<Service::Github> remote object.
+
+B<Examples:>
+
+  my $provider = Genesis::Kit::Provider::Github->new(
+      organization => 'genesis-community',
+  );
+  print $provider->domain(); # prints 'github.com'
+
+  # Load from stored config with custom domain
+  my $provider = Genesis::Kit::Provider::Github->new(
+      label        => 'Corp GHE',
+      domain       => 'github.corp.example.com',
+      organization => 'platform-team',
+      tls          => 'skip',
+  );
+
+=head2 opts (class method)
+
+  my @specs = Genesis::Kit::Provider::Github->opts();
+
+Returns the list of L<Getopt::Long> option specification strings supported
+by L</init>.  Used by L<Genesis::Kit::Provider/parse_opts> to register the
+correct options before parsing CLI arguments.
+
+B<Returns:> A list of option specification strings:
+
+  kit-provider-name=s
+  kit-provider-domain=s
+  kit-provider-org=s
+  kit-provider-tls=s
+  kit-provider-access-token=s
+
+B<Examples:>
+
+  my @specs = Genesis::Kit::Provider::Github->opts();
+  # Returns: ('kit-provider-name=s', 'kit-provider-domain=s', ...)
+
+=head2 opts_help
+
+  my $text = $provider->opts_help(%config);
+
+Returns a formatted help string describing the Github provider's CLI
+options, for inclusion in command-line help output.  Returns an empty
+string if C<'github'> is not listed in C<$config{valid_types}>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<valid_types>
+
+An array reference of provider type strings that are valid in the current
+context.  The method returns C<''> unless this list contains C<'github'>.
+
+=back
+
+B<Returns:> A multi-line help string describing all Github provider options,
+or an empty string if C<'github'> is not in C<valid_types>.
+
+B<Examples:>
+
+  my $help = $provider->opts_help(valid_types => [qw(genesis-community github)]);
+  print $help;
+  # Prints a block beginning with:
+  #   Kit Provider `github`:
+  #
+  #     This is a generic kit provider type for kits backed by Github...
+
+  # Returns empty when github is not a valid type
+  my $none = $provider->opts_help(valid_types => ['genesis-community']);
+  print length($none); # prints '0'
+
+=head2 label
+
+  my $label = $provider->label();
+
+Returns the human-readable label string for this provider.  Used in
+status messages and error output to identify the provider.
+
+Also provides several additional read-only delegation accessors that
+forward to the internal C<Service::Github> remote object:
+
+=over 4
+
+=item C<remote>
+
+Returns the C<Service::Github> remote object used to make API calls.
+
+=item C<domain>
+
+Returns the Github domain string (e.g., C<'github.com'>).
+
+=item C<organization>
+
+Returns the Github organization name string.
+
+=item C<credentials>
+
+Returns the credentials value for authenticated API requests, or C<undef>
+if no credentials are configured.  Credentials are sourced from the
+C<GITHUB_USER> and C<GITHUB_AUTH_TOKEN> environment variables by
+C<Service::Github>.
+
+=item C<tls>
+
+Returns the TLS mode string: one of C<'yes'>, C<'no'>, or C<'skip'>.
+
+=item C<check>
+
+Checks connectivity to the provider.  Accepts an optional URL argument;
+defaults to the organization's repository listing URL.  In list context
+returns C<($http_code, $error_message)>; in scalar context returns the
+error message string or C<undef> on success.
+
+=item C<repos_url>
+
+Returns the API URL for listing the organization's repositories.
+Accepts an optional page number for paginated results.
+
+=item C<releases_url>
+
+Returns the API URL for listing releases for a given repository name
+(without the C<-genesis-kit> suffix).  Accepts an optional page number.
+
+=item C<base_url>
+
+Returns the base API URL for the configured Github domain
+(e.g., C<'https://api.github.com'>).
+
+=item C<config>
+
+Returns a hash of configuration values suitable for serialization and
+later reconstruction via L</new>.  Always includes C<type> (C<'github'>)
+and C<organization>.  Includes C<label>, C<domain>, and C<tls> only when
+they differ from their respective defaults.
+
+=back
+
+B<Returns:> A string.  The default value is C<'Custom Github-based Kit Provider'>.
+
+B<Examples:>
+
+  my $provider = Genesis::Kit::Provider::Github->new(
+      organization => 'my-org',
+      label        => 'My Provider',
+  );
+  print $provider->label();        # prints 'My Provider'
+  print $provider->domain();       # prints 'github.com'
+  print $provider->organization(); # prints 'my-org'
+  print $provider->tls();          # prints 'yes'
+
+  my %cfg = $provider->config();
+  # %cfg = ( type => 'github', organization => 'my-org' )
+
+  print $provider->base_url(); # prints 'https://api.github.com'
+  print $provider->repos_url();
+  # prints 'https://api.github.com/users/my-org/repos'
+
+=head2 kit_names
+
+  my @names = $provider->kit_names($filter);
+
+Retrieves the list of kit names available from this provider.  Scans the
+configured Github organization for repositories whose names end in
+C<-genesis-kit>, strips that suffix, and returns the bare kit names.
+
+Results are cached on the object after the first call.  The optional
+C<$filter> regex is applied to the cached list on each call.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$filter>
+
+Optional.  A regular expression string.  Only kit names matching this
+pattern are returned.
+
+=back
+
+B<Returns:> A list of kit name strings.
+
+B<Errors:>
+
+If connectivity fails, the error message from C<check> is passed to
+C<bail>.
+
+If no kits are found (optionally after applying C<$filter>), dies with a
+message of the form C<"No genesis kit repositories found on ..."> and, if
+credentials are absent, appends a note that C<GITHUB_USER> and
+C<GITHUB_AUTH_TOKEN> may be required to see private repositories.
+
+B<Examples:>
+
+  my @kits = $provider->kit_names();
+  print scalar(@kits); # prints the number of available kits
+
+  my @bosh = $provider->kit_names('bosh');
+  print $bosh[0]; # prints 'bosh' if found
+
+=head2 kit_releases
+
+  my @releases = $provider->kit_releases($name);
+
+Retrieves the list of release objects for the named kit from Github.
+Results are cached per kit name after the first call.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Required.  The bare kit name (without the C<-genesis-kit> suffix).
+
+=back
+
+B<Returns:> A list of release info hash references as returned by the
+C<Service::Github> remote.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Missing name for retrieving kit releases">
+
+Raised when C<$name> is not supplied.
+
+=item C<"No kit named #C{%s} exists under %s">
+
+Raised when the releases URL returns HTTP 404 and the kit name is
+confirmed absent from C<kit_names()>.  The first C<%s> is the kit name
+and the second is the provider label.
+
+=item C<"$status">
+
+When the connectivity check for the releases URL returns a non-200,
+non-404 HTTP status, C<$status> (the error string from C<check>) is
+passed directly to C<bail>.  The content of this message depends on the
+HTTP response received.
+
+=back
+
+B<Examples:>
+
+  my @releases = $provider->kit_releases('bosh');
+  for my $r (@releases) {
+      print "$r->{name}\n"; # prints each release tag
+  }
+
+=head2 kit_versions
+
+  my @versions = $provider->kit_versions($name, %opts);
+
+Retrieves version information for the named kit.  Sets an asset filter on
+C<%opts> that matches the kit's tarball filename pattern (e.g.,
+C<bosh-1.2.3.tar.gz> or C<bosh-1.2.3.tgz>), then delegates to
+C<< $self->remote->versions >>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Required.  The bare kit name (without the C<-genesis-kit> suffix).
+
+=item C<%opts>
+
+Optional additional options passed through to C<< Service::Github->versions >>.
+Supported keys include:
+
+=over 4
+
+=item C<include_drafts>
+
+Boolean.  Include draft releases when true.
+
+=item C<include_prereleases>
+
+Boolean.  Include pre-release versions when true.
+
+=item C<latest>
+
+Integer.  Return at most this many versions in descending version order.
+
+=back
+
+=back
+
+B<Returns:> A list of version info hash references, each containing at
+least: C<version>, C<body>, C<draft>, C<prerelease>, C<date>, and
+optionally C<url>.
+
+B<Examples:>
+
+  my @versions = $provider->kit_versions('bosh');
+  for my $v (@versions) {
+      print "$v->{version}\n"; # prints each version string
+  }
+
+  # Only stable releases
+  my @stable = $provider->kit_versions('bosh',
+      include_drafts       => 0,
+      include_prereleases  => 0,
+  );
+
+=head2 fetch_kit_version
+
+  my ($name, $version, $file) = $provider->fetch_kit_version(
+      $name, $version, $path, $force
+  );
+
+Downloads the compiled kit tarball for the specified name and version from
+Github, with full download-time content validation before saving to disk.
+
+If C<$version> is C<undef> or the string C<'latest'>, the latest
+available version with a downloadable release asset is resolved first via
+C<latest_version_of()>.  Otherwise, any leading C<v> prefix is stripped
+from the version string.
+
+Three content validation checks are performed on the downloaded data
+before the file is written:
+
+=over 4
+
+=item 1. Empty response check
+
+If the downloaded response body is empty, the method dies immediately.
+
+=item 2. HTML interception check
+
+If the response starts with C<< <!DOCTYPE >>, C<< <html >>, or
+C<< <head >> (case-insensitive), the download is rejected as a proxy or
+captive-portal intercept.
+
+=item 3. Gzip magic bytes check
+
+If the response is non-empty but the first two bytes are not C<0x1f 0x8b>
+(the gzip magic number), a warning is emitted and the download proceeds.
+
+=back
+
+If the target file already exists and C<$force> is false, the downloaded
+content is compared against the existing file by SHA-1 hash.  If they are
+identical a warning is emitted and the process exits.  If they differ, the
+user is prompted interactively to confirm overwriting.
+
+The saved file is written with permissions C<0444> (read-only) and named
+C<$name-$version.tar.gz> under C<$path>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Required.  The bare kit name (without the C<-genesis-kit> suffix).
+
+=item C<$version>
+
+Required.  The version to download, or C<'latest'> to resolve
+automatically.  A leading C<v> prefix is stripped if present.
+
+=item C<$path>
+
+Required.  Directory where the tarball should be saved.
+
+=item C<$force>
+
+Optional.  When true, skips the existing-file check and overwrites any
+existing file without prompting.
+
+=back
+
+B<Returns:> A three-element list: C<($name, $version, $file)> where
+C<$file> is the absolute path to the saved tarball.
+
+B<Errors:>
+
+=over 4
+
+=item C<"No latest version of $name kit found with a downloadable release">
+
+Raised when C<$version> is C<'latest'> or C<undef> and no downloadable
+release is found.  C<$name> is the kit name.
+
+=item C<"Version %s/%s was not found\n">
+
+Raised when the specified version does not appear in the kit's version
+list.  The first C<%s> is the kit name and the second is the version.
+
+=item C<"Version %s/%s was found but is missing its resource url.It may have been revoked (see release notes below):\n\n%s\n">
+
+Raised when the version info exists but lacks a download URL.  The C<%s>
+values are the kit name, version, and release notes body respectively.
+
+=item C<"Failed to download %s/%s from %s: returned a %s status code\n">
+
+Raised when the HTTP download returns a non-200 response code.  The C<%s>
+values are the kit name, version, provider label, and HTTP status code.
+
+=item C<"Downloaded kit %s/%s from %s but received empty response.\nThe server returned HTTP 200 but no content.">
+
+Raised when the download succeeds (HTTP 200) but the response body is
+empty.  The C<%s> values are the kit name, version, and provider label.
+
+=item C<"Downloaded kit %s/%s from %s but received an HTML page\ninstead of a kit archive.\n\nA network proxy or captive portal likely intercepted the download.\nCheck network connectivity and proxy settings.">
+
+Raised when the downloaded content begins with an HTML tag.  The C<%s>
+values are the kit name, version, and provider label.
+
+=item C<"Aborted!\n">
+
+Raised when the user declines to overwrite an existing file that differs
+from the downloaded content.
+
+=back
+
+B<Warnings:>
+
+=over 4
+
+=item C<"Downloaded data for kit %s/%s does not appear to be gzip-compressed.\nProceeding, but the kit may fail to load.">
+
+Emitted when the downloaded content is non-empty but the first two bytes
+are not C<0x1f 0x8b> (the gzip magic number).  The download is saved
+regardless.  The C<%s> values are the kit name and version.
+
+=item C<"Exact same kit already exists under #C{%s} - no change.\n">
+
+Emitted when the target file already exists, C<$force> is false, and the
+SHA-1 hash of the downloaded content matches the existing file.  The
+process exits with status 0.  C<%s> is the humanized path.
+
+=back
+
+B<Examples:>
+
+  my ($name, $ver, $file) = $provider->fetch_kit_version(
+      'bosh', '2.3.0', '/tmp/kits', 0
+  );
+  print $file; # prints '/tmp/kits/bosh-2.3.0.tar.gz'
+
+  # Fetch latest version
+  my ($name, $ver, $file) = $provider->fetch_kit_version(
+      'bosh', 'latest', '/tmp/kits', 0
+  );
+
+=head2 fetch_kit_version_src
+
+  my ($name, $version, $file) = $provider->fetch_kit_version_src(
+      $name, $version, $path, $force
+  );
+
+Downloads the source tarball for the specified kit name and version from
+Github.  Similar in structure to C<fetch_kit_version()> but fetches the
+source archive (the C<tarball_url> from the release, not the compiled kit
+asset), and saves it with a C<-src.tar.gz> suffix.
+
+If C<$version> is C<undef> or the string C<'latest'>, the latest version
+is resolved via C<latest_version_of()>.  Otherwise, a leading C<v> prefix
+is stripped.  The release is located by matching the version against the
+release tag name via C<kit_releases()>.
+
+If the target file already exists and C<$force> is false, the downloaded
+content is compared against the existing file by SHA-1 hash.  If they are
+identical, a warning is emitted and the method returns C<1>.  If they
+differ, the user is prompted interactively to confirm overwriting.
+
+The saved file is written with permissions C<0444> and named
+C<$name-$version-src.tar.gz> under C<$path>.
+
+B<Note:> Unlike C<fetch_kit_version()>, this method does I<not> perform
+download-time content validation.  The empty-response check, HTML
+interception check, and gzip magic bytes check are absent.  See
+L</KNOWN ISSUES>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Required.  The bare kit name (without the C<-genesis-kit> suffix).
+
+=item C<$version>
+
+Required.  The version to download, or C<'latest'> to resolve
+automatically.  A leading C<v> prefix is stripped if present.
+
+=item C<$path>
+
+Required.  Directory where the source tarball should be saved.
+
+=item C<$force>
+
+Optional.  When true, skips the existing-file check and overwrites without
+prompting.
+
+=back
+
+B<Returns:> A three-element list C<($name, $version, $file)> where
+C<$file> is the absolute path to the saved source tarball.  Returns C<1>
+if an identical file already exists and C<$force> is false.
+
+B<Errors:>
+
+=over 4
+
+=item C<"No latest version of $name kit found with a downloadable release">
+
+Raised when C<$version> is C<'latest'> or C<undef> and no release is
+found.  C<$name> is the kit name.
+
+=item C<"Version %s/%s was not found\n">
+
+Raised when the specified version does not appear in the kit's releases.
+The first C<%s> is the kit name and the second is the version.
+
+=item C<"Release %s/%s was found but is missing its tarball url.It may have been revoked (see release notes below):\n\n%s\n">
+
+Raised when the release exists but lacks a C<tarball_url>.  The C<%s>
+values are the kit name, version, and release notes body.
+
+=item C<"Failed to download %s/%s source from %s: returned a %s status code\n">
+
+Raised when the HTTP download returns a non-200 response.  The C<%s>
+values are the kit name, version, provider label, and HTTP status code.
+
+=item C<"Aborted!\n">
+
+Raised when the user declines to overwrite an existing file that differs.
+
+=back
+
+B<Warnings:>
+
+=over 4
+
+=item C<"Exact same kit source already exists under #C{%s} - no change.\n">
+
+Emitted when the target file already exists, C<$force> is false, and the
+SHA-1 hash of the downloaded content matches the existing file.  The
+method returns C<1>.  C<%s> is the humanized path.
+
+=back
+
+B<Examples:>
+
+  my ($name, $ver, $file) = $provider->fetch_kit_version_src(
+      'bosh', '2.3.0', '/tmp/kits', 0
+  );
+  print $file; # prints '/tmp/kits/bosh-2.3.0-src.tar.gz'
+
+=head2 latest_version_of
+
+  my $version = $provider->latest_version_of($name, %opts);
+
+Returns the version string for the latest release of the named kit that
+has a downloadable asset URL.  Delegates to C<kit_versions()> with
+C<< latest => 1 >> and returns the version string from the first result,
+or C<undef> if none is found.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Required.  The bare kit name (without the C<-genesis-kit> suffix).
+
+=item C<include_drafts>
+
+Optional boolean in C<%opts>.  Passed through to C<kit_versions()> to
+include draft releases in the search.
+
+=item C<include_prereleases>
+
+Optional boolean in C<%opts>.  Passed through to C<kit_versions()> to
+include pre-release versions in the search.
+
+=back
+
+B<Returns:> A version string (e.g., C<'2.3.0'>) or C<undef> if no
+downloadable release exists.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Missing name for retrieving kit releases">
+
+Raised when C<$name> is not supplied.
+
+=back
+
+B<Examples:>
+
+  my $ver = $provider->latest_version_of('bosh');
+  print $ver; # prints '2.3.0' (or the current latest)
+
+  # Returns undef when no downloadable release exists
+  my $ver = $provider->latest_version_of('nonexistent-kit');
+  print defined($ver) ? $ver : 'undef'; # prints 'undef'
+
+=head2 status
+
+  my %status = $provider->status($verbose);
+
+Returns a hash of provider status information suitable for display.
+Performs a connectivity check and re-interprets HTTP error codes into
+human-readable messages.  When the check succeeds, collects kit names
+(and optionally per-kit release counts) and includes them in the result.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$verbose>
+
+Optional boolean.  When true, the C<kits> entry in the returned hash is a
+hash reference mapping each kit name to a release count summary string
+(e.g., C<'3 releases, 1 pre-release'>).  When false or omitted, C<kits>
+is an array reference of sorted kit name strings.
+
+=back
+
+B<Returns:> A hash with the following keys:
+
+=over 4
+
+=item C<type>
+
+Always C<'github'>.
+
+=item C<extras>
+
+Array reference C<["Name", "Domain", "Org", "Use TLS"]> listing the
+supplemental display keys.
+
+=item C<Name>
+
+The provider label.
+
+=item C<Domain>
+
+The configured Github domain.
+
+=item C<Org>
+
+The configured organization name.
+
+=item C<Use TLS>
+
+The configured TLS mode.
+
+=item C<status>
+
+A status string: C<'ok'> when the check succeeds, or an error message
+when it fails.
+
+=item C<kits>
+
+When the check succeeds: an array reference of sorted kit names
+(non-verbose), or a hash reference mapping kit names to release summary
+strings (verbose).  C<undef> when the check fails.
+
+=back
+
+B<Examples:>
+
+  my %info = $provider->status();
+  print $info{status};          # prints 'ok' on success
+  print $info{Name};            # prints the provider label
+  print scalar(@{$info{kits}}); # prints the number of available kits
+
+  my %verbose = $provider->status(1);
+  for my $kit (keys %{$verbose{kits}}) {
+      print "$kit: $verbose{kits}{$kit}\n";
+      # prints e.g. 'bosh: 5 releases, 1 pre-release'
+  }
+
+=head1 KNOWN ISSUES
+
+=head3 fetch_kit_version_src does not validate downloaded content
+
+C<fetch_kit_version_src()> does not perform any of the three download-time
+content validation checks that C<fetch_kit_version()> performs.
+Specifically:
+
+=over 4
+
+=item *
+
+No empty-response check -- a silent HTTP 200 with no body is saved to
+disk without error.
+
+=item *
+
+No HTML interception check -- a proxy or captive-portal response is saved
+as if it were a valid source archive.
+
+=item *
+
+No gzip magic bytes warning -- the file is written regardless of its
+content type.
+
+=back
+
+As a result, source archives downloaded via C<fetch_kit_version_src()> are
+not content-verified before saving.  This is tracked as B<FWT-706>.
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
 
 =cut

--- a/lib/Service/Github.pm
+++ b/lib/Service/Github.pm
@@ -423,7 +423,7 @@ sub latest_version_of {
 	bail("Missing name for retrieving release") unless $name;
 	my $version = (
 		grep {$_->{url}}
-		$self->versions($name, latest => 1, include_drafts => $opts{include_drafts}, include_prerelease => $opts{include_prereleases})
+		$self->versions($name, latest => 1, include_drafts => $opts{include_drafts}, include_prereleases => $opts{include_prereleases})
 	)[0];
 	return $version && $version->{version};
 }

--- a/t/unit-tests/kit-archive-validation.t
+++ b/t/unit-tests/kit-archive-validation.t
@@ -119,4 +119,50 @@ subtest 'valid archive loads successfully' => sub {
 	} 'valid kit archive loads without error';
 };
 
+# --- Test 9: local_kits skips corrupt archives instead of dying ---
+subtest 'local_kits skips corrupt archives and returns valid kits' => sub {
+	my $scan_dir = "$tmp/local_kits_test";
+	mkdir $scan_dir unless -d $scan_dir;
+
+	# Create one valid kit
+	mk_test_kit('alpha', '1.0.0', $scan_dir);
+
+	# Create one corrupt kit (HTML content, not a real tarball)
+	put_file("$scan_dir/broken-2.0.0.tar.gz",
+		"<!DOCTYPE html><html><body>403 Forbidden</body></html>");
+
+	# Create another valid kit
+	mk_test_kit('charlie', '3.0.0', $scan_dir);
+
+	my $result;
+	lives_ok {
+		$result = Genesis::Kit::Compiled->local_kits(undef, $scan_dir);
+	} 'local_kits does not die when a corrupt kit is present';
+
+	ok defined($result), 'local_kits returns a result';
+	ok ref($result) eq 'HASH', 'local_kits returns a hashref';
+	ok exists($result->{alpha}), 'valid kit alpha is present in results';
+	ok exists($result->{alpha}{'1.0.0'}), 'alpha version 1.0.0 is present';
+	ok exists($result->{charlie}), 'valid kit charlie is present in results';
+	ok exists($result->{charlie}{'3.0.0'}), 'charlie version 3.0.0 is present';
+	ok !exists($result->{broken}), 'corrupt kit broken is not in results';
+};
+
+# --- Test 10: local_kits with only valid kits works normally ---
+subtest 'local_kits with all valid kits works normally' => sub {
+	my $scan_dir = "$tmp/local_kits_valid";
+	mkdir $scan_dir unless -d $scan_dir;
+
+	mk_test_kit('foo', '1.0.0', $scan_dir);
+	mk_test_kit('bar', '2.0.0', $scan_dir);
+
+	my $result;
+	lives_ok {
+		$result = Genesis::Kit::Compiled->local_kits(undef, $scan_dir);
+	} 'local_kits works with all valid kits';
+
+	ok exists($result->{foo}{'1.0.0'}), 'foo/1.0.0 found';
+	ok exists($result->{bar}{'2.0.0'}), 'bar/2.0.0 found';
+};
+
 done_testing;


### PR DESCRIPTION
## Summary

- `local_kits()` now warns and skips corrupt kit archives instead of aborting the entire directory scan (eval-wrapped `new()` call)
- `fetch_kit_version_src()` now performs the same 3 download validation checks (empty response, HTML interception, gzip magic bytes) as `fetch_kit_version()`
- Resolved TODO on `_validate_tar_archive` line 220 with design rationale explaining why kit.yml cross-validation is unnecessary during archive validation
- Updated POD documentation to reflect fixes and removed KNOWN ISSUES entries

## Test Plan

- [x] `local_kits()` with mix of valid and corrupt kits returns valid kits only (new subtest)
- [x] `local_kits()` with all valid kits works normally (new subtest)
- [x] All 13 kit-archive-validation.t tests pass
- [x] `podchecker` passes on both Compiled.pod and Github.pod
- [x] Perl syntax check passes on both .pm files

## Ticket

FWT-706: https://fivetwenty.atlassian.net/browse/FWT-706