### PR TITLE
Complete POD for Env::Deployment classes

### DIFF
--- a/lib/Genesis/Env/Deployment.pod
+++ b/lib/Genesis/Env/Deployment.pod
@@ -252,14 +252,20 @@ C<action> is C<'deploy'>:
 =item started (optional)
 
 When the action started. Accepts a Time::Piece object or a string in
-EXODUS_TIME_FORMAT. Defaults to the commit time when C<commit()> is called if
-not provided at construction time.
+EXODUS_TIME_FORMAT. If not provided at construction time, this value is
+backfilled during C<commit()> from the deployment's existing C<timestamp>
+(as initialized during C<new()>), not from the wall-clock time at which
+C<commit()> runs. If no C<timestamp> is set on the object, it falls back
+to the C<completed> value or, lastly, the current time.
 
 =item completed (optional)
 
 When the action completed. Accepts a Time::Piece object or a string in
-EXODUS_TIME_FORMAT. Defaults to the commit time when C<commit()> is called if
-not provided at construction time.
+EXODUS_TIME_FORMAT. If not provided at construction time, this value is
+backfilled during C<commit()> from the deployment's existing C<timestamp>
+(as initialized during C<new()>), not from the wall-clock time at which
+C<commit()> runs. If no C<timestamp> is set on the object, it falls back
+to the current time.
 
 =item artifacts (optional)
 
@@ -561,7 +567,10 @@ artifacts are present, they are packaged as a base64-encoded gzip tarball and
 stored under the C<artifacts> key via vault's C<key@file> notation.
 
 If C<started> or C<completed> are not set on the object, they default to the
-commit time as a side effect of this method (known issue — FWT-708).
+deployment's C<timestamp> value (which is generally set during C<new()> and
+therefore often reflects the construction time). If no C<timestamp> is set on
+the object, they instead default to the time that C<commit()> is called. This
+mutation is a side effect of this method (known issue — FWT-708).
 
 B<Returns:>
 

--- a/lib/Genesis/Env/Deployment.pod
+++ b/lib/Genesis/Env/Deployment.pod
@@ -1,86 +1,74 @@
 =pod
 
+=encoding UTF-8
+
 =head1 NAME
 
 Genesis::Env::Deployment - Class representing a deployment audit for a Genesis environment
 
 =head1 SYNOPSIS
 
