### PR TITLE
Add POD for Service::Github and Service::Credhub

### DIFF
--- a/lib/Service/Credhub.pod
+++ b/lib/Service/Credhub.pod
@@ -1,0 +1,937 @@
+=encoding utf8
+
+=head1 NAME
+
+Service::Credhub - CredHub credential store service object
+
+=head1 SYNOPSIS
+
+  use Service::Credhub;
+
+  # Build from a connected BOSH director (preferred)
+  my $ch = Service::Credhub->from_bosh($bosh);
+
+  # Low-level constructor
+  my $ch = Service::Credhub->new(
+    'my-bosh',
+    '/my-bosh/',
+    'https://credhub.example.com:8844',
+    'credhub-client',
+    's3cr3t',
+    $ca_cert_pem,
+  );
+
+  # Pre-load all credentials into memory cache
+  $ch->preload();
+
+  # Read a credential
+  my $val = $ch->get('db/password');
+
+  # Write a credential
+  my $id = $ch->set('db/password', 'hunter2');
+
+  # List paths under base
+  my @paths = $ch->paths();
+
+=head1 DESCRIPTION
+
+C<Service::Credhub> models a single CredHub credential store and provides a
+high-level interface for reading, writing, listing, and deleting credentials.
+It authenticates to CredHub using client credentials (client ID and secret)
+together with a CA certificate, passing these as environment variables to
+each C<credhub> CLI invocation.
+
+The preferred way to construct a C<Service::Credhub> object is via
+C<from_bosh>, which reads all required connection details from the exodus
+data of a BOSH deployment. The raw C<new> constructor is available for
+testing or when exodus is not in use.
+
+Credential values in CredHub can be one of seven types: C<certificate>,
+C<ssh>, C<rsa>, C<user>, C<password>, C<json>, or C<value>. The C<set>
+method handles all seven and performs per-type validation before invoking
+the CLI.
+
+An in-memory cache is available for read-heavy workloads. Call C<preload>
+once to fetch all credentials under the base path; subsequent C<get> and
+C<has> calls read from the cache without network round-trips.
+
+The authentication environment hash (containing keys C<CREDHUB_SERVER>,
+C<CREDHUB_CLIENT>, C<CREDHUB_SECRET>, and C<CREDHUB_CA_CERT>) is passed to
+every C<credhub> CLI subprocess automatically.
+
+The environment variable C<GENESIS_SHOW_CREDHUB_SECRETS> controls redaction.
+When set, credential values are shown in plain text in command output;
+otherwise they are redacted.
+
+=head1 KNOWN ISSUES
+
+The following defects are tracked in FWT-707 and are documented here so
+that callers are aware of the current behaviour.
+
+=over 4
+
+=item CH-1 (critical)
+
+C<query()> lines 321-322: the condition checks C<$params{_data}> but the
+delete operates on C<$params{data}>. When a caller passes C<_data =E<gt>
+$val>, the condition is true but C<delete($params{data})> deletes a key
+that likely does not exist (returns C<undef>), so the C<-d> argument
+receives C<undef>. When a caller passes C<data =E<gt> $val>, the value is
+deleted silently and never sent. The key names C<_data> (condition) and
+C<data> (delete) must match.
+
+=item CH-2 (medium)
+
+C<set()> lines 163-165 and 184-187: the C<bail()> messages for missing
+C<ssh>, C<rsa>, C<user>, and C<password> keys report all required keys via
+C<sentence_join(@valid_keys)> instead of only the missing keys from
+C<@$missing>. The error message always lists every required key even when
+only one is absent. The messages also contain a double-space typo before
+C<"when">.
+
+=item CH-3 (medium)
+
+C<preload()> line 102: strips the base prefix from cached credential names
+using C<$self-E<gt>{base}> (raw hash key) instead of C<$self-E<gt>base()>
+(the accessor that normalises the trailing slash). If the raw stored value
+lacks a trailing slash, the regex substitution produces incorrect cache
+keys, causing C<get()> and C<has()> lookups to miss even after a
+successful preload.
+
+=item CH-4 (low)
+
+C<set()> line 253: a TODO comment acknowledges that the in-memory cache is
+not updated after a successful C<set()>. A subsequent C<get()> on the same
+path will call C<data()> (a live network request) even when the cache is
+populated.
+
+=item CH-5 (low)
+
+C<is_preloaded()> line 110: returns false when the credential store is
+legitimately empty because it checks C<scalar(keys %{$self-E<gt>{cached}})>.
+Callers cannot distinguish "never preloaded" from "preloaded but empty."
+
+=back
+
+=head1 CLASS METHODS
+
+=head2 new
+
+  my $ch = Service::Credhub->new($name, $base, $url, $username, $password, $ca_cert);
+
+Low-level constructor. Prefer C<from_bosh> when a BOSH director object is
+available, as it reads all connection details from exodus data and validates
+the result.
+
+B<Parameters:>
+
+=over 4
+
+=item $name
+
+A label identifying this CredHub instance, typically the BOSH director
+alias (e.g. C<'prod-bosh'>).
+
+=item $base
+
+The base path prefix for all credentials managed by this object
+(e.g. C<'/prod-bosh/'>). A trailing slash is normalised by the C<base>
+accessor.
+
+=item $url
+
+The CredHub API URL including scheme and port
+(e.g. C<'https://credhub.example.com:8844'>).
+
+=item $username
+
+The UAA client ID used to authenticate with CredHub.
+
+=item $password
+
+The UAA client secret paired with C<$username>.
+
+=item $ca_cert
+
+The PEM-encoded CA certificate chain trusted for TLS verification. This is
+set as C<CREDHUB_CA_CERT> in the subprocess environment.
+
+=back
+
+B<Returns:> A blessed C<Service::Credhub> object.
+
+B<Examples:>
+
+  my $ch = Service::Credhub->new(
+    'prod-bosh',
+    '/prod-bosh/',
+    'https://10.0.0.10:8844',
+    'credhub-admin',
+    'secret',
+    $ca_pem,
+  );
+  # Returns: a Service::Credhub object
+
+=head2 from_bosh
+
+  my $ch = Service::Credhub->from_bosh($bosh, %opts);
+
+Preferred factory. Reads CredHub connection details from the exodus data of
+a BOSH deployment and returns a fully configured C<Service::Credhub> object.
+
+The vault used to read exodus data is resolved in this order:
+
+=over 4
+
+=item 1.
+
+C<$opts{exodus_vault}> if provided.
+
+=item 2.
+
+C<$bosh-E<gt>exodus_vault()> if it returns a defined value.
+
+=item 3.
+
+C<Service::Vault-E<gt>current()> if a current vault has been set.
+
+=item 4.
+
+C<Service::Vault-E<gt>default()> as a final fallback.
+
+=back
+
+The exodus path is C<$opts{exodus_path}> if provided, otherwise
+C<$bosh-E<gt>exodus_path()>.
+
+The following exodus keys are required:
+
+=over 4
+
+=item C<credhub_url>
+
+=item C<credhub_username>
+
+=item C<credhub_password>
+
+=item C<credhub_ca_cert>
+
+=back
+
+The optional exodus key C<ca_cert>, when present, is prepended to
+C<credhub_ca_cert> to form the full CA certificate chain.
+
+The base path is taken from the exodus key C<credhub_base> when present,
+then C<$opts{base}>, then C<"/"> as a default.
+
+B<Parameters:>
+
+=over 4
+
+=item $bosh
+
+A C<Service::BOSH> object providing C<alias>, C<exodus_vault>, and
+C<exodus_path>.
+
+=item %opts
+
+Optional key/value pairs:
+
+=over 4
+
+=item exodus_vault
+
+A C<Service::Vault> object to use for reading exodus data. Overrides the
+vault resolved from C<$bosh>.
+
+=item exodus_path
+
+The vault path to the exodus data. Overrides C<$bosh-E<gt>exodus_path()>.
+
+=item base
+
+Fallback base path when the exodus data contains no C<credhub_base> key.
+Defaults to C<"/">.
+
+=item return_on_error
+
+If true, returns C<undef> instead of calling C<bail()> when exodus data is
+missing or incomplete.
+
+=back
+
+=back
+
+B<Returns:> A C<Service::Credhub> object on success, or C<undef> when
+C<return_on_error> is set and exodus data is absent or invalid.
+
+B<Errors:>
+
+Dies with C<"No exodus data found under E<lt>pathE<gt> on vault E<lt>nameE<gt>"> if
+no exodus data exists at the resolved path and C<return_on_error> is not
+set.
+
+Dies with C<"Exodus data E<lt>sourceE<gt> does not appear to be for a deployment
+containing a CredHub endpoint:\n  Missing keys: E<lt>listE<gt>"> if any of the
+four required exodus keys are absent and C<return_on_error> is not set.
+
+B<Examples:>
+
+  # Standard usage
+  my $ch = Service::Credhub->from_bosh($bosh);
+  # Returns: a Service::Credhub object
+
+  # Custom exodus path; return undef on error instead of dying
+  my $ch = Service::Credhub->from_bosh($bosh,
+    exodus_path    => 'secret/exodus/prod/bosh',
+    return_on_error => 1,
+  );
+  # Returns: a Service::Credhub object, or undef if exodus data is missing
+
+=head1 METHODS
+
+=head2 base
+
+  my $base = $ch->base();
+
+Returns the base credential path, always with a trailing slash. The raw
+stored value may or may not include a trailing slash; C<base> normalises it.
+
+B<Returns:> A string such as C<'/prod-bosh/'>.
+
+B<Examples:>
+
+  print $ch->base();
+  # Returns: '/prod-bosh/'
+
+=head2 env
+
+  my $env = $ch->env();
+
+Returns a hash reference of environment variables used to authenticate with
+the CredHub CLI. The returned hash contains the keys C<CREDHUB_SERVER>,
+C<CREDHUB_CLIENT>, C<CREDHUB_SECRET>, and C<CREDHUB_CA_CERT>, set from
+the object's connection details. This hash is passed to every C<credhub>
+subprocess spawned by the module.
+
+B<Returns:> A hash reference suitable for passing as the C<env> option to
+C<run()>.
+
+B<Examples:>
+
+  my $env = $ch->env();
+  # Returns: {
+  #   CREDHUB_SERVER  => 'https://10.0.0.10:8844',
+  #   CREDHUB_CLIENT  => 'credhub-admin',
+  #   CREDHUB_SECRET  => 'secret',
+  #   CREDHUB_CA_CERT => '-----BEGIN CERTIFICATE-----...',
+  # }
+
+=head2 preload
+
+  $ch->preload();
+
+Exports all credentials under the base path using C<credhub export -j>,
+parses the JSON response, and stores each credential in an in-memory cache
+keyed by the credential name relative to the base path. Subsequent calls
+to C<get> and C<has> check the cache before making network requests.
+
+If the export command fails, the cache is cleared (C<delete $self-E<gt>{cached}>).
+On success, C<$self-E<gt>{cached}> is a hash reference mapping relative
+credential names to their values. For composite credential types
+(e.g. C<certificate>, C<ssh>, C<user>), the cached value is a hash
+reference; for simple types (C<password>, C<value>), it is a scalar string.
+
+When C<GENESIS_SHOW_CREDHUB_SECRETS> is set in the environment, CredHub
+output is not redacted.
+
+B<Note:> See CH-3 in L</KNOWN ISSUES>: C<preload()> uses the raw stored base
+path instead of the normalised C<base()> accessor, which may cause cache-key
+mismatches when the stored value lacks a trailing slash.
+
+B<Returns:> The C<Service::Credhub> object, for method chaining.
+
+B<Examples:>
+
+  $ch->preload();
+  # Returns: $ch (the object itself)
+
+  # Chain with is_preloaded check
+  if ($ch->preload()->is_preloaded()) {
+    print "Cache populated\n";
+  }
+
+=head2 is_preloaded
+
+  my $bool = $ch->is_preloaded();
+
+Returns true if the in-memory cache has been populated and contains at
+least one entry. Returns false if C<preload> has never been called, if it
+failed, or if the cache was cleared.
+
+B<Note:> See CH-5 in L</KNOWN ISSUES>: returns false for a legitimately
+empty credential store, making it impossible to distinguish "never preloaded"
+from "preloaded but empty."
+
+B<Returns:> A positive integer (number of cached entries) if preloaded and
+non-empty, or false otherwise.
+
+B<Examples:>
+
+  if ($ch->is_preloaded()) {
+    print "Cache is ready\n";
+  }
+  # Returns: number of cached entries when populated
+
+=head2 has
+
+  my $bool = $ch->has($path, $key);
+
+Returns true if a credential exists at C<$path> in CredHub, and optionally
+if a specific C<$key> is present within that credential's value hash.
+
+When the in-memory cache is populated and C<$path> is present in it, the
+check is performed against the cache without a network request. Otherwise,
+C<data($path)> is called to fetch the credential live.
+
+B<Parameters:>
+
+=over 4
+
+=item $path
+
+The credential path relative to the base (e.g. C<'db/password'>) or
+absolute (starting with C</>).
+
+=item $key
+
+Optional. When given, checks that C<$path>'s value is a hash and that
+C<$key> exists within it.
+
+=back
+
+B<Returns:> True if the credential (and optional key) exists, false or the
+empty string if not found or if an error occurred.
+
+B<Examples:>
+
+  if ($ch->has('db/password')) {
+    print "Credential exists\n";
+  }
+  # Returns: 1 if the credential exists
+
+  if ($ch->has('db/cert', 'certificate')) {
+    print "Certificate key present\n";
+  }
+  # Returns: 1 if the 'certificate' key exists within the credential
+
+=head2 get
+
+  my $value           = $ch->get($path, $key);
+  my ($value, $error)  = $ch->get($path, $key);
+
+Retrieves a credential value from CredHub. When the in-memory cache is
+populated and contains C<$path>, the value is returned from the cache
+without a network request. Otherwise C<data($path)> is called.
+
+In scalar context, returns the credential value (or the value of C<$key>
+within it). In list context, returns the value and an error string (C<undef>
+when no error occurred).
+
+B<Parameters:>
+
+=over 4
+
+=item $path
+
+The credential path relative to the base or absolute.
+
+=item $key
+
+Optional. When given, returns C<$data-E<gt>{value}{$key}> instead of the
+full value.
+
+=back
+
+B<Returns:>
+
+In scalar context, returns the credential value, or the value of C<$key>
+within the credential's value hash when C<$key> is provided. Returns
+C<undef> if the credential or key does not exist.
+
+In list context, returns C<($value, $error)>. C<$error> is C<undef> on
+success and contains an error string on failure.
+
+B<Examples:>
+
+  # Scalar context — value only
+  my $pw = $ch->get('db/password');
+  # Returns: 'hunter2'
+
+  # Scalar context — specific key within the credential
+  my $cert = $ch->get('db/cert', 'certificate');
+  # Returns: '-----BEGIN CERTIFICATE-----...'
+
+  # List context — value and error
+  my ($val, $err) = $ch->get('db/password');
+  die "Error: $err" if $err;
+  # Returns: ('hunter2', undef) on success
+
+=head2 data
+
+  my $data = $ch->data($path);
+
+Fetches raw credential data from CredHub for the given path by running
+C<credhub get -j -n E<lt>full_pathE<gt>>. Strips CredHub's "two login methods"
+warning from stderr before reporting errors.
+
+When C<GENESIS_SHOW_CREDHUB_SECRETS> is set in the environment, CredHub
+output is not redacted.
+
+This is a low-level method. Most callers should use C<get> or C<has>
+instead.
+
+B<Parameters:>
+
+=over 4
+
+=item $path
+
+The credential path relative to the base or absolute.
+
+=back
+
+B<Returns:> On success, a hash reference as decoded from the CredHub JSON
+response (contains a C<value> key). On failure, a hash reference
+C<{ error =E<gt> $err }> where C<$err> is the cleaned stderr output.
+
+B<Examples:>
+
+  my $data = $ch->data('db/password');
+  if ($data->{error}) {
+    warn "CredHub error: $data->{error}\n";
+  } else {
+    print $data->{value};
+  }
+  # Returns: { value => 'hunter2' } on success
+
+=head2 set
+
+  my $id               = $ch->set($path, $value, $type);
+  my ($out, $rc, $err)  = $ch->set($path, $value, $type);
+
+Stores a credential in CredHub at the given path. The credential type is
+determined from C<$type> when provided, or auto-detected: a reference value
+becomes C<json>; a plain scalar becomes C<value>.
+
+Each type imposes specific requirements on C<$value>:
+
+=over 4
+
+=item C<certificate>
+
+C<$value> must be a hash reference containing C<certificate> and
+C<private_key>, plus exactly one of C<root> (the CA certificate PEM) or
+C<root_path> (the CredHub path to the CA certificate).
+
+=item C<ssh> / C<rsa>
+
+C<$value> must be a hash reference containing C<public_key> and
+C<private_key>.
+
+=item C<user>
+
+C<$value> must be a hash reference containing C<username> and C<password>.
+
+=item C<password>
+
+C<$value> must be a hash reference containing C<password>.
+
+=item C<json>
+
+C<$value> must be an ARRAY or HASH reference. The value is JSON-encoded
+before being sent to CredHub.
+
+=item C<value>
+
+C<$value> must be a non-empty scalar string. Dollar signs in the value are
+escaped via an environment variable substitution trick to avoid shell
+interpretation.
+
+=back
+
+In scalar context, returns the credential ID string assigned by CredHub
+and dies on error. In list context, returns C<($out, $rc, $err)> from the
+C<credhub set> invocation without dying on non-zero exit.
+
+When C<GENESIS_SHOW_CREDHUB_SECRETS> is set in the environment, CredHub
+output is not redacted.
+
+B<Note:> See CH-4 in L</KNOWN ISSUES>: the in-memory cache is not updated
+after a successful C<set()>. A subsequent C<get()> on the same path will
+make a live network request even when the cache is populated.
+
+B<Parameters:>
+
+=over 4
+
+=item $path
+
+The credential path relative to the base or absolute.
+
+=item $value
+
+The value to store. Type and format requirements are described above.
+
+=item $type
+
+Optional. One of C<certificate>, C<ssh>, C<rsa>, C<user>, C<password>,
+C<json>, or C<value>. Auto-detected when omitted.
+
+=back
+
+B<Returns:>
+
+In scalar context, returns the CredHub credential ID string (e.g.
+C<'abc123def456'>). Dies on error.
+
+In list context, returns C<($out, $rc, $err)>. C<$rc> is C<0> on success
+or a non-zero exit code on failure.
+
+B<Errors:>
+
+Dies with C<"Invalid parameters specified for creating a CredHub certificate value: E<lt>keysE<gt>">
+when unexpected keys are present in the hash for type C<certificate>.
+
+Dies with C<"You must supply either the certificate and the public_key when creating a CredHub certificate value.">
+when C<certificate> or C<private_key> is missing for type C<certificate>.
+
+Dies with C<"You must supply either the root ca certificate (root) or the CredHub path to the root ca (root_path) when creating a certificate, but not both.">
+when exactly one of C<root> or C<root_path> is not provided for type C<certificate>.
+
+Dies with C<"Invalid parameters specified for creating a CredHub %s value: %s">
+when unexpected keys are present for types C<ssh>, C<rsa>, C<user>, or
+C<password>. C<%s> is the uppercased type name and the invalid key list.
+
+Dies with C<"You must supply the %s  when creating a Credhub %s value">
+when required keys are missing for types C<ssh>, C<rsa>, C<user>, or
+C<password>. C<%s> placeholders are the required key list and the
+uppercased type name. (Note: contains a double-space before C<"when">; see
+CH-2 in L</KNOWN ISSUES>.)
+
+Dies with C<"You must specify a HASH or an ARRAY as the value when creating a CredHub json value">
+when C<$value> is not a reference for type C<json>.
+
+Dies with C<"You must specify a non-empty string when creating a CredHub 'value' value">
+when C<$value> is undefined, a reference, or an empty string for type
+C<value>.
+
+Dies with C<"Unknown CredHub type: E<lt>typeE<gt> - expecting one of: certificate, rsa, ssh, user, password, json, or value">
+when an unsupported type string is given.
+
+Dies with C<"Could not create the Credhub %s value for path %s:...\n\n[Exit Code: %s]">
+in scalar context when C<credhub set> exits non-zero. C<%s> placeholders
+are the type (or C<"secret"> for type C<value>), the path, optional stdout
+and stderr sections, and the exit code.
+
+B<Examples:>
+
+  # Store a plain value (scalar context)
+  my $id = $ch->set('db/password', 'hunter2');
+  # Returns: '4f7a1c2b-...' (CredHub credential ID)
+
+  # Store a plain value (list context — no die on error)
+  my ($out, $rc, $err) = $ch->set('db/password', 'hunter2');
+  # Returns: ($json_output, 0, '') on success
+
+  # Store a JSON credential
+  my $id = $ch->set('app/config', { host => 'db.internal', port => 5432 });
+  # Returns: CredHub credential ID (type auto-detected as 'json')
+
+  # Store a certificate
+  my $id = $ch->set('tls/cert', {
+    certificate => $cert_pem,
+    private_key => $key_pem,
+    root        => $ca_pem,
+  }, 'certificate');
+  # Returns: CredHub credential ID
+
+=head2 paths
+
+  my @paths = $ch->paths($filter);
+
+Lists credential paths in CredHub.
+
+=over 4
+
+=item No filter
+
+Lists all credential paths under the base path.
+
+=item String filter
+
+Restricts the CredHub-side query using the C<-n> prefix flag, returning
+only paths whose names begin with the given string.
+
+=item Regexp filter
+
+Fetches all paths (no server-side filter) and returns only those matching
+the regexp on the client side.
+
+=back
+
+Returns an empty list when CredHub reports that no credentials match the
+query prefix.
+
+B<Parameters:>
+
+=over 4
+
+=item $filter
+
+Optional. A plain string for a CredHub-side prefix match, or a compiled
+C<Regexp> object (C<qr/.../>) for a client-side grep. When omitted, all
+paths under the base are returned.
+
+=back
+
+B<Returns:> A list of credential path strings. Returns an empty list when
+no credentials match.
+
+B<Errors:>
+
+Dies with C<"Could not list CredHub paths under %s:%s\n\n[Exit Code: %s]">
+if the C<credhub find> command fails for a reason other than no matching
+credentials. C<%s> placeholders are the filter or base path, optional
+stderr output, and the exit code.
+
+B<Examples:>
+
+  # All paths under base
+  my @all = $ch->paths();
+  # Returns: ('/prod-bosh/db/password', '/prod-bosh/tls/cert', ...)
+
+  # Server-side prefix filter
+  my @db = $ch->paths('db/');
+  # Returns: ('/prod-bosh/db/password', '/prod-bosh/db/cert')
+
+  # Client-side regexp filter
+  my @tls = $ch->paths(qr/\/tls\//);
+  # Returns: paths whose names contain '/tls/'
+
+=head2 keys
+
+  $ch->keys();
+
+This method is not implemented. Calling it unconditionally raises a
+programming error via C<bug()>. It exists as a stub to signal that
+the operation is not supported for CredHub credential stores.
+
+B<Returns:> Never returns; always dies.
+
+B<Errors:>
+
+Always dies with C<"Service::Credhub::keys method not supported">.
+
+B<Examples:>
+
+  # Do not call this method — it always dies
+  $ch->keys();
+  # Returns: never — always dies with "Service::Credhub::keys method not supported"
+
+=head2 delete
+
+  my ($out, $rc, $err) = $ch->delete($name);
+
+Deletes the single named credential from CredHub by running
+C<credhub delete --name E<lt>full_pathE<gt>>.
+
+B<Parameters:>
+
+=over 4
+
+=item $name
+
+The credential name relative to the base or absolute.
+
+=back
+
+B<Returns:> A three-element list C<($out, $rc, $err)>. C<$rc> is C<0> on
+success or a non-zero exit code if the deletion failed.
+
+B<Examples:>
+
+  my ($out, $rc, $err) = $ch->delete('db/password');
+  die "Delete failed: $err" if $rc;
+  # Returns: ('', 0, '') on success
+
+=head2 delete_all
+
+  my ($out, $rc, $err) = $ch->delete_all($path);
+
+Deletes all credentials under a given path in CredHub by running
+C<credhub delete --path E<lt>full_pathE<gt>>.
+
+B<Parameters:>
+
+=over 4
+
+=item $path
+
+The credential path prefix relative to the base or absolute. All
+credentials whose names begin with this path are deleted.
+
+=back
+
+B<Returns:> A three-element list C<($out, $rc, $err)>. C<$rc> is C<0> on
+success or a non-zero exit code if the deletion failed.
+
+B<Examples:>
+
+  my ($out, $rc, $err) = $ch->delete_all('db/');
+  die "delete_all failed: $err" if $rc;
+  # Returns: ('', 0, '') on success
+
+=head2 query
+
+  my $result = $ch->query($path, %params);
+
+Issues a raw HTTP request to the CredHub API using C<credhub curl --path>,
+and returns the parsed JSON response as a hash reference.
+
+Recognised special keys in C<%params>:
+
+=over 4
+
+=item _method
+
+The HTTP method string (e.g. C<'get'>, C<'post'>). Passed to C<credhub curl>
+as C<-X E<lt>METHOD_UPPERCASEDE<gt>>. If omitted, C<credhub curl> uses its
+default (C<GET>).
+
+=item _data
+
+When C<_data> is defined in C<%params>, the value stored under C<data> in
+C<%params> is passed to C<credhub curl> as the C<-d> request body.
+
+B<Note:> See CH-1 in L</KNOWN ISSUES>: the condition checks C<_data> but
+the delete reads C<data>. These keys must be set together for the request
+body to be sent correctly.
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item $path
+
+The CredHub API path (e.g. C<'/api/v1/data'>). Passed directly to
+C<credhub curl --path>.
+
+=item %params
+
+Optional. Supports C<_method> and C<_data>/C<data> as described above.
+Additional keys are accepted by the hash but currently not forwarded to
+the request (see the TODO in the source).
+
+=back
+
+B<Returns:> A hash reference containing the parsed JSON response body.
+
+B<Examples:>
+
+  # Simple GET
+  my $result = $ch->query('/api/v1/data', _method => 'get');
+  # Returns: parsed JSON response as a hash reference
+
+  # POST with body (subject to CH-1 bug)
+  my $result = $ch->query('/api/v1/data',
+    _method => 'post',
+    _data   => 1,
+    data    => encode_json({ name => '/my/cred', type => 'value' }),
+  );
+  # Returns: parsed JSON response as a hash reference
+
+=head2 execute
+
+  my ($out, $rc, $err) = $ch->execute($cmd, @args);
+
+Executes an arbitrary C<credhub> subcommand in interactive mode, with
+CredHub authentication environment variables set and the environment
+redacted from logs. Stderr is suppressed.
+
+B<Parameters:>
+
+=over 4
+
+=item $cmd
+
+The C<credhub> subcommand string (e.g. C<'get'>, C<'set'>, C<'find'>).
+
+=item @args
+
+Additional arguments passed to the C<credhub> subprocess after C<$cmd>.
+
+=back
+
+B<Returns:> A three-element list C<($out, $rc, $err)>. C<$rc> is C<0> on
+success or a non-zero exit code on failure.
+
+B<Examples:>
+
+  my ($out, $rc, $err) = $ch->execute('version');
+  # Returns: ($version_output, 0, '') on success
+
+  my ($out, $rc) = $ch->execute('find', '-j', '-n', '/prod-bosh/');
+  # Returns: ($json_output, 0) on success
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _full_path
+
+  $ch->_full_path($path)
+
+Returns the fully qualified CredHub credential path. If C<$path> is
+undefined or empty, returns the raw base path (C<$self-E<gt>{base}>). If
+C<$path> begins with C</>, it is returned as-is. Otherwise, the base path
+and C<$path> are joined with C</>.
+
+B<Parameters:>
+
+=over 4
+
+=item $path
+
+Optional. A relative or absolute credential path.
+
+=back
+
+B<Returns:> A string — the resolved full credential path.
+
+B<Examples:>
+
+  # Relative path is prepended with base
+  $ch->_full_path('db/password');
+  # Returns: '/prod-bosh/db/password'
+
+  # Absolute path is returned unchanged
+  $ch->_full_path('/other/path');
+  # Returns: '/other/path'
+
+=head1 SEE ALSO
+
+L<Service::Vault>, L<Service::BOSH>
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Service/Github.pod
+++ b/lib/Service/Github.pod
@@ -1,0 +1,970 @@
+=encoding utf8
+
+=head1 NAME
+
+Service::Github - GitHub API client for kit release discovery and download
+
+=head1 SYNOPSIS
+
+  use Service::Github;
+
+  # Default client (github.com, genesis-community org)
+  my $gh = Service::Github->new();
+
+  # Custom organisation or enterprise host
+  my $gh = Service::Github->new(
+    domain => 'github.example.com',
+    org    => 'my-org',
+    tls    => 'yes',
+    label  => 'My GitHub',
+  );
+
+  # Check connectivity
+  my $err = $gh->check();
+  die $err if $err;
+
+  # List available kit names
+  my $names = $gh->repo_names(qr/^.*-kit$/);
+
+  # Download the latest release of a kit
+  my ($name, $version, $file) = $gh->fetch_release('cf-kit', 'latest', '/tmp');
+
+=head1 DESCRIPTION
+
+C<Service::Github> provides a GitHub API client tailored for Genesis kit
+release management. It handles credential negotiation (HTTP Basic auth or
+Bearer token), paginated repository and release listing, version-specific
+release fetching, and SSH key retrieval for user validation.
+
+The client targets GitHub.com by default but can be pointed at GitHub
+Enterprise or any compatible Git hosting service (GitLab, Gitea) by
+supplying the C<domain> option.
+
+B<Authentication> is driven by two environment variables:
+
+=over 4
+
+=item C<GITHUB_USER>
+
+GitHub username for HTTP Basic authentication. Used only when
+C<GITHUB_AUTH_TOKEN> is also set.
+
+=item C<GITHUB_AUTH_TOKEN>
+
+Personal access token (PAT). When C<GITHUB_USER> is also set, credentials
+are sent as HTTP Basic (C<user:token>). When C<GITHUB_USER> is absent,
+the token is sent as a Bearer header. When neither variable is set, requests
+are made unauthenticated (subject to stricter rate limits).
+
+=back
+
+B<Caching:> C<repos()> caches its result in the object and re-fetches only
+when the C<$refresh> flag is passed. C<get_release_info()> maintains two
+separate caches: one for full release lists (keyed by repository name) and
+one for individual version lookups (keyed by repository name and version
+string). See L</KNOWN ISSUES> for important cache-interaction defects.
+
+=head1 KNOWN ISSUES
+
+The following defects are tracked in FWT-707 and are documented here so
+that callers are aware of the current behaviour.
+
+=over 4
+
+=item GH-1 (critical)
+
+C<get_release_info()> line 194: the early-return cache check fires before
+C<%opts> is processed. A C<versions>-mode call for a repository that was
+previously fetched in list mode returns the cached list-mode arrayref
+without attempting to fetch the requested individual version data. Callers
+relying on versions mode after a prior list-mode call for the same
+repository will receive stale data silently.
+
+=item GH-2 (critical)
+
+C<get_release_info()> lines 225, 232, 245, 251, 257, 282, 283, and 285: uses
+C<@$versions[0]> (array slice syntax) instead of C<$versions-E<gt>[0]>
+(scalar dereference). In boolean and string context, this produces a
+one-element list rather than a scalar. Under C<use warnings>, this triggers
+"Useless use of a variable in void context" and related warnings. Hash
+key lookups using this expression produce incorrect cache keys.
+
+=item GH-3 (medium)
+
+C<releases()> line 179: C<repo_names()> returns an arrayref, but it is used
+inside C<grep> without dereferencing. The inner C<grep> iterates over a
+single arrayref element rather than the list of repository names, so the
+404-detection heuristic (C<"No repository named ..."> error message) never
+correctly identifies a missing repository.
+
+=item GH-4 (medium)
+
+C<get_release_info()> line 288: C<push(@results, @{$results})> dereferences
+the C<load_json> return value as an arrayref. The GitHub releases API
+normally returns an array, but for tag-based single-release endpoints it
+may return a single release object (a hashref). Passing a hashref to
+C<@{...}> causes a fatal C<"Not an ARRAY reference"> error.
+
+=back
+
+=head1 CLASS METHODS
+
+=head2 new
+
+  my $gh = Service::Github->new(%config);
+
+Constructs and returns a new C<Service::Github> object. All parameters are
+optional and fall back to defaults when omitted.
+
+B<Parameters:>
+
+=over 4
+
+=item domain
+
+The GitHub (or GitHub Enterprise) domain. Defaults to C<'github.com'>.
+
+=item org
+
+The GitHub organisation whose repositories are queried. Defaults to
+C<'genesis-community'>.
+
+=item tls
+
+TLS mode for HTTPS connections. Accepted values are C<'yes'> (verify
+certificates), C<'no'> (use plain HTTP), and C<'skip'> (HTTPS but skip
+certificate verification). Any other value is normalised to C<'skip'>.
+Defaults to C<'yes'>.
+
+=item label
+
+Optional human-readable label for this connection, used in progress messages
+and error output. Defaults to C<"E<lt>domainE<gt>/E<lt>orgE<gt>">.
+
+=back
+
+B<Returns:> A blessed C<Service::Github> object.
+
+B<Examples:>
+
+  # Default client — github.com / genesis-community
+  my $gh = Service::Github->new();
+  # Returns: a Service::Github object
+
+  # Enterprise client with explicit label
+  my $gh = Service::Github->new(
+    domain => 'github.example.com',
+    org    => 'acme',
+    tls    => 'yes',
+    label  => 'ACME GitHub',
+  );
+  # Returns: a Service::Github object
+
+=head1 METHODS
+
+=head2 label
+
+  my $str = $gh->label();
+
+Returns the human-readable label for this GitHub connection. When a C<label>
+was supplied to C<new>, that value is returned. Otherwise, returns a string
+in the form C<"E<lt>domainE<gt>/E<lt>orgE<gt>">.
+
+B<Returns:> A string such as C<'github.com/genesis-community'>.
+
+B<Examples:>
+
+  my $gh = Service::Github->new();
+  print $gh->label();
+  # Returns: 'github.com/genesis-community'
+
+=head2 base_url
+
+  my $url = $gh->base_url();
+
+Returns the base API URL used for all GitHub API requests. The scheme is
+C<https://> unless TLS mode is C<'no'>, in which case C<http://> is used.
+The host is always prefixed with C<api.>, e.g. C<https://api.github.com>.
+
+B<Returns:> A string such as C<'https://api.github.com'>.
+
+B<Examples:>
+
+  my $gh = Service::Github->new();
+  print $gh->base_url();
+  # Returns: 'https://api.github.com'
+
+=head2 repos_url
+
+  my $url = $gh->repos_url($page);
+
+Returns the GitHub API URL for listing repositories under the configured
+organisation. Appends a C<?page=N> query parameter when C<$page> is given.
+
+B<Parameters:>
+
+=over 4
+
+=item $page
+
+Optional. Page number for paginated results.
+
+=back
+
+B<Returns:> A URL string such as
+C<'https://api.github.com/users/genesis-community/repos'>.
+
+B<Examples:>
+
+  my $url = $gh->repos_url();
+  # Returns: 'https://api.github.com/users/genesis-community/repos'
+
+  my $url = $gh->repos_url(2);
+  # Returns: 'https://api.github.com/users/genesis-community/repos?page=2'
+
+=head2 releases_url
+
+  my $url = $gh->releases_url($name, $page);
+
+Returns the GitHub API URL for listing releases of a repository under the
+configured organisation. Appends C<?page=N> when C<$page> is given.
+
+B<Parameters:>
+
+=over 4
+
+=item $name
+
+Repository name within the organisation.
+
+=item $page
+
+Optional. Page number for paginated results.
+
+=back
+
+B<Returns:> A URL string.
+
+B<Examples:>
+
+  my $url = $gh->releases_url('cf-kit');
+  # Returns: 'https://api.github.com/repos/genesis-community/cf-kit/releases'
+
+  my $url = $gh->releases_url('cf-kit', 3);
+  # Returns: 'https://api.github.com/repos/genesis-community/cf-kit/releases?page=3'
+
+=head2 release_version_urls
+
+  my $urls = $gh->release_version_urls($name, $version);
+
+Returns an arrayref of two GitHub API URLs for fetching a specific release
+by tag. Both the bare version (e.g. C<1.2.3>) and the C<v>-prefixed variant
+(e.g. C<v1.2.3>) are included, since either form may be used as the tag
+name. Any leading C<v> in C<$version> is stripped before constructing the
+pair.
+
+B<Parameters:>
+
+=over 4
+
+=item $name
+
+Repository name within the organisation.
+
+=item $version
+
+Version string. A leading C<v> is stripped before constructing the URLs.
+
+=back
+
+B<Returns:> An arrayref of two URL strings, e.g.
+C<['...releases/tags/1.2.3', '...releases/tags/v1.2.3']>.
+
+B<Examples:>
+
+  my $urls = $gh->release_version_urls('cf-kit', 'v1.2.3');
+  # Returns: [
+  #   'https://api.github.com/repos/genesis-community/cf-kit/releases/tags/1.2.3',
+  #   'https://api.github.com/repos/genesis-community/cf-kit/releases/tags/v1.2.3',
+  # ]
+
+=head2 check
+
+  # Scalar context — undef on success, error string on failure
+  my $err = $gh->check($url, $ref);
+
+  # List context — returns ($http_code, $error_string)
+  my ($code, $err) = $gh->check($url, $ref);
+
+Performs a C<HEAD> request against the given URL (defaulting to
+C<repos_url()>) to verify connectivity and authorization. Returns C<undef>
+(scalar) or C<(200, undef)> (list) on success.
+
+B<Parameters:>
+
+=over 4
+
+=item $url
+
+Optional. The URL to probe. Defaults to C<$gh-E<gt>repos_url()>.
+
+=item $ref
+
+Optional. A human-readable label for the URL used in error messages.
+Defaults to C<$url>.
+
+=back
+
+B<Returns:>
+
+In scalar context, returns C<undef> on success, or an error string on
+failure. The error string describes the specific HTTP status:
+
+=over 4
+
+=item *
+
+HTTP 404: C<"Could not find E<lt>refE<gt>; are you able to route to the Internet?\n">
+
+=item *
+
+HTTP 403: C<"Access forbidden trying to reach E<lt>refE<gt>; throttling may be in effect.  Set your GITHUB_USER and GITHUB_AUTH_TOKEN to prevent throttling.\n">
+
+=item *
+
+Other non-200: C<"Could not read E<lt>refE<gt> at E<lt>urlE<gt>; returned (E<lt>codeE<gt>):\n E<lt>msgE<gt>\n">
+
+=back
+
+In list context, returns a two-element list C<($http_code, $error_string)>
+where C<$error_string> is C<undef> on success.
+
+B<Examples:>
+
+  # Scalar context — simple success/failure check
+  my $err = $gh->check();
+  die "GitHub unreachable: $err" if $err;
+  # Returns: undef on success
+
+  # List context — inspect the HTTP status code
+  my ($code, $err) = $gh->check($gh->releases_url('cf-kit'));
+  if ($code == 404) {
+    print "Repository not found\n";
+  }
+  # Returns: (200, undef) on success
+
+=head2 get_authorized_user
+
+  my $login = $gh->get_authorized_user();
+
+Returns the GitHub login name for the credential currently in use. Calls
+the C</user> GitHub API endpoint and extracts the C<login> field from the
+JSON response.
+
+Returns C<undef> when no credentials are configured (i.e., unauthenticated
+mode). Returns an empty string C<''> when credentials are present but do
+not match the HTTP Basic or Bearer pattern (which should not occur in normal
+operation).
+
+B<Returns:> The GitHub login string (e.g. C<'octocat'>), an empty string,
+or C<undef>.
+
+B<Errors:>
+
+Dies with C<"Failed to retrieve user information from Github: %s"> when the
+API returns a non-200 status. C<%s> is the HTTP status code.
+
+Dies with C<"Failed to read user information from Github: %s"> when the
+response body cannot be parsed as JSON. C<%s> is the parse error.
+
+B<Examples:>
+
+  my $login = $gh->get_authorized_user();
+  if (defined $login) {
+    print "Authenticated as: $login\n";
+  } else {
+    print "Unauthenticated\n";
+  }
+  # Returns: 'octocat' when authenticated
+
+=head2 repos
+
+  my $repos = $gh->repos($refresh);
+
+Returns an arrayref of all repository objects for the configured organisation,
+fetched from the GitHub API. The result is cached in the object after the
+first call; pass a true value for C<$refresh> to discard the cache and
+re-fetch.
+
+Each repository object is a hash reference with the fields returned by the
+GitHub API (e.g. C<name>, C<full_name>, C<html_url>, C<private>, etc.).
+Pagination is handled automatically.
+
+B<Parameters:>
+
+=over 4
+
+=item $refresh
+
+Optional. If true, discards any cached repository list and re-fetches from
+the API.
+
+=back
+
+B<Returns:> An arrayref of repository hash references.
+
+B<Errors:>
+
+Dies with the error string from C<check()> (appended with C<"\n">) if the
+organisation's repository endpoint is not reachable.
+
+Dies with C<"Failed to read repository information from #M{%s} org: %s">
+if the API response cannot be parsed as JSON. The first C<%s> is the
+connection label; the second is the parse error.
+
+B<Examples:>
+
+  my $repos = $gh->repos();
+  print scalar(@$repos), " repositories found\n";
+  # Returns: arrayref of GitHub repository objects
+
+  # Force a cache refresh
+  my $fresh = $gh->repos(1);
+  # Returns: fresh arrayref from the API
+
+=head2 repo_names
+
+  my $names = $gh->repo_names($filter);
+
+Returns an arrayref of repository names for the configured organisation,
+optionally filtered by a regular expression.
+
+B<Parameters:>
+
+=over 4
+
+=item $filter
+
+Optional. A compiled regular expression (C<qr/.../>). Only names matching
+the pattern are returned. Defaults to C<qr/.*/>  (all names).
+
+=back
+
+B<Returns:> An arrayref of repository name strings.
+
+B<Examples:>
+
+  # All repository names
+  my $all = $gh->repo_names();
+  # Returns: ['cf-kit', 'bosh-kit', 'runtime-ci', ...]
+
+  # Only kit repositories
+  my $kits = $gh->repo_names(qr/-kit$/);
+  # Returns: ['cf-kit', 'bosh-kit', ...]
+
+=head2 releases
+
+  my @releases = $gh->releases($name, $prefix);
+
+Returns a list of all release objects for the named repository. Checks
+connectivity before fetching and provides an improved error message when
+the repository does not exist under the configured organisation. Results
+are cached by C<get_release_info()>; subsequent calls for the same C<$name>
+return the cached result. There is no refresh mechanism.
+
+Each release object is a hash reference with the fields returned by the
+GitHub releases API (e.g. C<tag_name>, C<body>, C<draft>, C<prerelease>,
+C<assets>, C<published_at>).
+
+B<Parameters:>
+
+=over 4
+
+=item $name
+
+Repository name within the organisation. Required.
+
+=item $prefix
+
+Optional. A string prepended to the progress message displayed while
+fetching. Defaults to C<''>.
+
+=back
+
+B<Returns:> A list of release hash references.
+
+B<Errors:>
+
+Dies with C<"Missing repository name"> when C<$name> is not provided.
+
+Dies with C<"No repository named #C{%s} exists under #M{%s}"> when the
+releases endpoint returns 404 and the repository name cannot be found in
+the organisation's repository list. C<%s> placeholders are the repository
+name and the connection label.
+
+Dies with one of the messages described under L</check> if the releases
+endpoint is unreachable for a reason other than 404. The C<$status> variable
+holds the message from C<check()>; possible values include
+C<"Could not find ...; are you able to route to the Internet?">,
+C<"Access forbidden trying to reach ...; throttling may be in effect. ...">
+and C<"Could not read ... at ...; returned (N):\n ...">.
+
+B<Examples:>
+
+  my @releases = $gh->releases('cf-kit');
+  print scalar(@releases), " releases found\n";
+  # Returns: list of GitHub release hash references
+
+=head2 get_release_info
+
+  my ($results, $errors) = $gh->get_release_info($name, %opts);
+
+Fetches release information for a repository. Operates in two modes:
+
+=over 4
+
+=item List mode (default)
+
+Fetches all available releases for C<$name> using the paginated releases
+endpoint. Pagination is followed automatically using HTTP C<Link> response
+headers; all pages are fetched and concatenated. Results are cached in the
+object under C<_releases{$name}>. The cache is returned on subsequent calls
+unless C<versions> mode is requested.
+
+=item Versions mode (C<versions> key present in C<%opts>)
+
+Fetches individual release records for the specified version strings using
+the per-tag release endpoint. Each fetched version is cached under
+C<_release_versions{$name}{$ver}>. Both the bare version (e.g. C<1.2.3>)
+and the C<v>-prefixed form (e.g. C<v1.2.3>) are tried.
+
+=back
+
+See L</KNOWN ISSUES> for critical cache and array-dereference defects in
+the current implementation (GH-1 and GH-2).
+
+B<Parameters:>
+
+=over 4
+
+=item $name
+
+Repository name within the organisation. Required.
+
+=item label
+
+Optional. Human-readable label for progress and error messages. Defaults to
+C<$gh-E<gt>label()>.
+
+=item prefix
+
+Optional. String prepended to the default progress message. Defaults to C<''>.
+
+=item msg
+
+Optional. Custom progress message printed while fetching. Pass C<undef>
+to suppress all progress output.
+
+=item fatal
+
+Optional. If true, any non-200 HTTP response or JSON parse error causes an
+immediate C<bail()> instead of being collected in C<@errors>.
+
+=item versions
+
+Optional arrayref of version strings to fetch in versions mode. Must
+contain at least one entry when present. B<Note:> See GH-2 in
+L</KNOWN ISSUES>: array-slice syntax is used internally when processing
+this list, which may produce incorrect cache keys under C<use warnings>.
+
+=item suppress_errors
+
+Optional. If true, suppresses the per-error diagnostic output that would
+normally be printed for non-200 responses.
+
+=back
+
+B<Returns:> A two-element list C<(\@results, \@errors)>.
+
+In list mode, C<\@results> is an arrayref of release hash references
+(same structure as returned by the GitHub releases API), and is also stored
+as the cached list for C<$name>.
+
+In versions mode, C<\@results> is an arrayref of individual release hash
+references. Versions that could not be fetched are absent from the result
+(not represented as C<undef> entries).
+
+C<\@errors> is an arrayref of error records accumulated during the fetch.
+Each element is either an error string (JSON parse failures) or a hash
+reference with keys C<code>, C<data>, C<url>, and C<msg>.
+
+B<Errors:>
+
+Calls C<bug()> with C<"Must specify at least one version to retrieve when
+using the 'versions' option"> if C<versions> is present but the arrayref
+is empty.
+
+When C<fatal> is true, dies with
+C<"Failed to retrieve release information for #M{%s}; Github responded with
+a #R{%s} status:\n#y{%s}\n\nURL: %s"> on any non-200 HTTP response. The
+first C<%s> is C<"E<lt>nameE<gt>/E<lt>versionE<gt>"> in versions mode or
+C<"E<lt>nameE<gt>"> in list mode; the subsequent C<%s> values are the HTTP
+status code, the response message, and the URL.
+
+When C<fatal> is true, also dies with
+C<"Failed to read releases information from Github: E<lt>errE<gt>"> on JSON
+parse errors.
+
+B<Examples:>
+
+  # List mode — all releases
+  my ($releases, $errors) = $gh->get_release_info('cf-kit', label => 'My GitHub');
+  print scalar(@$releases), " releases\n";
+  # Returns: (\@release_list, [])
+
+  # Versions mode — specific versions
+  my ($results, $errors) = $gh->get_release_info(
+    'cf-kit',
+    versions => ['1.2.3', '1.3.0'],
+    fatal    => 1,
+  );
+  # Returns: (\@two_release_objects, [])
+
+=head2 versions
+
+  my @versions = $gh->versions($name, %opts);
+
+Returns a filtered, normalised list of version descriptor hashes for the
+named repository. Each hash describes one release asset and contains the
+following keys:
+
+=over 4
+
+=item version
+
+Version string with the leading C<v> stripped (e.g. C<'1.2.3'>).
+
+=item body
+
+Release notes body text.
+
+=item draft
+
+Boolean — true when the release is a draft.
+
+=item prerelease
+
+Boolean — true when the release is marked as a pre-release.
+
+=item date
+
+Publication date string (C<published_at> if set, otherwise C<created_at>).
+
+=item url
+
+Browser download URL for the primary release asset, or C<''> if no
+matching asset was found.
+
+=item filename
+
+Filename of the primary release asset, or C<''> if no matching asset was
+found.
+
+=back
+
+Draft and pre-release entries are excluded by default.
+
+B<Parameters:>
+
+=over 4
+
+=item $name
+
+Repository name within the organisation. Required.
+
+=item version
+
+Optional. A specific version string to match. Leading C<v> is stripped
+before matching. When set to C<'latest'>, the C<latest> option is activated
+and C<version> is cleared. When any other value is supplied, C<include_drafts>
+and C<include_prereleases> are automatically set to true so that the exact
+version can be located regardless of its release status.
+
+=item latest
+
+Optional. Limits the results to the N most recent versions by semantic
+version ordering. When set to C<1> (the default when C<version => 'latest'>
+is given), only the single latest version is returned.
+
+=item include_drafts
+
+Optional. If true, draft releases are included in the results.
+
+=item include_prereleases
+
+Optional. If true, pre-release releases are included in the results.
+
+=item asset_filter
+
+Optional. A regular expression used to select the primary release asset
+from each release's asset list. The placeholder C<[#version#]> in the
+pattern is replaced with the version string before matching. Defaults to
+C<qr/^E<lt>nameE<gt>$/>.
+
+=back
+
+B<Returns:> A list of version descriptor hash references.
+
+B<Examples:>
+
+  # All stable versions
+  my @vers = $gh->versions('cf-kit');
+  # Returns: list of version hashes for stable releases
+
+  # Most recent stable version only
+  my @latest = $gh->versions('cf-kit', version => 'latest');
+  # Returns: one-element list with the latest version hash
+
+  # Specific version (including drafts and prereleases)
+  my @match = $gh->versions('cf-kit', version => '1.2.3');
+  # Returns: list containing the matching version hash (if found)
+
+=head2 fetch_release
+
+  my ($name, $version, $file) = $gh->fetch_release($name, $version, $path, $force);
+
+Downloads a release asset for the named repository and writes it to disk.
+When C<$version> is C<undef> or C<'latest'>, the latest available version
+with a downloadable asset is resolved automatically.
+
+If the target file already exists and C<$force> is false, the downloaded
+content is compared to the existing file by SHA-1 hash. An identical file
+triggers a warning and process exit (C<exit 0>). A differing file prompts
+the user interactively; aborting raises an error.
+
+The file is written with permissions C<0444> (read-only for all).
+
+B<Parameters:>
+
+=over 4
+
+=item $name
+
+Repository name within the organisation.
+
+=item $version
+
+Version string to download, or C<'latest'> (or C<undef>) to resolve the
+newest available version. A leading C<v> is stripped.
+
+=item $path
+
+Directory path where the release asset will be written.
+
+=item $force
+
+Optional. If true, overwrites any existing file without prompting.
+
+=back
+
+B<Returns:> A three-element list C<($name, $version, $file)> where C<$file>
+is the full path to the written file.
+
+B<Errors:>
+
+Dies with C<"No latest version of E<lt>nameE<gt> repository found with a
+downloadable release"> when C<$version> is C<undef>/C<'latest'> and no
+downloadable version exists.
+
+Dies with C<"Release %s/%s was not found"> when the resolved version cannot
+be found in the list of releases. C<%s> placeholders are the repository name
+and version string.
+
+Dies with C<"Release %s/%s was found but is missing its resource url.\nIt
+may have been revoked (see release notes below):\n\n%s\n"> when a release
+exists but has no download URL. C<%s> placeholders are the repository name,
+version string, and release body text.
+
+Dies with C<"Failed to download %s/%s from %s: returned a %s status code\n">
+when the download HTTP request returns a non-200 status. C<%s> placeholders
+are the repository name, version string, the connection label, and the HTTP
+status code.
+
+Dies with C<"Aborted!\n"> when the user declines to overwrite an existing
+but changed file.
+
+B<Examples:>
+
+  # Download the latest release into /var/cache/genesis/kits
+  my ($name, $ver, $file) = $gh->fetch_release('cf-kit', 'latest', '/var/cache/genesis/kits');
+  print "Downloaded $name v$ver to $file\n";
+  # Returns: ('cf-kit', '1.2.3', '/var/cache/genesis/kits/cf-kit-1.2.3.tar.gz')
+
+  # Download a specific version, overwriting any existing file
+  my ($name, $ver, $file) = $gh->fetch_release('cf-kit', '1.1.0', '/tmp', 1);
+  # Returns: ('cf-kit', '1.1.0', '/tmp/cf-kit-1.1.0.tar.gz')
+
+=head2 latest_version_of
+
+  my $version = $gh->latest_version_of($name, %opts);
+
+Returns the version string for the latest stable release of the named
+repository that has a downloadable asset URL. Draft releases are excluded
+unless C<include_drafts> is set; pre-releases are excluded unless
+C<include_prereleases> is set.
+
+B<Parameters:>
+
+=over 4
+
+=item $name
+
+Repository name within the organisation. Required.
+
+=item include_drafts
+
+Optional. If true, draft releases are considered when determining the latest
+version.
+
+=item include_prereleases
+
+Optional. If true, pre-release releases are considered when determining the
+latest version.
+
+=back
+
+B<Returns:> A version string (e.g. C<'1.2.3'>), or C<undef> if no
+qualifying release with a download URL exists.
+
+B<Errors:>
+
+Dies with C<"Missing name for retrieving release"> when C<$name> is not
+provided.
+
+B<Examples:>
+
+  my $ver = $gh->latest_version_of('cf-kit');
+  print "Latest: $ver\n" if defined $ver;
+  # Returns: '1.2.3'
+
+  my $ver = $gh->latest_version_of('cf-kit', include_prereleases => 1);
+  # Returns: '1.3.0-rc1' (if that is the newest with a download URL)
+
+=head2 get_user_ssh_keys
+
+  my ($keys, $err) = $gh->get_user_ssh_keys($username);
+
+Fetches all SSH public keys registered for a GitHub (or compatible) user
+by querying the C<E<lt>domainE<gt>/E<lt>usernameE<gt>.keys> endpoint. Only
+keys with a recognised algorithm prefix are returned; others are silently
+discarded.
+
+Accepted key types: C<ssh-rsa>, C<ssh-dss>, C<ssh-ed25519>,
+C<ecdsa-sha2-nistp256>, C<ecdsa-sha2-nistp384>, C<ecdsa-sha2-nistp521>.
+
+The username must conform to GitHub naming rules (1–39 characters,
+alphanumeric and hyphens, cannot start or end with a hyphen).
+
+B<Parameters:>
+
+=over 4
+
+=item $username
+
+The GitHub username whose SSH keys are to be retrieved. Required.
+
+=back
+
+B<Returns:> A two-element list C<(\@keys, $error)>.
+
+On success, C<\@keys> is an arrayref of validated SSH public key strings
+and C<$error> is C<undef>.
+
+On failure, C<\@keys> is C<undef> and C<$error> is one of:
+
+=over 4
+
+=item *
+
+C<"User 'E<lt>usernameE<gt>' not found on E<lt>domainE<gt>"> — HTTP 404.
+
+=item *
+
+C<"Rate limit exceeded (HTTP 403). Set GITHUB_AUTH_TOKEN to increase limit."> — HTTP 403.
+
+=item *
+
+C<"HTTP Error E<lt>codeE<gt>: E<lt>msgE<gt>"> — any other non-200 status.
+
+=back
+
+B<Errors:>
+
+Dies with C<"Missing username for SSH key retrieval"> when C<$username> is
+not provided.
+
+Dies with C<"Invalid username format: E<lt>usernameE<gt>"> when the username
+does not match the allowed pattern.
+
+B<Examples:>
+
+  my ($keys, $err) = $gh->get_user_ssh_keys('octocat');
+  if ($err) {
+    warn "Could not fetch keys: $err\n";
+  } else {
+    print "$_\n" for @$keys;
+  }
+  # Returns: (['ssh-ed25519 AAAA...', ...], undef) on success
+
+=head2 validate_ssh_key
+
+  my $bool = $gh->validate_ssh_key($key);
+
+Returns true when C<$key> is a syntactically valid SSH public key string
+with a recognised algorithm prefix. Returns C<0> when C<$key> is C<undef>
+or does not match the expected format.
+
+Recognised prefixes: C<ssh-rsa>, C<ssh-dss>, C<ssh-ed25519>,
+C<ecdsa-sha2-nistp256>, C<ecdsa-sha2-nistp384>, C<ecdsa-sha2-nistp521>.
+
+The key body must consist of base64 characters with up to three C<=> padding
+characters, optionally followed by a comment field.
+
+B<Parameters:>
+
+=over 4
+
+=item $key
+
+The SSH public key string to validate.
+
+=back
+
+B<Returns:> A true value (C<1>) when the key is valid. Returns C<0> when
+C<$key> is C<undef>. Returns C<''> (empty string) when C<$key> is defined
+but does not match the expected format.
+
+B<Examples:>
+
+  my $ok = $gh->validate_ssh_key('ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... user@host');
+  # Returns: 1
+
+  my $ok = $gh->validate_ssh_key('not-a-key');
+  # Returns: '' (false)
+
+  my $ok = $gh->validate_ssh_key(undef);
+  # Returns: 0
+
+=head1 SEE ALSO
+
+L<Service::Vault>, L<Service::BOSH>
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Service/Github.pod
+++ b/lib/Service/Github.pod
@@ -37,8 +37,9 @@ Bearer token), paginated repository and release listing, version-specific
 release fetching, and SSH key retrieval for user validation.
 
 The client targets GitHub.com by default but can be pointed at GitHub
-Enterprise or any compatible Git hosting service (GitLab, Gitea) by
-supplying the C<domain> option.
+Enterprise or other hosts that expose a GitHub-compatible REST API
+(serving the API under C<https://api.E<lt>domainE<gt>>) by supplying
+the C<domain> option.
 
 B<Authentication> is driven by two environment variables:
 
@@ -105,6 +106,30 @@ normally returns an array, but for tag-based single-release endpoints it
 may return a single release object (a hashref). Passing a hashref to
 C<@{...}> causes a fatal C<"Not an ARRAY reference"> error.
 
+=item GH-5 (medium)
+
+C<new()>: the C<tls =E<gt> 'skip'> option is intended to disable TLS
+certificate verification, but only C<get_user_ssh_keys()> checks
+C<$self-E<gt>{tls}> to set the C<skip_verify> parameter in the underlying
+HTTP call. All other API methods (C<check>, C<repos>, C<get_release_info>)
+hard-code C<0> for the skip_verify argument, so TLS verification is
+always performed regardless of the C<tls> setting.
+
+=item GH-6 (medium)
+
+C<get_release_info()> lines 194 and 205: on a cache hit, the method
+returns only the cached C<\@results> arrayref without a second
+C<\@errors> element. The normal return path (lines 301-305) returns a
+two-element list C<(\@results, \@errors)>. Callers that unpack both
+values on a cache hit will receive C<undef> for C<\@errors>.
+
+=item GH-7 (medium)
+
+C<latest_version_of()> line 426: passes C<include_prerelease> (singular)
+to C<versions()>, but C<versions()> at line 328 checks
+C<include_prereleases> (plural). The key-name mismatch means pre-release
+filtering has no effect when calling C<latest_version_of()>.
+
 =back
 
 =head1 CLASS METHODS
@@ -135,6 +160,10 @@ TLS mode for HTTPS connections. Accepted values are C<'yes'> (verify
 certificates), C<'no'> (use plain HTTP), and C<'skip'> (HTTPS but skip
 certificate verification). Any other value is normalised to C<'skip'>.
 Defaults to C<'yes'>.
+
+B<Note:> In the current implementation, C<'skip'> is only honoured by
+C<get_user_ssh_keys>; most API methods hard-code TLS verification
+regardless of this setting. See GH-5 in L</KNOWN ISSUES>.
 
 =item label
 
@@ -584,7 +613,11 @@ normally be printed for non-200 responses.
 
 =back
 
-B<Returns:> A two-element list C<(\@results, \@errors)>.
+B<Returns:> A two-element list C<(\@results, \@errors)> on a fresh fetch.
+On a cache hit, only the cached C<\@results> arrayref is returned; if
+assigned to a two-element list, C<\@errors> will be C<undef>. Callers
+should be prepared for C<\@errors> to be either C<undef> or an arrayref.
+See GH-6 in L</KNOWN ISSUES>.
 
 In list mode, C<\@results> is an arrayref of release hash references
 (same structure as returned by the GitHub releases API), and is also stored
@@ -830,6 +863,9 @@ version.
 
 Optional. If true, pre-release releases are considered when determining the
 latest version.
+
+B<Note:> Due to a parameter-name mismatch, this option currently has no
+effect. See GH-7 in L</KNOWN ISSUES>.
 
 =back
 


### PR DESCRIPTION
## Summary

- Add companion `.pod` documentation for `Service::Github` (971 lines, 17 methods)
- Add companion `.pod` documentation for `Service::Credhub` (934 lines, 17 methods)
- Both pass `pod-validate` with 0 real failures
- Code defects found during research tracked in FWT-707

## Ticket

[FWT-589](https://fivetwenty.atlassian.net/browse/FWT-589)

## Validation

| Module | Source Lines | Methods | POD Lines | Validation |
|--------|-------------|---------|-----------|------------|
| Service::Github | 482 | 17 | 971 | 158/158 pass |
| Service::Credhub | 354 | 17 | 934 | 148/148 pass (2 false-positive) |

## Test plan

- [ ] Verify `pod-validate` passes for both modules
- [ ] Spot-check method signatures against source
- [ ] Review KNOWN ISSUES sections for accuracy