-  # Create a new deployment audit object
-  my $deployment = Genesis::Env::Deployment->new($env,
-    action         => 'deploy',
-    result         => 'success',
-    reason         => 'User initiated deployment',
-    started        => $start_time,
-    completed      => $end_time,
-    genesis_version => $GENESIS_VERSION,
-    kit            => {
-      id          => $kit->id,
-      name        => $kit->name,
-      version     => $kit->version,
-      is_dev      => $kit->is_dev,
-      features    => $kit->requested_features
-    },
-    user          => {
-      shell       => $ENV{SHELL},
-      repo        => $ENV{GENESIS_REPO} // 'unknown',
-      vault       => $env->vault->url
-    },
-    manifest       => {
-      type        => $manifest->type,
-      sha2        => $manifest_sha2
-    },
-    artifacts      => {
-      manifest     => $env->manifest_file,
-      log          => $env->workpath('output.log')
+    # Create a new deployment audit object
+    my $deployment = Genesis::Env::Deployment->new($env,
+      action          => 'deploy',
+      result          => 'success',
+      reason          => 'User initiated deployment',
+      genesis_version => $GENESIS_VERSION,
+      kit             => {
+        id       => $kit->id,
+        name     => $kit->name,
+        version  => $kit->version,
+        is_dev   => $kit->is_dev,
+        features => $kit->requested_features
+      },
+      user => {
+        shell => $ENV{SHELL},
+        repo  => $ENV{GENESIS_REPO} // 'unknown',
+        vault => $env->vault->url
+      },
+      manifest => {
+        type => $manifest->type,
+        sha2 => $manifest_sha2
+      },
+      artifacts => {
+        manifest => $env->manifest_file,
+        log      => $env->workpath('output.log')
+      }
+    );
+
+    # Commit the deployment audit to vault
+    $deployment->commit;
+
+    # Check if deployment has been committed
+    if ($deployment->committed) {
+      say "Deployment action: " . $deployment->action;
+      say "Deployment result: " . $deployment->result;
+      say "Started at: " . $deployment->started;
+      say "Completed at: " . $deployment->completed;
+
+      # Check success or error
+      say "Success: " . ($deployment->succeeded ? 'Yes' : 'No');
+      if ($deployment->has_error) {
+        say "Error: " . $deployment->error;
+      }
+
+      # Get user information
+      say "User: " . $deployment->user_description;
+      my ($colorized, @roles) = $deployment->user_colorized_roles;
+
+      # Access artifacts
+      my $manifest = $deployment->artifact('manifest');
+      my $all      = $deployment->artifacts;
+      my $files    = $deployment->extract_artifacts_to('/tmp/artifacts');
     }
-  );
-  
-  # Commit the deployment audit
-  $deployment->commit;
-  
-  # Check if deployment has been committed
-  if ($deployment->committed) {
-    # Access deployment information
-    say "Deployment action: " . $deployment->action;
-    say "Deployment result: " . $deployment->result;
-    say "Deployment reason: " . $deployment->reason;
-    say "Started at: " . $deployment->started;
-    say "Completed at: " . $deployment->completed;
-    say "Duration: " . $deployment->duration;
-    
-    # Check if deployment succeeded
-    say "Success: " . ($deployment->succeeded ? 'Yes' : 'No');
-    
-    # Get user information
-    say "User: " . $deployment->user_description;
-    my $colorized_roles = $deployment->user_colorized_roles;
-    my $legend = Genesis::Env::Deployment::user_colorized_legend();
-    
-    # Access artifact types and filenames
-    my @types = $deployment->artifact_types;
-    my @filenames = $deployment->artifact_filenames;
-    
-    # Get contents of a specific artifact
-    my $manifest = $deployment->artifact('manifest');
-    
-    # Get multiple artifacts
-    my $artifacts = $deployment->artifacts('manifest', 'log');
-    
-    # Get detailed artifact information
-    my @details = $deployment->details_for_artifacts('manifest', 'log');
-    
-    # Extract artifacts to a directory
-    my $files = $deployment->extract_artifacts_to('/tmp/artifacts');
-  }
 
 =head1 DESCRIPTION
 
-Genesis::Env::Deployment represents a deployment audit for a Genesis environment. 
-It records metadata about deployments, including the action performed (deploy or 
+Genesis::Env::Deployment represents a deployment audit for a Genesis environment.
+It records metadata about deployments, including the action performed (deploy or
 terminate), the result, timestamps, and associated artifacts.
 
-This class provides methods for creating, committing, and retrieving deployment 
+This class provides methods for creating, committing, and retrieving deployment
 audits, as well as accessing and extracting deployment artifacts.
 
 =head1 CLASS CONSTANTS
@@ -117,16 +105,78 @@ Constant value: '_artifact_map.json'
 
 =head2 is_a_successful_result($result)
 
-Returns true if the given result represents a successful deployment (success or post-failed).
+Returns true if the given result represents a successful deployment. A result
+is considered successful if it is C<'success'> or C<'post-failed'>.
+
+B<Parameters:>
+
+=over
+
+=item $result
+
+The result string to check.
+
+=back
+
+B<Returns:> True (1) if the result is C<'success'> or C<'post-failed'>, false otherwise.
+
+B<Examples:>
+
+    Genesis::Env::Deployment::is_a_successful_result('success');     # Returns: 1
+    Genesis::Env::Deployment::is_a_successful_result('post-failed'); # Returns: 1
+    Genesis::Env::Deployment::is_a_successful_result('failed');      # Returns: ''
 
 =head2 is_a_failed_result($result)
 
-Returns true if the given result represents a failed deployment.
+Returns true if the given result represents a failed deployment. A result is
+considered failed only if it is C<'failed'>. Note that C<'post-failed'> is
+considered successful, not failed.
+
+B<Parameters:>
+
+=over
+
+=item $result
+
+The result string to check.
+
+=back
+
+B<Returns:> True (1) if the result is C<'failed'>, false otherwise.
+
+B<Examples:>
+
+    Genesis::Env::Deployment::is_a_failed_result('failed');      # Returns: 1
+    Genesis::Env::Deployment::is_a_failed_result('success');     # Returns: ''
+    Genesis::Env::Deployment::is_a_failed_result('post-failed'); # Returns: ''
 
 =head2 user_colorized_legend(@roles)
 
-Class method that returns a colorized legend for user roles. If no roles are provided,
-returns a legend for all known roles. The legend uses Genesis Term color codes.
+Class method that returns a colorized legend string for user roles. If no
+roles are provided, returns a legend for all known roles (shell, bosh, vault,
+repo, concourse). If roles are provided, only the ones that are in the known
+set are included. The legend uses Genesis Term color codes.
+
+B<Parameters:>
+
+=over
+
+=item @roles (optional)
+
+Zero or more role names to include in the legend. When omitted, all known
+roles are included.
+
+=back
+
+B<Returns:> A comma-joined string of colorized role labels.
+
+B<Examples:>
+
+    my $legend = Genesis::Env::Deployment::user_colorized_legend();
+    # Returns: "#y{shell},#B{bosh},#m{vault},#r{repo},#c{concourse}"
+
+    my $partial = Genesis::Env::Deployment::user_colorized_legend('shell', 'vault');
+    # Returns: "#y{shell},#m{vault}"
 
 =head1 CLASS METHODS
 
@@ -134,228 +184,883 @@ returns a legend for all known roles. The legend uses Genesis Term color codes.
 
 Creates a new Genesis::Env::Deployment object based on the provided data.
 
-Required fields in %data:
+B<Parameters:>
 
 =over
 
-=item action
+=item $env
 
-The action performed (deploy or terminate).
+A Genesis::Env object representing the environment this deployment belongs to.
 
-=item result 
+=item %data
 
-The result of the action (success, failed, pending, post-failed, assumed).
+A hash of deployment data. The following keys are recognised:
 
-=item started
+=over
 
-When the action started (Time::Piece object or string in EXODUS_TIME_FORMAT).
+=item action (required)
 
-=item completed
+The action performed. Must be one of: C<'deploy'>, C<'terminate'>.
 
-When the action completed (Time::Piece object or string in EXODUS_TIME_FORMAT).
+=item result (required)
 
-=item genesis_version
+The result of the action. Must be one of: C<'success'>, C<'failed'>,
+C<'pending'>, C<'post-failed'>, C<'assumed'>.
 
-The version of Genesis used for the deployment.
+=item genesis_version (required)
 
-=item reason
+The version string of Genesis used for the deployment.
+
+=item reason (required)
 
 The reason for the deployment.
 
-=item kit
+=item user (required)
 
-A hashref containing kit information with these keys:
-  - id: The kit identifier
-  - name: The kit name
-  - version: The kit version
-  - is_dev: Whether the kit is a development kit
-  - features: An array of features enabled for the kit
+A hashref containing user information. The C<shell> key is required; C<repo>
+and C<vault> are optional:
 
-=item user
+  user => {
+    shell => $ENV{SHELL},
+    repo  => $ENV{GENESIS_REPO} // 'unknown',  # optional
+    vault => $env->vault->url,                 # optional
+  }
 
-A hashref containing user information with these keys:
-  - shell: The user's shell
-  - repo (optional): The repository path
-  - vault (optional): The vault URL
+=item kit (required when action is 'deploy')
 
-=item manifest
+A hashref containing kit information. All of the following keys are required
+when C<action> is C<'deploy'>:
 
-A hashref containing manifest information with these keys:
-  - type: The manifest type
-  - sha2: The SHA-256 hash of the manifest
+  kit => {
+    id       => $kit->id,
+    name     => $kit->name,
+    version  => $kit->version,
+    is_dev   => $kit->is_dev,
+    features => $kit->requested_features,
+  }
+
+=item manifest (required when action is 'deploy')
+
+A hashref containing manifest information. Both keys are required when
+C<action> is C<'deploy'>:
+
+  manifest => {
+    type => $manifest->type,
+    sha2 => $manifest_sha2,
+  }
+
+=item started (optional)
+
+When the action started. Accepts a Time::Piece object or a string in
+EXODUS_TIME_FORMAT. Defaults to the commit time when C<commit()> is called if
+not provided at construction time.
+
+=item completed (optional)
+
+When the action completed. Accepts a Time::Piece object or a string in
+EXODUS_TIME_FORMAT. Defaults to the commit time when C<commit()> is called if
+not provided at construction time.
 
 =item artifacts (optional)
 
-Either:
-  - A hashref mapping artifact types to file paths
-  - A base64 gzipped string containing artifact contents
+Either a hashref mapping artifact type names to local file paths, or a
+base64-encoded gzip string containing a tarball of artifact contents.
+
+=item state (legacy)
+
+When a C<state> key is present (from older Genesis versions), it is
+automatically converted: C<'deployed'> maps to C<action='deploy'>, any other
+value maps to C<action='terminate'>. The result is set to C<'success'>, and
+default values are filled in for C<kit>, C<user>, C<manifest>, and
+C<genesis_version> if not already present.
 
 =back
+
+=back
+
+B<Returns:> A blessed Genesis::Env::Deployment object.
+
+B<Errors:>
+
+=over
+
+=item C<"Expected Genesis::Env object, got %s">
+
+Thrown via C<bug()> if C<$env> is not a Genesis::Env instance. The C<%s>
+placeholder is the actual ref type or the string C<'undefined'>.
+
+=item C<"Missing required fields for $timestamp deployment audit: ...">
+
+Thrown via C<bug()> if any required fields are absent from C<%data>. The
+missing field names are listed in the message.
+
+=item C<"Invalid action '%s' for deployment audit - must be one of: %s">
+
+Thrown via C<bug()> if the C<action> value is not C<'deploy'> or
+C<'terminate'>. The first C<%s> is the supplied action; the second is the
+allowed list.
+
+=item C<"Invalid result '%s' for deployment audit - must be one of: %s">
+
+Thrown via C<bug()> if the C<result> value is not one of the known constants.
+The first C<%s> is the supplied result; the second is the allowed list.
+
+=item C<"Invalid artifacts format - must be a hashref or base64 gzipped string">
+
+Thrown via C<bug()> if the C<artifacts> value is neither a hashref nor a
+base64-encoded gzip string.
+
+=back
+
+B<Examples:>
+
+    my $deployment = Genesis::Env::Deployment->new($env, %data);
+    # Returns: Genesis::Env::Deployment object
+
+    # Typical deploy audit:
+    my $deploy = Genesis::Env::Deployment->new($env,
+      action          => 'deploy',
+      result          => 'success',
+      reason          => 'CI pipeline triggered',
+      genesis_version => '3.1.0',
+      kit             => { id => 'bosh/1.0', name => 'bosh',
+                           version => '1.0', is_dev => 0, features => [] },
+      user            => { shell => '/bin/bash' },
+      manifest        => { type => 'bosh', sha2 => 'abc123' },
+    );
+    # Returns: Genesis::Env::Deployment object
 
 =head1 INSTANCE METHODS
 
 =head2 action()
 
-Returns the action performed (deploy or terminate).
+Returns the action performed.
+
+B<Returns:> String — either C<'deploy'> or C<'terminate'>.
 
 =head2 result()
 
-Returns the result of the action (success, failed, pending, post-failed, assumed).
+Returns the result of the action.
+
+B<Returns:> String — one of C<'success'>, C<'failed'>, C<'pending'>,
+C<'post-failed'>, or C<'assumed'>.
 
 =head2 succeeded()
 
-Returns true if the deployment was successful (result is either 'success' or 'post-failed').
+Returns true if the deployment was successful. A deployment is considered
+successful if its result is either C<'success'> or C<'post-failed'>.
 
-=head2 started([$strftime_format])
+B<Returns:> True if the result is C<'success'> or C<'post-failed'>, false otherwise.
 
-Returns the Time::Piece object representing when the action started.
-If $strftime_format is provided, returns the formatted string instead.
+=head2 has_error()
 
-=head2 completed([$strftime_format])
+Returns true if the deployment has an error message stored.
 
-Returns the Time::Piece object representing when the action completed.
-If $strftime_format is provided, returns the formatted string instead.
+B<Returns:> Boolean — true (C<!!1>) if C<$self-E<gt>{data}{error}> is set and
+truthy, false otherwise.
+
+B<Examples:>
+
+    if ($deployment->has_error) {
+      warn "Deployment error: " . $deployment->error;
+    }
+    # Returns: 1 if error is set, '' otherwise
+
+=head2 error()
+
+Returns the error message for this deployment, if any.
+
+B<Returns:> String — the error message, or an empty string C<''> if no error
+is stored.
+
+B<Examples:>
+
+    my $msg = $deployment->error;
+    # Returns: "vault connection refused" (or '')
+
+=head2 started([$strf_format])
+
+Returns the timestamp for when the action started.
+
+B<Parameters:>
+
+=over
+
+=item $strf_format (optional)
+
+A C<strftime>-compatible format string. When provided, the method returns
+the timestamp formatted as a string rather than as a Time::Piece object.
+
+=back
+
+B<Returns:> A Time::Piece object, or a formatted string if C<$strf_format>
+is supplied.
+
+B<Errors:>
+
+=over
+
+=item C<"Cannot format started timestamp '%s' - not a Time::Piece object">
+
+Thrown via C<bail()> if C<$strf_format> is provided but the stored
+timestamp is not a Time::Piece object. The C<%s> placeholder is the raw
+stored value.
+
+=back
+
+B<Examples:>
+
+    my $ts  = $deployment->started;
+    # Returns: Time::Piece object
+
+    my $str = $deployment->started('%Y-%m-%d %H:%M:%S');
+    # Returns: "2024-01-15 14:30:00"
+
+=head2 completed([$strf_format])
+
+Returns the timestamp for when the action completed.
+
+B<Parameters:>
+
+=over
+
+=item $strf_format (optional)
+
+A C<strftime>-compatible format string. When provided, the method returns
+the timestamp formatted as a string rather than as a Time::Piece object.
+
+=back
+
+B<Returns:> A Time::Piece object, or a formatted string if C<$strf_format>
+is supplied.
+
+B<Errors:>
+
+=over
+
+=item C<"Cannot format completed timestamp '%s' - not a Time::Piece object">
+
+Thrown via C<bail()> if C<$strf_format> is provided but the stored
+timestamp is not a Time::Piece object. The C<%s> placeholder is the raw
+stored value.
+
+=back
+
+B<Examples:>
+
+    my $ts  = $deployment->completed;
+    # Returns: Time::Piece object
+
+    my $str = $deployment->completed('%Y-%m-%d %H:%M:%S');
+    # Returns: "2024-01-15 14:35:22"
 
 =head2 duration()
 
-Returns the duration of the action (completed - started) in seconds.
+Returns the duration of the deployment in seconds, computed as
+C<completed - started>.
+
+B<Returns:> Numeric — number of seconds between started and completed.
 
 =head2 reason()
 
-Returns the reason for the deployment. Returns 'unknown' if no reason is set.
+Returns the reason for the deployment.
+
+B<Returns:> String — the reason, or C<'unknown'> if no reason was set.
 
 =head2 has_reason()
 
-Returns true if the deployment has a meaningful reason (not 'unknown', '<unspecified>', 
-'none', 'null', or undefined).
+Returns true if the deployment has a meaningful reason. A reason is considered
+meaningful if it is set, defined, and not one of the placeholder strings:
+C<'unknown'>, C<'E<lt>unspecifiedE<gt>'>, C<'none'>, or C<'null'>.
 
-=head2 lookup(@keys)
+B<Returns:> 1 if a meaningful reason is present, 0 otherwise.
 
-Looks up a value in the deployment data using struct_lookup.
+=head2 lookup
+
+Looks up a value in the deployment's internal data hash using
+C<struct_lookup>. All arguments after C<$self> are passed through to
+C<struct_lookup> and support dot-notation paths
+(e.g., C<'kit.name'>, C<'user.shell'>).
+
+B<Returns:> The value found at the given path, or C<undef> if not found.
+Always returns a scalar regardless of calling context.
 
 =head2 timestamp()
 
-Returns the timestamp for this deployment in EXODUS_TIME_FORMAT_SHORT format.
+Returns the timestamp key for this deployment in EXODUS_TIME_FORMAT_SHORT
+format (e.g., C<'20240115143000'>).
+
+B<Returns:> String — the deployment timestamp key.
 
 =head2 sequence()
 
-Returns the sequence number for this deployment.
+Returns the sequence number for this deployment as stored in the exodus data.
+
+B<Returns:> Integer sequence number, or C<undef> if not yet committed.
 
 =head2 user_description()
 
-Returns a formatted string describing the user who performed the deployment,
-including any additional roles (repo, vault, concourse, bosh).
+Returns a formatted string describing the user who performed the deployment.
+The primary identifier is the C<shell> value from the user hash (with tmux
+session information stripped). Any additional non-shell roles that are set and
+not C<'unknown'> are appended in square brackets.
+
+B<Returns:> String — e.g., C<"/bin/bash [repo: /home/user/cf, vault: https://vault.example.com]">.
 
 =head2 user_colorized_roles()
 
-Returns a colorized string of user roles using Genesis Term color codes.
-In list context, returns both the colorized string and an array of role names.
-If no roles are found, returns '#ki{unknown}'.
+Returns a colorized string of user roles using Genesis Term color codes. Each
+role is rendered as C<#COLOR{value}>, with roles joined by C<|>. Tmux session
+information is stripped from shell values. Roles with no value or a value of
+C<'unknown'> are omitted.
+
+In list context, returns the colorized role string followed by the list of
+role names that were included.
+
+In scalar context, returns just the colorized role string.
+
+If no roles are found, returns C<'#ki{unknown}'> in both list and scalar
+context (no wantarray check on the fallback path).
+
+B<Returns:>
+
+In list context: C<($role_string, @role_names)>
+
+In scalar context: C<$role_string>
+
+B<Examples:>
+
+    my $colored = $deployment->user_colorized_roles;
+    # Returns: "#y{/bin/bash}|#r{/home/user/repos/cf}"
+
+    my ($colored, @roles) = $deployment->user_colorized_roles;
+    # $colored: "#y{/bin/bash}|#r{/home/user/repos/cf}"
+    # @roles:   ('shell', 'repo')
 
 =head2 env()
 
 Returns the Genesis::Env object associated with this deployment.
 
+B<Returns:> A Genesis::Env object.
+
 =head2 committed()
 
-Returns true if the deployment has been committed to exodus.
+Returns true if this deployment has been committed to exodus in the vault.
+
+Note: C<committed()> checks the vault path C<'deployments/' . $self-E<gt>timestamp()>,
+which is a relative path. Due to a known issue (FWT-708), this may not match
+the full exodus path used by C<commit()>.
+
+B<Returns:> True if the vault path exists, false otherwise.
 
 =head2 commit()
 
-Saves the deployment audit to the environment's vault under the exodus path.
-Throws an error if the deployment has already been committed.
+Saves the deployment audit to the environment's vault under the full exodus
+path. The deployment data is flattened and written as key-value pairs. If
+artifacts are present, they are packaged as a base64-encoded gzip tarball and
+stored under the C<artifacts> key via vault's C<key@file> notation.
 
-=head2 artifact_types()
+If C<started> or C<completed> are not set on the object, they default to the
+commit time as a side effect of this method (known issue — FWT-708).
 
-Returns a sorted list of artifact types available in this deployment.
+B<Returns:>
 
-=head2 artifact_filenames()
+In list context: C<($out, $rc, $err)> from the underlying vault query. Note
+that list context bypasses the error check — the caller is responsible for
+inspecting C<$rc>.
 
-Returns a sorted list of artifact filenames available in this deployment.
+In scalar context: Returns C<1> on success.
 
-=head2 artifact($artifact)
-
-Returns the contents of a specific artifact by type or filename.
-Throws an error if the artifact is not found.
-
-=head2 artifacts(@artifacts)
-
-Returns a hashref mapping artifact types or filenames to their contents.
-If no arguments are provided, returns all artifacts.
-Throws an error if any of the requested artifacts are not found.
-
-=head2 details_for_artifacts(@artifacts)
-
-Returns detailed information about the specified artifacts (or all if none specified).
-Each detail entry is a hashref containing:
-  - type: The artifact type
-  - filename: The artifact filename
-  - sha2: The SHA-256 hash of the content (undef if empty)
-  - size: The size of the content in bytes
-  - content: The actual content
-
-Returns an array in list context, arrayref in scalar context.
-
-=head2 extract_artifacts_to($path, @artifacts)
-
-Extracts the specified artifacts to the given path.
-If no artifacts are specified, extracts all artifacts.
-The path can be relative (resolved against GENESIS_CALLER_DIR) or absolute.
-Returns a hashref mapping artifact names to their extracted file paths.
-Throws an error if the path is not a directory or if any artifacts are not found.
-
-=head1 INTERNAL METHODS
-
-These methods are used internally and are not meant to be called directly:
+B<Errors:>
 
 =over
 
-=item _get_artifact_hash(@artifacts)
+=item C<"Cannot commit a deployment that already exists!">
 
-Internal helper to get all artifacts as a hash.
+Thrown via C<bail()> if C<committed()> returns true before the vault write.
 
-=item _build_artifacts_file($artifact_file, %artifacts)
+=item C<"Failed to set deployment audit data in exodus: %s\n%s">
 
-Builds a tarball of deployment artifacts and stores it as a base64-encoded file.
+Thrown via C<bail()> in scalar context if the vault write returns a non-zero
+exit code. The first C<%s> is stdout from the vault command; the second is
+stderr.
 
-=item _collect_secrets_from_paths(@paths)
+=back
 
-Collects secrets from the specified vault paths and returns them as JSON.
-Cannot use vault export as it gets everything under the path including subpaths.
+B<Examples:>
 
-=item _get_artifact_tarball()
+    # Scalar context — throws on failure
+    $deployment->commit;
+    # Returns: 1
 
-Gets the artifact tarball for this deployment (for b64-gzipped format).
+    # List context — caller checks return code
+    my ($out, $rc, $err) = $deployment->commit;
+    die "vault write failed: $err" if $rc;
 
-=item _artifact_map()
+=head2 artifact_types()
 
-Returns the artifact map for this deployment, mapping types to filenames.
+Returns a sorted list of artifact type names available in this deployment
+(e.g., C<'log'>, C<'manifest'>, C<'secrets'>).
 
-=item _is_artifact_type($ref)
+B<Returns:> Sorted list of type name strings.
 
-Checks if the given reference is an artifact type.
+=head2 artifact_filenames()
 
-=item _is_artifact_filename($ref)
+Returns a sorted list of artifact filenames available in this deployment
+(e.g., C<'myenv.yml'>, C<'myenv-output.log'>).
 
-Checks if the given reference is an artifact filename.
+B<Returns:> Sorted list of filename strings.
 
-=item _get_artifact_type($ref)
+=head2 artifact($artifact)
 
-Returns the artifact type for the given reference.
+Returns the contents of a specific artifact, looked up by type name or
+filename.
 
-=item _get_artifact_filename($ref)
+B<Parameters:>
 
-Returns the artifact filename for the given reference.
+=over
 
-=item _is_base64_gzipped($data)
+=item $artifact
 
-Determines if a string is base64-encoded gzipped data by checking for base64
-format and gzip magic number.
+The artifact type name (e.g., C<'manifest'>) or filename
+(e.g., C<'myenv.yml'>) to retrieve.
 
-=item _get_ts_string($timestamp)
+=back
 
-Converts a timestamp to EXODUS_TIME_FORMAT_SHORT string format. Accepts
-Time::Piece objects or properly formatted timestamp strings.
+B<Returns:> String — the raw contents of the artifact.
+
+B<Errors:>
+
+=over
+
+=item C<"Artifact name is required">
+
+Thrown via C<bail()> if C<$artifact> is not provided or is false.
+
+=item C<"artifact '$artifact' not found in deployment">
+
+Thrown via C<bail()> if the named artifact does not exist in this deployment.
+
+=back
+
+B<Examples:>
+
+    my $manifest_content = $deployment->artifact('manifest');
+    # Returns: "---\nname: my-env\n..."
+
+    my $log = $deployment->artifact('myenv-output.log');
+    # Returns: raw log file contents
+
+=head2 artifacts(@artifacts)
+
+Returns a hashref mapping artifact type names or filenames to their contents.
+If no arguments are provided, returns all artifacts.
+
+Returns an empty hashref (C<{}>) if no artifacts are stored on this
+deployment. Throws via C<_get_artifact_hash()> if invalid artifact names are
+requested.
+
+B<Parameters:>
+
+=over
+
+=item @artifacts (optional)
+
+Zero or more artifact type names or filenames to retrieve. When omitted, all
+available artifacts are returned.
+
+=back
+
+B<Returns:> Hashref mapping artifact identifiers to content strings. Returns
+C<{}> if the deployment has no artifacts.
+
+B<Examples:>
+
+    my $all = $deployment->artifacts(@artifacts);
+    # Returns: { manifest => "---\n...", log => "Deploying...\n" }
+
+    # No args — returns all artifacts:
+    my $all = $deployment->artifacts;
+    # Returns: { manifest => "---\n...", log => "Deploying...\n" }
+
+    # Specific artifacts:
+    my $subset = $deployment->artifacts('manifest', 'log');
+    # Returns: { manifest => "---\n...", log => "Deploying...\n" }
+
+=head2 details_for_artifacts(@artifacts)
+
+Returns detailed information about the specified artifacts (or all if none
+specified). Each artifact is described by a hashref with these keys:
+
+=over
+
+=item type
+
+The artifact type name.
+
+=item filename
+
+The artifact filename.
+
+=item sha2
+
+The SHA-256 hex digest of the content, or C<undef> if the content is empty.
+
+=item size
+
+The size of the content in bytes.
+
+=item content
+
+The raw content string.
+
+=back
+
+In list context returns a list of detail hashrefs. In scalar context returns
+an arrayref.
+
+B<Parameters:>
+
+=over
+
+=item @artifacts (optional)
+
+Zero or more artifact type names or filenames. When omitted, all available
+artifact types are used.
+
+=back
+
+B<Returns:>
+
+In list context: list of detail hashrefs.
+
+In scalar context: arrayref of detail hashrefs.
+
+B<Examples:>
+
+    my @details = $deployment->details_for_artifacts('manifest');
+    # Returns: ({ type => 'manifest', filename => 'myenv.yml',
+    #             sha2 => 'abc123...', size => 1024,
+    #             content => "---\n..." })
+
+    my $all = $deployment->details_for_artifacts;
+    # Returns: arrayref of all artifact detail hashrefs
+
+=head2 extract_artifacts_to($path, @artifacts)
+
+Extracts the specified artifacts (or all if none specified) to the given
+directory. If C<$path> is relative, it is resolved against
+C<$ENV{GENESIS_CALLER_DIR}>. Each artifact is written using the artifact's
+filename (not its type name). Returns a hashref mapping artifact identifiers
+to their absolute output paths.
+
+Returns C<{}> if the deployment has no artifacts.
+
+B<Parameters:>
+
+=over
+
+=item $path
+
+The target directory path. May be relative (resolved against
+C<GENESIS_CALLER_DIR>) or absolute.
+
+=item @artifacts (optional)
+
+Zero or more artifact type names or filenames to extract. When omitted, all
+artifacts are extracted.
+
+=back
+
+B<Returns:> Hashref mapping artifact identifiers to absolute file paths of the
+extracted files.
+
+B<Errors:>
+
+=over
+
+=item C<"Path #B{%s} is not a directory">
+
+Thrown via C<bail()> if the resolved C<$path> does not exist or is not a
+directory. The C<%s> placeholder is the original (unresolved) C<$path> value.
+
+=item C<"Invalid artifact filename '#B{%s}'%s - artifact names cannot contain path separators">
+
+Thrown via C<bail()> if an artifact's stored filename contains a C</> character.
+The first C<%s> is the filename; the second is an empty string if the artifact
+identifier equals the filename, or the text C<" for artifact #M{$artifact}"> otherwise.
+
+=back
+
+B<Examples:>
+
+    my $files = $deployment->extract_artifacts_to($path, @artifacts);
+    # Returns: hashref mapping artifact names to extracted file paths
+
+    # Extract all artifacts:
+    my $all = $deployment->extract_artifacts_to('/tmp/artifacts');
+    # Returns: { manifest => '/tmp/artifacts/myenv.yml',
+    #             log      => '/tmp/artifacts/myenv-output.log' }
+
+    # Extract specific artifact:
+    my $subset = $deployment->extract_artifacts_to('/tmp/out', 'manifest');
+    # Returns: { manifest => '/tmp/out/myenv.yml' }
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _get_artifact_hash
+
+    $self->_get_artifact_hash(@artifacts)
+
+Returns a hashref mapping artifact identifiers to their raw content strings.
+If C<@artifacts> is empty, all artifact types are returned. If specific
+artifacts are requested, each is validated against the artifact map; invalid
+names cause a C<bail()>. Handles both C<'local-file-hash'> and
+C<'b64-gzipped'> artifact formats.
+
+B<Returns:> Hashref mapping artifact identifier strings to raw content strings.
+
+B<Errors:>
+
+=over
+
+=item C<"Invalid artifacts requested: %s">
+
+Thrown via C<bail()> when one or more of the requested artifact names are not
+valid types or filenames in the artifact map. The C<%s> placeholder is a
+comma-joined list of the invalid names.
+
+=item C<"artifact '$artifact' file not found">
+
+Thrown via C<bail()> for C<'local-file-hash'> format when the local file for
+an artifact does not exist on disk.
+
+=item C<"Failed to extract artifact '$ref' from archive">
+
+Thrown via C<bail()> for C<'b64-gzipped'> format when the tar object's
+get_content call returns C<undef> for the requested artifact.
+
+=back
+
+B<Examples:>
+
+    my $hash = $self->_get_artifact_hash('manifest');
+    # Returns: { manifest => "---\nname: my-env\n..." }
+
+=head2 _build_artifacts_file
+
+    $self->_build_artifacts_file($artifact_file, %artifacts)
+
+Builds a gzip-compressed tar archive of the deployment artifacts and writes
+it as a base64-encoded string to C<$artifact_file>. The C<secrets> key in
+C<%artifacts>, if present, is handled separately by calling
+C<_collect_secrets_from_paths()> and stored as C<secrets.json> in the archive.
+The artifact map (C<_artifact_map.json>) is also included in the archive.
+
+B<Returns:> 1 on success.
+
+B<Errors:>
+
+=over
+
+=item C<"Failed to compress manifest artifacts">
+
+Thrown via C<bail()> if the tar write call fails during gzip compression.
+
+=back
+
+B<Examples:>
+
+    $self->_build_artifacts_file($artifact_file, %artifacts);
+    # Returns: 1
+
+=head2 _collect_secrets_from_paths
+
+    $self->_collect_secrets_from_paths(@paths)
+
+Collects secrets from the specified vault paths and returns them as a JSON
+string. Each path may be in C<'path:key'> format (to retrieve a single key)
+or plain C<'path'> format (to retrieve all keys at that path via
+C<get_path>). Uses per-path vault reads rather than vault export to avoid
+retrieving subpath contents. Returns C<'{}'> if no secrets are found.
+
+B<Returns:> JSON string of collected secrets.
+
+B<Examples:>
+
+    my $json = $self->_collect_secrets_from_paths(@paths);
+    # Returns: '{"secret/myenv":{"username":"admin",...}}'
+
+=head2 _get_artifact_tarball
+
+    $self->_get_artifact_tarball()
+
+Returns an Archive::Tar object for the deployment's base64-encoded gzip
+artifact tarball. The result is cached in C<$self-E<gt>{__tarball}>. Throws
+via C<bug()> with C<"Cannot get artifact tarball for deployment without compressed artifacts">
+if the deployment does not have C<'b64-gzipped'> format artifacts. Throws
+via C<bail()> with C<"Failed to decompress manifest artifacts"> if
+decompression fails.
+
+B<Returns:> An Archive::Tar object.
+
+B<Examples:>
+
+    my $tar = $self->_get_artifact_tarball();
+    # Returns: Archive::Tar object
+
+=head2 _artifact_map
+
+    $self->_artifact_map()
+
+Returns a hashref mapping artifact type names to artifact filenames for this
+deployment. The result is cached in C<$self-E<gt>{artifacts}{map}>. Returns
+C<undef> if the deployment has no artifacts. For C<'local-file-hash'> format,
+builds the map from the local file hash (only including files that exist on
+disk). For C<'b64-gzipped'> format, reads the embedded C<_artifact_map.json>
+from the tarball, or constructs a map by matching filenames against
+environment-name-based patterns.
+
+=head2 _is_artifact_type
+
+    $self->_is_artifact_type($ref)
+
+Returns 1 if C<$ref> is a key in the artifact map (i.e., a type name),
+0 otherwise.
+
+B<Returns:> 1 or 0.
+
+B<Examples:>
+
+    $self->_is_artifact_type('manifest');
+    # Returns: 1
+
+=head2 _is_artifact_filename
+
+    $self->_is_artifact_filename($ref)
+
+Returns 1 if C<$ref> appears as a value in the artifact map (i.e., a
+filename), 0 otherwise.
+
+B<Returns:> 1 or 0.
+
+B<Examples:>
+
+    $self->_is_artifact_filename('myenv.yml');
+    # Returns: 1
+
+=head2 _get_artifact_type
+
+    $self->_get_artifact_type($ref)
+
+Returns the artifact type name for the given reference. If C<$ref> is already
+a type key in the artifact map, it is returned as-is. Otherwise, returns the
+type whose mapped filename equals C<$ref>.
+
+B<Returns:> String — the artifact type name.
+
+B<Examples:>
+
+    $self->_get_artifact_type('manifest');
+    # Returns: "manifest"
+
+    $self->_get_artifact_type('myenv.yml');
+    # Returns: "manifest"
+
+=head2 _get_artifact_filename
+
+    $self->_get_artifact_filename($ref)
+
+Returns the artifact filename for the given reference. If C<$ref> is a type
+key in the artifact map, returns its mapped filename. Otherwise, returns
+C<$ref> if it exists as a value (filename) in the map.
+
+B<Returns:> String — the artifact filename.
+
+B<Examples:>
+
+    $self->_get_artifact_filename('manifest');
+    # Returns: "myenv.yml"
+
+    $self->_get_artifact_filename('myenv.yml');
+    # Returns: "myenv.yml"
+
+=head2 _is_base64_gzipped
+
+    Genesis::Env::Deployment::_is_base64_gzipped($base64_data)
+
+Returns true if C<$base64_data> appears to be a base64-encoded gzip string.
+Checks that the string is at least 12 characters, that the first 12 characters
+are valid base64, and that the decoded bytes begin with the gzip magic number
+C<\x1F\x8B>.
+
+B<Parameters:>
+
+=over
+
+=item $base64_data
+
+The string to test.
+
+=back
+
+B<Returns:> True if the string looks like base64-encoded gzip data, false otherwise.
+
+B<Examples:>
+
+    Genesis::Env::Deployment::_is_base64_gzipped($base64_data);
+    # Returns: 1 if base64-gzipped, '' otherwise
+
+=head2 _get_ts_string
+
+    Genesis::Env::Deployment::_get_ts_string($timestamp)
+
+Converts a timestamp to EXODUS_TIME_FORMAT_SHORT string format
+(e.g., C<'20240115143000'>). Accepts a Time::Piece object (formatted via
+C<strftime>) or a string matching a recognized ISO-8601-like UTC timestamp
+pattern (digits, dashes, colons, T, Z, and C<+0000> suffix stripped). Throws
+via C<bail()> with C<"Invalid timestamp format: $ts"> if the input does not
+match either form. If called as an instance method on a
+Genesis::Env::Deployment object, the object argument is consumed and the next
+argument is used as the timestamp.
+
+B<Returns:> String — timestamp in EXODUS_TIME_FORMAT_SHORT format.
+
+B<Examples:>
+
+    Genesis::Env::Deployment::_get_ts_string(Time::Piece->new);
+    # Returns: "20240115143000"
+
+    Genesis::Env::Deployment::_get_ts_string('2024-01-15T14:30:00Z');
+    # Returns: "20240115143000"
+
+=head1 KNOWN ISSUES
+
+The following defects are tracked and pending resolution (FWT-708):
+
+=over
+
+=item *
+
+C<committed()> checks a relative vault path (C<'deployments/' . $self-E<gt>timestamp()>)
+rather than the full exodus path used by C<commit()>. This means C<committed()>
+may return incorrect results (FWT-708 C-1 through M-5).
+
+=item *
+
+C<commit()> mutates the object's internal data as a side effect: it sets
+C<started> and C<completed> on C<$self-E<gt>{data}> if they are not already
+present. Callers that inspect C<started()> or C<completed()> before and after
+C<commit()> may observe different values.
+
+=item *
+
+In list context, C<commit()> returns the raw C<($out, $rc, $err)> tuple from
+the vault query without performing error checking. The caller must inspect
+C<$rc> to detect failures.
 
 =back
 

--- a/lib/Genesis/Env/DeploymentManager.pod
+++ b/lib/Genesis/Env/DeploymentManager.pod
@@ -7,61 +7,65 @@ Genesis::Env::DeploymentManager - Manager for deployment audits in Genesis envir
 =head1 SYNOPSIS
 
   # Create a new deployment manager for an environment
-  my $deployment_manager = Genesis::Env::DeploymentManager->new($env);
-  
-  # Get all deployment audits
-  my @all_deployments = $deployment_manager->all();
-  
-  # Find specific deployments with filters
-  my @successful_deploys = $deployment_manager->find(
-    action => 'deploy',
-    result => 'success'
-  );
-  
-  # Get deployments within a date range
-  my @recent = $deployment_manager->find(
-    range => '>20240101',
-    limit => 10
-  );
-  
+  my $mgr = Genesis::Env::DeploymentManager->new($env);
+
+  # Get all deployment audits (newest first)
+  my @all = $mgr->all();
+
+  # Find successful deployments with filters
+  my @deploys = $mgr->find(action => 'deploy', result => 'success');
+
+  # Find deployments within a timestamp range
+  my @recent = $mgr->find(range => '>20240101', limit => 10);
+
+  # Find deployments at integer offsets
+  my @last_three = $mgr->find(range => '0...2');
+
   # Get the latest deployment
-  my $latest = $deployment_manager->latest();
-  
+  my $latest = $mgr->latest();
+
   # Get the latest successful deployment
-  my $latest_successful = $deployment_manager->latest_successful();
-  
+  my $latest_successful = $mgr->latest_successful();
+
   # Check current deployment state
-  my $state = $deployment_manager->current_state(); # 'deployed', 'terminated', or 'undeployed'
-  
-  # Build a new deployment audit
-  my $deployment = $deployment_manager->build(
+  my $state = $mgr->current_state(); # 'deployed', 'terminated', or 'undeployed'
+
+  # Build a new deployment audit object
+  my $deployment = $mgr->build(
     'deploy', 'success',
-    reason => 'User initiated deployment',
-    started => Time::Piece->new,
-    completed => Time::Piece->new + 300
+    reason    => 'User initiated deployment',
+    started   => Time::Piece->new,
+    completed => Time::Piece->new + 300,
   );
-  
-  # Commit the deployment audit
+
+  # Commit the deployment audit to vault
   $deployment->commit();
-  
+
+  # Synthesize a deployment from pre-audit exodus data
+  my $synth = $mgr->synthesize_from_exodus();
+
   # Reset cached deployments
-  $deployment_manager->reset();
+  $mgr->reset();
 
 =head1 DESCRIPTION
 
-Genesis::Env::DeploymentManager provides comprehensive management of deployment 
+Genesis::Env::DeploymentManager provides comprehensive management of deployment
 audits for Genesis environments. It handles the lifecycle of deployment records,
 including creation, retrieval, filtering, and state management.
 
-This class maintains a cache of deployment audits retrieved from Vault and 
-provides various methods to query and filter these deployments based on 
+This class maintains a cache of deployment audits retrieved from Vault and
+provides various methods to query and filter these deployments based on
 different criteria such as action type, result status, timestamps, and more.
 
 =head1 CONSTRUCTOR
 
 =head2 new($env)
 
+  my $mgr = Genesis::Env::DeploymentManager->new($env);
+
 Creates a new deployment manager for the given Genesis environment.
+
+B<Parameters:>
 
 =over
 
@@ -71,207 +75,747 @@ A Genesis::Env object representing the environment to manage deployments for.
 
 =back
 
-Returns a new Genesis::Env::DeploymentManager instance.
+B<Returns:> A new Genesis::Env::DeploymentManager instance.
+
+B<Examples:>
+
+  my $mgr = Genesis::Env::DeploymentManager->new($env);
+  my @deploys = $mgr->all();
+  # Returns: list of Genesis::Env::Deployment objects
 
 =head1 METHODS
 
 =head2 all()
 
-Retrieves all deployment audits for the environment, sorted by timestamp 
-(newest first). Results are cached for performance.
+  my @deployments = $mgr->all();
 
-Returns an array of Genesis::Env::Deployment objects.
+Retrieves all deployment audits for the environment, sorted by timestamp
+(newest first). Results are cached after the first retrieval; call reset()
+to force a fresh fetch.
+
+B<Returns:> A list of Genesis::Env::Deployment objects. Returns an empty list
+if no deployment audits exist.
+
+B<Examples:>
+
+  my @all = $mgr->all();
+  printf "Found %d deployments\n", scalar @all;
+  # prints: Found 12 deployments
 
 =head2 reset()
 
-Clears the cached deployment audits, forcing a fresh retrieval from Vault 
-on the next access.
+  $mgr->reset();
+
+Clears the internal deployment cache, forcing a fresh retrieval from Vault
+on the next call to all(), find(), latest(), or any other method that
+accesses deployment data.
+
+Does not return a meaningful value.
+
+B<Examples:>
+
+  $mgr->reset();
+  my @fresh = $mgr->all(); # Re-fetched from Vault
 
 =head2 find(%options)
 
-Finds deployment audits matching the specified criteria. This is the most 
-flexible method for querying deployments.
+  my @results = $mgr->find(%options);
 
-Valid options:
+Finds deployment audits matching the specified criteria. By default, only
+successful deployments are returned. Specifying C<result> automatically
+sets C<all =E<gt> 1>, disabling the successful-only filter so that the
+exact result you requested is matched.
+
+Timestamp ranges are evaluated against all deployments before C<action>
+and C<result> filters are applied. Integer index ranges are applied after
+action and result filtering.
+
+B<Parameters:>
 
 =over
 
 =item action
 
-Filter by action type ('deploy' or 'terminate').
+Filter by action type. Valid values: C<'deploy'> or C<'terminate'>.
 
 =item result
 
-Filter by result status ('success', 'failed', 'pending', 'post-failed').
+Filter by result status. Valid values: C<'success'>, C<'failed'>,
+C<'pending'>, C<'post-failed'>. Providing this option automatically
+enables C<all =E<gt> 1>.
 
 =item all
 
-Include pending and failed deployments. By default, only successful 
-deployments are returned unless a specific result is requested.
+If true, include pending and failed deployments. By default only successful
+deployments are returned (unless C<result> is specified).
 
 =item timestamps_only
 
-Return only timestamps instead of full deployment objects.
+If true, return only timestamp strings instead of full Genesis::Env::Deployment
+objects.
 
 =item limit
 
-Limit the number of deployments returned (latest N deployments).
+Integer. Limit the number of deployments returned (most-recent N from the
+already-filtered set, since results are newest-first).
 
 =item range
 
-Filter by timestamp range. Supports multiple formats:
-  - [<|>|<=|>=]<timestamp> - Compare with timestamp
-  - <timestamp>[<|<=]x[<|<=]<timestamp> - Between timestamps  
-  - N[...M] - Integer offsets (negative for reverse)
+Filter by a timestamp range or integer index range. Supported formats:
 
-Where <timestamp> format is: YYYY[-?MM[-?DD[T| ][HH[:?MM[:?SS[Z| ][+-]HHMM]]]]]
+  [<|>|<=|>=]<timestamp>        Compare with a single timestamp boundary
+  <ts1>[<|<=]x[<|<=]<ts2>      Between two timestamps (exclusive or inclusive)
+  =<timestamp>                  Exact match (e.g. =2024 for all of year 2024)
+  N[...M]                       Integer index range (0-based, newest-first)
+
+Where C<E<lt>timestampE<gt>> follows the format:
+
+  YYYY[-MM[-DD[T|space][HH[:MM[:SS[Z|space][+-HHMM]]]]]]
+
+Timestamp ranges (all formats except integer index) modify the deployment
+list in place. Integer index ranges are stored and applied after action and
+result filters, selecting by position in the filtered list.
 
 =back
 
-Returns an array of Genesis::Env::Deployment objects or timestamps.
+B<Returns:> A list of Genesis::Env::Deployment objects, or a list of
+timestamp strings if C<timestamps_only> is set. Returns an empty list if
+no matching deployments are found.
+
+B<Errors:>
+
+Calls C<bail()> with C<"Invalid options: %s"> (where C<%s> is a
+comma-separated list of unrecognised keys) if any option key is not one of
+C<action>, C<result>, C<all>, C<timestamps_only>, C<limit>, or C<range>.
+
+B<Examples:>
+
+  # All successful deployments
+  my @successes = $mgr->find();
+
+  # All deployments of any result
+  my @all = $mgr->find(all => 1);
+
+  # Only failed deployments
+  my @failed = $mgr->find(result => 'failed');
+
+  # Deployments after Jan 1 2024, limit 10
+  my @recent = $mgr->find(range => '>20240101', limit => 10);
+
+  # Exact year range
+  my @in_2023 = $mgr->find(range => '=2023');
+
+  # The 2nd and 3rd most-recent successful deployments (0-based index)
+  my @slice = $mgr->find(range => '1...2');
+
+  # Timestamps only
+  my @ts = $mgr->find(timestamps_only => 1, limit => 5);
+  # Returns: ('2024-03-15 14:22:01 +0000', '2024-02-10 09:11:00 +0000', ...)
 
 =head2 at($timestamp)
 
-Retrieves the deployment audit at a specific timestamp.
+  my $deployment = $mgr->at($timestamp);
+
+Retrieves the deployment audit whose timestamp matches C<$timestamp> exactly.
+
+B<Parameters:>
 
 =over
 
 =item $timestamp
 
-The timestamp string of the deployment to retrieve.
+The timestamp string of the deployment to retrieve, in the same format
+stored by Genesis (e.g. C<"2024-03-15 14:22:01 +0000">).
 
 =back
 
-Returns a Genesis::Env::Deployment object or undef if not found.
+B<Returns:> A Genesis::Env::Deployment object, or C<undef> if no deployment
+with that timestamp exists or if no deployments exist at all.
+
+B<Examples:>
+
+  my $d = $mgr->at('2024-03-15 14:22:01 +0000');
+  print $d->result if $d;
+  # prints: success
 
 =head2 latest(%options)
 
-Gets the most recent deployment audit, optionally filtered by criteria.
+  my $deployment = $mgr->latest(%options);
 
-Valid options:
+Gets the most recent deployment audit that matches the given criteria.
+Deployments are examined newest-first; the first one that passes all
+filters is returned.
+
+By default, any deployment whose result equals the class constant
+C<action_failed> (C<'failed'>) is skipped. Pass C<include_failed =E<gt> 1>
+to include failed deployments.
+
+Note: if you pass C<result =E<gt> 'failed'> without C<include_failed =E<gt> 1>,
+the method will always return C<undef>, because failed deployments are
+excluded before the result filter is checked.
+
+B<Parameters:>
 
 =over
 
 =item action
 
-Filter by action type ('deploy' or 'terminate').
+Filter by action type. Valid values: C<'deploy'> or C<'terminate'>.
 
 =item result
 
-Filter by result status.
+Filter by result status (e.g. C<'success'>, C<'failed'>).
 
 =item include_failed
 
-Include failed deployments in the search.
+If true, include deployments whose result is C<'failed'> in the search.
+Without this, failed deployments are always skipped regardless of the
+C<result> option.
 
 =back
 
-Returns a Genesis::Env::Deployment object or undef if none found.
+B<Returns:> A Genesis::Env::Deployment object, or C<undef> if no matching
+deployment is found.
+
+B<Examples:>
+
+  # Most recent deployment of any result (including non-failed)
+  my $latest = $mgr->latest();
+
+  # Most recent terminate action, including failed ones
+  my $term = $mgr->latest(action => 'terminate', include_failed => 1);
+  # Returns: a Genesis::Env::Deployment object, or undef
 
 =head2 latest_successful(%options)
 
-Gets the latest successful deployment. This is a convenience method that 
-calls find() with a limit of 1, which by default only returns successful 
-deployments.
+  my $deployment = $mgr->latest_successful(%options);
+
+Gets the latest successful deployment. This is a convenience wrapper around
+find() that hard-codes C<limit =E<gt> 1>. Because find() defaults to
+returning only successful deployments, no additional C<result> filter is
+needed.
+
+Note: C<limit =E<gt> 1> is always applied, overriding any C<limit> option
+passed by the caller.
 
 Accepts the same options as find().
 
-Returns a Genesis::Env::Deployment object or undef.
+B<Returns:> A Genesis::Env::Deployment object, or C<undef> if no successful
+deployment exists.
+
+B<Examples:>
+
+  my $last_good = $mgr->latest_successful();
+  print $last_good->timestamp if $last_good;
+
+  # Latest successful deploy action only
+  my $last_deploy = $mgr->latest_successful(action => 'deploy');
+  # Returns: a Genesis::Env::Deployment object, or undef
 
 =head2 current_state()
 
-Determines the current deployment state of the environment by examining 
-the latest successful deployment.
+  my $state = $mgr->current_state();
 
-Returns one of:
-  - 'deployed' - Environment is currently deployed
-  - 'terminated' - Environment has been terminated  
-  - 'undeployed' - Environment has never been deployed
+Determines the current deployment state of the environment by examining
+the most recent successful deployment.
+
+If no deployment audits exist at all, the method falls back to checking
+exodus data via C<$self-E<gt>env-E<gt>exodus_lookup('.', {})>. If that
+lookup returns any data, the environment is considered C<'deployed'>.
+
+The return value C<'undeployed'> is used in two distinct cases:
+
+=over
+
+=item *
+
+No deployment audits exist and no exodus data was found.
+
+=item *
+
+Deployment audits exist but none of them succeeded.
+
+=back
+
+B<Returns:> One of the following strings:
+
+=over
+
+=item C<'deployed'>
+
+The most recent successful deployment had action C<'deploy'>, or no
+deployment audits exist but exodus data is present.
+
+=item C<'terminated'>
+
+The most recent successful deployment had action C<'terminate'>.
+
+=item C<'undeployed'>
+
+No successful deployment exists and no exodus data was found, or all
+existing deployments failed.
+
+=back
+
+B<Examples:>
+
+  my $state = $mgr->current_state();
+  if ($state eq 'deployed') {
+    print "Environment is deployed\n";
+  } elsif ($state eq 'terminated') {
+    print "Environment was terminated\n";
+  } else {
+    print "Environment has never been deployed\n";
+  }
 
 =head2 build($action, $result, %options)
 
-Builds a new deployment audit object with the specified action and result,
-merging in additional options with base deployment content.
+  my $deployment = $mgr->build($action, $result, %options);
+
+Builds a new Genesis::Env::Deployment object with the specified action and
+result. Generates base deployment content (action, result, genesis version,
+kit information, user details, artifacts, and manifest data), then merges
+any additional C<%options> on top.
+
+B<Parameters:>
 
 =over
 
 =item $action
 
-The deployment action ('deploy' or 'terminate').
+The deployment action. Valid values: C<'deploy'> or C<'terminate'>.
 
-=item $result  
+=item $result
 
-The deployment result ('success', 'failed', 'pending', 'post-failed').
+The deployment result. Valid values: C<'success'>, C<'failed'>,
+C<'pending'>, C<'post-failed'>.
 
 =item %options
 
-Additional deployment data to merge with the base content.
+Additional deployment data to deep-merge with the base content. Keys in
+C<%options> take precedence over base defaults.
 
 =back
 
-Returns a new Genesis::Env::Deployment object ready for committing.
+B<Returns:> A new Genesis::Env::Deployment object ready to be persisted
+via C<$deployment-E<gt>commit()>.
+
+B<Examples:>
+
+  my $d = $mgr->build(
+    'deploy', 'success',
+    reason    => 'Triggered by pipeline',
+    started   => Time::Piece->new,
+    completed => Time::Piece->new + 420,
+  );
+  $d->commit();
+  # Returns: a Genesis::Env::Deployment object
 
 =head2 next_sequence_number($action)
 
-Calculates the next sequence number for deployments. This ensures proper 
-ordering and tracking of deployment history.
+  my $seq = $mgr->next_sequence_number($action);
+
+Calculates the next sequence number for deployment audits. If no
+deployments exist, returns C<1>. If the latest deployment has no sequence
+field, returns C<scalar($self-E<gt>all) + 1>. Otherwise returns
+C<$latest-E<gt>sequence + 1>.
+
+B<Parameters:>
 
 =over
 
 =item $action
 
-The deployment action (currently unused but reserved for future use).
+The deployment action. Currently unused but reserved for future use.
 
 =back
 
-Returns the next sequence number as an integer.
+B<Returns:> The next sequence number as an integer.
 
-=head2 env()
+B<Examples:>
 
-Returns the Genesis::Env object this deployment manager is associated with.
+  my $seq = $mgr->next_sequence_number('deploy');
+  print "Next sequence: $seq\n";
+  # prints: Next sequence: 7
 
-=head1 PRIVATE METHODS
+=head2 synthesize_from_exodus($exodus_data)
 
-=head2 _base_deployment_content($action, $result)
+  my $deployment = $mgr->synthesize_from_exodus($exodus_data);
 
-Generates the base deployment audit content including kit information, 
-user details, artifacts, and manifest data.
+Synthesizes a Genesis::Env::Deployment object from pre-audit exodus data.
+This method exists for backward compatibility: when an environment was
+deployed before Genesis supported deployment audits, there are no audit
+records in vault, but exodus data may still describe the last deployment.
 
-=head2 _base_artifacts($action)
+If C<$exodus_data> is not provided, it is read from
+C<$self-E<gt>env-E<gt>exodus_lookup('.', {})>.
 
-Returns a hashref of artifacts based on the deployment action. For deploy 
-actions, includes logs, manifests, vars, state, store, and secrets. For 
-terminate actions, includes logs and state only.
-
-=head1 PRIVATE FUNCTIONS
-
-=head2 _get_last_day_of_month($year, $month)
-
-Utility function to calculate the last day of a given month, accounting 
-for leap years.
-
-=head2 _parse_into_timestamp_cmp($timestamp, $comparison_operator)
-
-Parses a timestamp string and comparison operator into a normalized 
-timestamp string suitable for range comparisons.
-
-=head1 CACHING
-
-The deployment manager implements intelligent caching to improve performance:
+The synthesized deployment always has C<action =E<gt> 'deploy'> and
+C<result =E<gt> 'success'>. Exodus fields are mapped to deployment fields
+as follows:
 
 =over
 
 =item *
 
-Deployment audits are cached after the first retrieval from Vault
+C<reason> from C<$exodus_data-E<gt>{reason}>, defaulting to
+C<'unknown - synthesized from previous exodus data'>
 
 =item *
 
-Cache is automatically invalidated when deployments are committed  
+C<started> from C<$exodus_data-E<gt>{dated}>
 
 =item *
 
-Manual cache clearing is available via the reset() method
+C<completed> from C<$exodus_data-E<gt>{completed}> or C<{dated}>
+
+=item *
+
+C<genesis_version> from C<$exodus_data-E<gt>{version}>
+
+=item *
+
+C<bosh_target> set to C<{ name =E<gt> $exodus_data-E<gt>{bosh} }>
+
+=item *
+
+C<manifest.sha2> populated from C<$exodus_data-E<gt>{manifest_sha1}>
+(see KNOWN ISSUES)
+
+=back
+
+B<Parameters:>
+
+=over
+
+=item $exodus_data
+
+Optional. A hashref of exodus data. If omitted, the method calls
+C<$self-E<gt>env-E<gt>exodus_lookup('.', {})> to obtain the data.
+
+=back
+
+B<Returns:> A Genesis::Env::Deployment object synthesized from the exodus
+data, or C<undef> if no exodus data exists (the hashref is empty).
+
+B<Examples:>
+
+  my $synth = $mgr->synthesize_from_exodus();
+  if ($synth) {
+    printf "Previously deployed with kit %s\n", $synth->lookup('kit.id');
+    # prints: Previously deployed with kit cf/1.14.2
+  }
+
+=head2 env()
+
+  my $env = $mgr->env();
+
+Returns the Genesis::Env object this deployment manager is associated with.
+
+B<Returns:> The Genesis::Env object passed to new().
+
+B<Examples:>
+
+  my $env_name = $mgr->env->name;
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _all()
+
+  my @deployments = $mgr->_all();
+  my $deployments  = $mgr->_all(); # arrayref in scalar context
+
+Retrieves all deployment audits from vault, creates Genesis::Env::Deployment
+objects sorted newest-first, and stores the result in
+C<$self-E<gt>{__all_deployments}> for subsequent calls.
+
+In list context, returns C<@deployments>. In scalar context, returns the
+cached arrayref directly for efficiency.
+
+Results are cached in C<$self-E<gt>{__all_deployments}>. Call reset() to
+invalidate the cache.
+
+B<Returns:> In list context, returns a (possibly empty) list of
+Genesis::Env::Deployment objects. In scalar context, returns an arrayref
+(possibly empty).
+
+B<Examples:>
+
+  # Internal scalar-context usage for efficiency
+  my $ref = $mgr->_all(); # arrayref
+
+  # Internal list-context usage to get a copy safe to modify
+  my @copy = $mgr->_all();
+  # Returns: list of Genesis::Env::Deployment objects
+
+=head2 _base_deployment_content($action, $result)
+
+  my $content = $mgr->_base_deployment_content($action, $result);
+
+Generates the base deployment audit content hashref, including action,
+result, genesis version, kit information, user details, artifacts, and
+(for deploy actions) manifest and parameters.
+
+When C<$result> is C<'assumed'>, the kit, user, artifact, manifest, and
+parameter fields are omitted.
+
+For the user shell field, the method calls C<who -mH> via run(). If that
+call returns no TTY data, C<$user_data-E<gt>[0]> will be undef, causing a
+fatal null-dereference in the string concatenation on the following line
+(see KNOWN ISSUES).
+
+B<Parameters:>
+
+=over
+
+=item $action
+
+The deployment action: C<'deploy'> or C<'terminate'>.
+
+=item $result
+
+The deployment result: C<'success'>, C<'failed'>, C<'pending'>,
+C<'post-failed'>, or C<'assumed'>.
+
+=back
+
+B<Returns:> A hashref of base deployment data suitable for passing to
+Genesis::Env::Deployment->new().
+
+B<Examples:>
+
+  my $base = $mgr->_base_deployment_content('deploy', 'success');
+  my $d = Genesis::Env::Deployment->new($env, %$base);
+  # Returns: hashref with keys action, result, genesis_version, kit, user, artifacts, manifest, parameters
+
+=head2 _base_artifacts($action)
+
+  my $artifacts = $mgr->_base_artifacts($action);
+
+Returns a hashref of artifact paths based on the deployment action.
+
+For C<'deploy'> actions, the hashref contains:
+
+  log      => deploy log path
+  manifest => resolved manifest path
+  unpruned => unpruned manifest path
+  vars     => vars file path
+  state    => state file path
+  store    => store file path
+  secrets  => [ list of vault secret paths ]
+
+For C<'terminate'> actions, the hashref contains only C<log> and C<state>.
+
+B<Parameters:>
+
+=over
+
+=item $action
+
+The deployment action: C<'deploy'> or C<'terminate'>.
+
+=back
+
+B<Returns:> A hashref of artifact metadata.
+
+B<Errors:>
+
+Calls C<bail()> with C<"Invalid action: %s"> (where C<%s> is the value of
+C<$action>) if the action is not C<'deploy'> or C<'terminate'>.
+
+B<Examples:>
+
+  my $artifacts = $mgr->_base_artifacts('deploy');
+  print $artifacts->{log};
+  # prints: /path/to/deploy.log
+
+=head2 _filter_by_range($deployments, $range)
+
+  my $indices = $mgr->_filter_by_range(\@deployments, $range);
+
+Filters the deployment array by a range specification. Calls
+_confirm_deployments_sorted() before filtering.
+
+For integer index ranges (e.g. C<"0...2">), the method does not modify
+C<$deployments>. Instead it returns an arrayref of integer indices. The
+caller applies these indices after other filters have been run.
+
+For all timestamp-based range formats, the method modifies C<$deployments>
+in place (by shifting from the front and splicing from the tail) and
+returns C<undef>.
+
+Supported range formats:
+
+  N[...M]                  Integer index range (deferred)
+  [<|>|<=|>=]<timestamp>   Single boundary
+  <ts>[<|<=]x[<|<=]<ts>   Between two timestamps
+  [=]<timestamp>           Exact match (e.g. =2024 for the whole year)
+
+B<Parameters:>
+
+=over
+
+=item $deployments
+
+An arrayref of Genesis::Env::Deployment objects. For timestamp ranges,
+this array is modified in place.
+
+=item $range
+
+A range string in one of the supported formats described above.
+
+=back
+
+B<Returns:> An arrayref of integer indices (for integer ranges), or
+C<undef> (for timestamp ranges, which modify C<$deployments> in place).
+
+B<Errors:>
+
+Calls C<bail()> with C<"Invalid range format: %s"> (where C<%s> is the
+value of C<$range>) if the range string does not match any recognised
+format.
+
+B<Examples:>
+
+  my $indices = $mgr->_filter_by_range(\@deploys, '1...3');
+  # $indices is [1, 2, 3]; @deploys is unchanged
+
+  $mgr->_filter_by_range(\@deploys, '>20240101');
+  # Returns: undef; @deploys now contains only deployments after 2024-01-01
+
+=head2 _confirm_deployments_sorted($deployments)
+
+  $mgr->_confirm_deployments_sorted(\@deployments);
+
+Verifies that the deployments array is sorted newest-first by timestamp.
+If C<$deployments> is not provided, defaults to C<$self-E<gt>_all()>.
+
+Returns immediately without checking if the array has one or zero elements.
+
+B<Parameters:>
+
+=over
+
+=item $deployments
+
+Optional arrayref of Genesis::Env::Deployment objects. Defaults to all
+deployments via _all().
+
+=back
+
+B<Returns:> C<1> if the array is correctly sorted.
+
+B<Errors:>
+
+Calls C<bug()> with a message of the form:
+
+  "Deployments are not sorted by timestamp in latest-first order!\n\nDeployment %s at index %s is after Deployment %s at index %s"
+
+if any deployment is found to be newer than the one before it.
+
+B<Examples:>
+
+  $mgr->_confirm_deployments_sorted(\@deploys);
+  # Returns: 1 if sorted; calls bug() and dies if not sorted
+
+=head2 _get_last_day_of_month($year, $month)
+
+  my $day = _get_last_day_of_month($year, $month);
+
+Package-level function (not a method; no C<$self> argument). Calculates
+the last day of a given month by constructing the first day of the
+following month and subtracting one day. Correctly handles December and
+leap years.
+
+B<Parameters:>
+
+=over
+
+=item $year
+
+Integer. The four-digit year (e.g. C<2024>).
+
+=item $month
+
+Integer. The month number, 1-12.
+
+=back
+
+B<Returns:> An integer representing the last day of the specified month
+(e.g. C<28>, C<29>, C<30>, or C<31>).
+
+B<Examples:>
+
+  my $last = _get_last_day_of_month(2024, 2); # Returns: 29 (leap year)
+  my $last = _get_last_day_of_month(2023, 2); # Returns: 28
+
+=head2 _parse_into_timestamp_gt_cmp($timestamp, $cmp_op)
+
+  my $cmp_ts = _parse_into_timestamp_gt_cmp($timestamp, $cmp_op);
+
+Package-level function (not a method). Parses a partial timestamp string
+and a comparison operator, expands the timestamp to its full boundary
+(filling in omitted fields with their maximum or minimum values depending
+on direction), adjusts by one second to implement strict vs. inclusive
+comparison, and returns a normalized timestamp string suitable for Perl
+string comparison against stored deployment timestamps.
+
+For C<'>'> and C<'<='>, one second is subtracted from the boundary
+timestamp (to convert between strict and inclusive bounds). For C<'>='> and
+C<'<'>, the boundary is used as-is.
+
+B<Parameters:>
+
+=over
+
+=item $timestamp
+
+A timestamp string in the format:
+
+  YYYY[-MM[-DD[T|space][HH[:MM[:SS[Z|space][+-HHMM]]]]]]
+
+Omitted fields are filled in: for C<'>'>/C<'>='> boundaries, missing
+fields default to their maximum values (month=12, day=last day of month,
+hour=23, minute=59, second=59, tz=+0000). For C<'<'>/C<'<='> boundaries,
+missing fields default to their minimum values (month=1, day=1, hour=0,
+minute=0, second=0, tz=+0000).
+
+=item $cmp_op
+
+One of C<'E<gt>'>, C<'E<gt>='>, C<'E<lt>'>, or C<'E<lt>='>.
+
+=back
+
+B<Returns:> A normalized timestamp string in EXODUS_TIME_FORMAT_SHORT
+format, suitable for string comparison against stored deployment timestamps.
+
+B<Examples:>
+
+  # Boundary for "after all of 2024"
+  my $ts = _parse_into_timestamp_gt_cmp('2024', '>');
+  # Returns: '2024-12-31 23:59:58 +0000' (end-of-year minus one second)
+
+=head1 CACHING
+
+The deployment manager implements caching to improve performance:
+
+=over
+
+=item *
+
+Deployment audits are cached after the first retrieval from Vault.
+
+=item *
+
+Cache is invalidated by calling reset(), which is called automatically by
+Genesis::Env::Deployment::commit().
+
+=item *
+
+Manual cache clearing is available via the reset() method.
 
 =back
 
@@ -283,19 +827,58 @@ The class follows Genesis error handling conventions:
 
 =item *
 
-Uses bail() for user-facing errors with helpful messages
+Uses C<bail()> for user-facing errors with helpful messages.
 
 =item *
 
-Uses bug() for internal consistency errors
+Uses C<bug()> for internal consistency errors that indicate a programming
+defect (e.g. an unsorted deployment list).
 
 =item *
 
-Validates all input parameters and options
+Validates all input options in find() and raises an error for unrecognised
+keys.
 
 =item *
 
-Gracefully handles missing or malformed deployment data
+Gracefully handles missing or empty deployment data by returning empty
+lists or C<undef>.
+
+=back
+
+=head1 KNOWN ISSUES
+
+The following defects are tracked under ticket FWT-709:
+
+=over
+
+=item *
+
+C<E<lt>=> operator produces an incorrect boundary in
+_parse_into_timestamp_gt_cmp(): the C<$time -= 1> adjustment is applied
+when C<$gt xor $eq>, meaning C<'E<lt>='> subtracts a second from the upper
+boundary rather than using it inclusively.
+
+=item *
+
+splice off-by-one in _filter_by_range(): the condition
+C<$idx E<lt> @$deployments - 1> means the final element is never spliced,
+leaving one extra deployment in the array when filtering by an upper
+timestamp bound.
+
+=item *
+
+Fatal null-dereference in _base_deployment_content() when there is no
+controlling TTY: C<parse_fixed_width_table> returns no rows when C<who -mH>
+produces no output, so C<$user_data-E<gt>[0]> is C<undef>, and the
+subsequent string concatenation dies.
+
+=item *
+
+C<bosh_target> is structured differently in synthesized vs. live
+deployments: synthesize_from_exodus() sets it as
+C<{ name =E<gt> $exodus_data-E<gt>{bosh} }> at the top level, whereas
+_base_deployment_content() places it inside the C<kit> key.
 
 =back
 

--- a/lib/Genesis/Env/DeploymentManager.pod
+++ b/lib/Genesis/Env/DeploymentManager.pod
@@ -141,8 +141,8 @@ Filter by action type. Valid values: C<'deploy'> or C<'terminate'>.
 =item result
 
 Filter by result status. Valid values: C<'success'>, C<'failed'>,
-C<'pending'>, C<'post-failed'>. Providing this option automatically
-enables C<all =E<gt> 1>.
+C<'pending'>, C<'post-failed'>, C<'assumed'>. Providing this option
+automatically enables C<all =E<gt> 1>.
 
 =item all
 
@@ -210,7 +210,7 @@ B<Examples:>
 
   # Timestamps only
   my @ts = $mgr->find(timestamps_only => 1, limit => 5);
-  # Returns: ('2024-03-15 14:22:01 +0000', '2024-02-10 09:11:00 +0000', ...)
+  # Returns: ('20240315142201', '20240210091100', ...)
 
 =head2 at($timestamp)
 
@@ -224,8 +224,8 @@ B<Parameters:>
 
 =item $timestamp
 
-The timestamp string of the deployment to retrieve, in the same format
-stored by Genesis (e.g. C<"2024-03-15 14:22:01 +0000">).
+The timestamp string of the deployment to retrieve, in
+EXODUS_TIME_FORMAT_SHORT format (e.g. C<"20240315142201">).
 
 =back
 
@@ -234,7 +234,7 @@ with that timestamp exists or if no deployments exist at all.
 
 B<Examples:>
 
-  my $d = $mgr->at('2024-03-15 14:22:01 +0000');
+  my $d = $mgr->at('20240315142201');
   print $d->result if $d;
   # prints: success
 
@@ -252,7 +252,8 @@ to include failed deployments.
 
 Note: if you pass C<result =E<gt> 'failed'> without C<include_failed =E<gt> 1>,
 the method will always return C<undef>, because failed deployments are
-excluded before the result filter is checked.
+excluded whenever C<include_failed> is false, even if you explicitly filter
+for a failed result.
 
 B<Parameters:>
 


### PR DESCRIPTION
## Summary

- Validate and complete companion `.pod` documentation for `Genesis::Env::Deployment` and `Genesis::Env::DeploymentManager` (FWT-653)
- Add 8 missing methods, fix accuracy issues in 10+ existing method docs, add examples for 22 methods, add KNOWN ISSUES sections
- Both modules pass mechanical validation with 0 failures (304/305 and 170/170 checks respectively)

## Changes

**Deployment.pod** (367 → 1140 lines):
- Add missing `has_error()` and `error()` methods
- Fix `new()` accuracy (optional fields, legacy state migration, error conditions)
- Fix `commit()` wantarray return and mutation side effect
- Fix `artifacts()` silent empty return vs throw claim
- Convert private methods from `=item` to `=head2`
- Add KNOWN ISSUES referencing FWT-708

**DeploymentManager.pod** (307 → 890 lines):
- Add 6 missing methods (`synthesize_from_exodus`, `_all`, `_filter_by_range`, `_confirm_deployments_sorted`, `_get_last_day_of_month`, `_parse_into_timestamp_gt_cmp`)
- Fix `_parse_into_timestamp_cmp` name to match actual code
- Fix `find()`, `latest()`, `latest_successful()`, `current_state()` accuracy
- Fix CACHING section invalidation claim
- Add KNOWN ISSUES referencing FWT-709

## Related Tickets

- [FWT-653](https://fivetwenty.atlassian.net/browse/FWT-653) — POD: Genesis::Env::Deployment Classes
- [FWT-708](https://fivetwenty.atlassian.net/browse/FWT-708) — Code defects in Genesis::Env::Deployment
- [FWT-709](https://fivetwenty.atlassian.net/browse/FWT-709) — Code defects in Genesis::Env::DeploymentManager

## Test plan

- [x] `podchecker` passes on both `.pod` files
- [x] `perldoc` renders cleanly for both files
- [x] `skill.py validate` passes with 0 failures for both modules
- [x] Code path verification confirms POD matches actual code behavior
- [ ] Review KNOWN ISSUES sections for accuracy