### PR TITLE
Fix code defects in Store::Vault

### DIFF
--- a/lib/Genesis/Env/Secrets/Store/Vault.pm
+++ b/lib/Genesis/Env/Secrets/Store/Vault.pm
@@ -253,14 +253,17 @@ sub generate {
 }
 
 sub regenerate {
+	my ($self, $secret) = @_;
 	bail "Regenerate not implemented for Vault store";
 }
 
 sub remove {
+	my ($self, $secret) = @_;
 	bail "Remove not implemented for Vault store";
 }
 
 sub remove_all {
+	my ($self, @secrets) = @_;
 	bail "Remove_all not implemented for Vault store";
 }
 

--- a/lib/Genesis/Env/Secrets/Store/Vault.pm
+++ b/lib/Genesis/Env/Secrets/Store/Vault.pm
@@ -29,7 +29,7 @@ sub new {
 	bug("No '$_' specified in call to Genesis::Env::Secrets::Store::Vault->new")
 		for grep {!$opts{$_}} @required_options;
 	bug("Unknown '$_' option specified in call to Genesis::Env::Secrets::Store::Vault->new")
-		for grep {my $k = $_; ! grep {$_ eq $k} @valid_options} CORE::keys(%opts);
+		for grep {my $k = $_; ! grep {$_ eq $k} @valid_options} keys(%opts);
 
 	$opts{mount_override}   //= $env->lookup('genesis.secrets_mount');
 	$opts{slug_override}    //= $env->lookup(['genesis.secrets_path','params.vault_prefix','params.vault']);

--- a/lib/Genesis/Env/Secrets/Store/Vault.pm
+++ b/lib/Genesis/Env/Secrets/Store/Vault.pm
@@ -237,14 +237,14 @@ sub empty {
 
 sub check {
 	my ($self, $secret) = @_;
-	my $ok = $self->get($secret) unless $secret->has_value;
-	return $ok;
+	$self->read($secret) unless $secret->has_value;
+	return $secret->check_value;
 }
 
 sub validate {
 	my ($self, $secret) = @_;
-	my $ok = $self->get($secret) unless $secret->has_value;
-	return $secret->validate();
+	$self->read($secret) unless $secret->has_value;
+	return $secret->validate_value;
 }
 
 sub generate {

--- a/lib/Genesis/Env/Secrets/Store/Vault.pm
+++ b/lib/Genesis/Env/Secrets/Store/Vault.pm
@@ -105,9 +105,21 @@ sub root_ca_path {
 
 sub store_data {
 	my $self = shift;
-	# FIXME: Handle errors better...
-	$self->{__data} //= read_json_from($self->service->query({stderr => '&1', redact_output => 1}, 'export', grep {$_} ($self->base, $self->root_ca_path)));
-	return $self->{__data}//{};
+	unless (exists $self->{__data}) {
+		my $data = read_json_from(
+			$self->service->query(
+				{stderr => '&1', redact_output => 1},
+				'export',
+				grep {$_} ($self->base, $self->root_ca_path)
+			)
+		);
+		if (defined $data) {
+			$self->{__data} = $data;
+		} else {
+			warning("Vault export returned no data for %s", $self->base);
+		}
+	}
+	return $self->{__data} // {};
 }
 
 sub store_paths {

--- a/lib/Genesis/Env/Secrets/Store/Vault.pm
+++ b/lib/Genesis/Env/Secrets/Store/Vault.pm
@@ -141,10 +141,10 @@ sub keys {
 	my $self = shift;
 	return $self->service->keys(@_) unless exists($self->{__data});
 	my @paths = $self->paths(@_);
-	my $base = $self->base;
+	my $base = $self->base =~ s/\/$//r;
 	my @keys = ();
 	for my $path (@paths) {
-		if ($path =~ /^\Q$base\E\//) {
+		if ($path =~ /^\Q$base\E(\/|$)/) {
 			push (@keys, CORE::keys %{$self->{__data}{$path}})
 		} else {
 			push (@keys, $self->service->keys($path));

--- a/lib/Genesis/Env/Secrets/Store/Vault.pod
+++ b/lib/Genesis/Env/Secrets/Store/Vault.pod
@@ -316,6 +316,11 @@ called.
 The returned hash is keyed by absolute Vault path; values are hashes of
 key-value pairs at that path.
 
+If the Vault export command succeeds but returns no parseable data, a
+warning is emitted and the cache is not populated. Subsequent calls will
+retry the export. Hard errors (non-zero exit code with stderr output)
+cause C<read_json_from> to bail.
+
 B<Returns:>
 
 A hash reference mapping Vault paths to their key-value hashes. Returns an
@@ -611,12 +616,13 @@ B<Examples:>
 
 =head2 check
 
-    my $ok = $store->check($secret);
+    my $status = $store->check($secret);
+    my ($status, $msg) = $store->check($secret);
 
 Checks whether a secret is present in the store. If the secret does not
 already have a value loaded (C<< $secret->has_value >> is false), fetches
-it via C<get>, which is AUTOLOAD-delegated to
-C<< $self-E<gt>{service}-E<gt>get() >>.
+it via C<read>, which populates the secret's value from Vault. Returns the
+result of C<< $secret->check_value >>.
 
 B<Parameters:>
 
@@ -628,22 +634,25 @@ B<Parameters:>
 
 B<Returns:>
 
-The result of the C<get> call, or C<undef> if the secret already had a
-value loaded.
+In scalar context, the status string from C<< $secret->check_value >>:
+C<'ok'> if the secret is present, or C<'missing'> if it is not. In list
+context, returns C<($status, $msg)> where C<$msg> describes which keys
+are missing (if any).
 
 B<Examples:>
 
     my $ok = $store->check($secret);
-    print defined($ok) ? 'found' : 'skipped (already loaded)';
-    # Returns: 'found' or 'skipped (already loaded)'
+    print $ok eq 'ok' ? 'present' : 'missing';
+    # Returns: 'present' or 'missing'
 
 =head2 validate
 
-    my $result = $store->validate($secret);
+    my ($result, @validations) = $store->validate($secret);
 
 Validates a secret's stored value. If the secret does not already have a
-value loaded (C<< $secret->has_value >> is false), fetches it via the
-delegated C<get> method on the service before validating.
+value loaded (C<< $secret->has_value >> is false), fetches it via C<read>,
+which populates the secret's value from Vault. Returns the result of
+C<< $secret->validate_value >>.
 
 B<Parameters:>
 
@@ -655,12 +664,14 @@ B<Parameters:>
 
 B<Returns:>
 
-The result of C<< $secret->validate() >>.
+The result of C<< $secret->validate_value >>: a status string (C<'ok'>,
+C<'warn'>, or C<'error'>) followed by validation detail messages.
 
 B<Examples:>
 
-    my $result = $store->validate($secret);
-    # Returns: the validation result from the secret object
+    my ($result, @msgs) = $store->validate($secret);
+    print "validation: $result\n";
+    # Returns: 'ok', 'warn', or 'error'
 
 =head2 generate
 
@@ -696,9 +707,17 @@ B<Examples:>
 
 =head2 regenerate
 
-    $store->regenerate;
+    $store->regenerate($secret);
 
 Not implemented for the Vault store backend. Always dies immediately.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$secret> - Accepted but ignored.
+
+=back
 
 B<Returns:>
 
@@ -714,15 +733,23 @@ B<Errors:>
 
 B<Examples:>
 
-    eval { $store->regenerate };
+    eval { $store->regenerate($secret) };
     print $@ if $@;
     # Returns: 'Regenerate not implemented for Vault store at ...'
 
 =head2 remove
 
-    $store->remove;
+    $store->remove($secret);
 
 Not implemented for the Vault store backend. Always dies immediately.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$secret> - Accepted but ignored.
+
+=back
 
 B<Returns:>
 
@@ -738,15 +765,23 @@ B<Errors:>
 
 B<Examples:>
 
-    eval { $store->remove };
+    eval { $store->remove($secret) };
     print $@ if $@;
     # Returns: 'Remove not implemented for Vault store at ...'
 
 =head2 remove_all
 
-    $store->remove_all;
+    $store->remove_all(@secrets);
 
 Not implemented for the Vault store backend. Always dies immediately.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<@secrets> - Accepted but ignored.
+
+=back
 
 B<Returns:>
 
@@ -762,7 +797,7 @@ B<Errors:>
 
 B<Examples:>
 
-    eval { $store->remove_all };
+    eval { $store->remove_all(@secrets) };
     print $@ if $@;
     # Returns: 'Remove_all not implemented for Vault store at ...'
 

--- a/t/test-manifest.txt
+++ b/t/test-manifest.txt
@@ -40,6 +40,7 @@ unit-tests/genesis_env-creation.t  # Genesis::Env object creation (new, create e
 unit-tests/genesis_env-metadata.t  # Genesis::Env metadata accessors (scale, iaas, features, has_feature)
 unit-tests/genesis_env-bosh.t  # Genesis::Env BOSH-related methods (_parse_bosh_env, bosh_env, bosh_alias)
 unit-tests/genesis_env_secrets_parser_fromkit-core.t  # FromKit parser defect regression tests
+unit-tests/genesis_env_secrets_store_vault-core.t  # Store::Vault code defect regression tests
 #unit-tests/genesis-cli.t
 
 [integration-tests]

--- a/t/unit-tests/genesis_env_secrets_store_vault-core.t
+++ b/t/unit-tests/genesis_env_secrets_store_vault-core.t
@@ -138,7 +138,7 @@ subtest 'Defect 1b: validate() uses read(), not get()' => sub {
 
 subtest 'Defect 2: keys() cache regex matches paths correctly' => sub {
 	# When cache is populated, keys() should match paths under base()
-	# base() returns '/secret/my/org/my-env/bosh/' (with trailing slash)
+	# base() returns '/secret/my/org/my/env/bosh/' (with trailing slash)
 	# Bug: the old regex /^\Q$base\E\// demands a double-slash '//' that
 	# never appears in paths. The fix strips trailing slash from base and
 	# uses (\/|$) alternation.
@@ -185,6 +185,33 @@ subtest 'Defect 3: stubs accept $self correctly' => sub {
 
 	throws_ok { $store->remove_all } qr/Remove_all not implemented/,
 		"remove_all() dies with expected message when called as method";
+};
+
+subtest 'Defect 4: store_data() handles undef export safely' => sub {
+	my $read_json_calls = 0;
+
+	my $store = make_store();
+
+	# Monkey-patch read_json_from in the Vault package namespace to simulate
+	# vault export decoding to undef (the function is imported, so we must
+	# override it in the consuming package's symbol table)
+	no warnings 'redefine';
+	local *Genesis::Env::Secrets::Store::Vault::read_json_from = sub {
+		$read_json_calls++;
+		return undef;
+	};
+	use warnings 'redefine';
+
+	# (1) undef JSON → returns {} without caching
+	my $data = $store->store_data();
+	is_deeply($data, {}, "store_data() returns {} when export decodes to undef");
+
+	# (2) cache must remain unset so paths/keys delegate to service
+	ok(!exists $store->{__data}, "cache not populated after undef export");
+
+	# (3) subsequent call retries (read_json_from called again)
+	$store->store_data();
+	is($read_json_calls, 2, "store_data() retries export after undef result");
 };
 
 subtest 'Defect 5: new() validates options without CORE::keys' => sub {

--- a/t/unit-tests/genesis_env_secrets_store_vault-core.t
+++ b/t/unit-tests/genesis_env_secrets_store_vault-core.t
@@ -139,27 +139,32 @@ subtest 'Defect 1b: validate() uses read(), not get()' => sub {
 subtest 'Defect 2: keys() cache regex matches paths correctly' => sub {
 	# When cache is populated, keys() should match paths under base()
 	# base() returns '/secret/my/org/my-env/bosh/' (with trailing slash)
-	# The regex should not require a double-slash
+	# Bug: the old regex /^\Q$base\E\// demands a double-slash '//' that
+	# never appears in paths. The fix strips trailing slash from base and
+	# uses (\/|$) alternation.
 
 	my $store = make_store();
 
-	# Pre-populate cache with sample data
+	# Verify base() has trailing slash (this is what causes the bug)
+	like($store->base, qr/\/$/, "base() ends with trailing slash");
+
+	# Pre-populate cache — keys() with no args calls paths() which returns
+	# all CORE::keys of __data, then keys() checks each against the base regex
 	$store->{__data} = {
-		'/secret/my/org/my-env/bosh/certs/server' => {
+		$store->base . 'certs/server' => {
 			certificate => 'cert-data',
 			key         => 'key-data',
 		},
-		'/secret/my/org/my-env/bosh/certs/ca' => {
+		$store->base . 'certs/ca' => {
 			certificate => 'ca-cert-data',
 		},
 	};
 
-	# Verify base() has trailing slash
-	like($store->base, qr/\/$/, "base() ends with trailing slash");
-
-	# Ask for keys at a specific path — should come from cache
-	my @keys = $store->keys('/secret/my/org/my-env/bosh/certs/server');
+	# Call keys() with no arguments — paths() returns all cache keys,
+	# then keys() must match them against base to look up their values
+	my @keys = $store->keys();
 	ok(scalar(@keys) > 0, "keys() returns keys from cache (not empty)");
+	is(scalar(@keys), 3, "keys() returns all 3 keys across 2 paths");
 
 	# Verify we got the right keys
 	my %key_set = map { $_ => 1 } @keys;

--- a/t/unit-tests/genesis_env_secrets_store_vault-core.t
+++ b/t/unit-tests/genesis_env_secrets_store_vault-core.t
@@ -99,11 +99,11 @@ subtest 'Defect 1b: validate() uses read(), not get()' => sub {
 		path                   => 'certs/server',
 		default_key            => 'certificate',
 		full_path              => 'certs/server:certificate',
-		validate_value         => sub { return ('ok', '') },
+		validate_value         => 'ok',
 		# The buggy code calls $secret->validate() instead of
 		# $secret->validate_value — provide it so the test doesn't crash,
 		# but return a sentinel value to detect the wrong call path
-		validate               => sub { return ('WRONG_METHOD_CALLED', '') },
+		validate               => 'WRONG_METHOD_CALLED',
 		set_value              => sub { },
 		promote_value_to_stored => sub { },
 		can                    => sub { 0 },
@@ -225,9 +225,9 @@ subtest 'validate() skips read when secret already has value' => sub {
 
 	my $secret = Mock->new(
 		has_value      => 1,
-		validate_value => sub { return ('ok', '') },
+		validate_value => 'ok',
 		# Provide validate to prevent crash with buggy code
-		validate       => sub { return ('WRONG_METHOD_CALLED', '') },
+		validate       => 'WRONG_METHOD_CALLED',
 	);
 
 	my $store = make_store();

--- a/t/unit-tests/genesis_env_secrets_store_vault-core.t
+++ b/t/unit-tests/genesis_env_secrets_store_vault-core.t
@@ -1,0 +1,250 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use lib 't';
+use lib 'lib';
+use helper;
+
+# Test Genesis::Env::Secrets::Store::Vault
+# Regression tests for code defects found during FWT-729 POD review
+
+use_ok 'Genesis::Env::Secrets::Store::Vault';
+
+# Minimal mock environment — provides name, type, lookup
+{
+	package MockEnv;
+	sub new {
+		bless {
+			name         => 'my-org-my-env',
+			type         => 'bosh',
+			lookup_value => undef,
+			@_[1..$#_],
+		}, $_[0];
+	}
+	sub name   { $_[0]{name} }
+	sub type   { $_[0]{type} }
+	sub lookup { $_[0]{lookup_value} }
+}
+
+# Helper: build a store with mock env and service
+sub make_store {
+	my (%overrides) = @_;
+	my $env     = delete $overrides{env}     || MockEnv->new();
+	my $service = delete $overrides{service} || Mock->new(
+		get   => sub { 'mock-value' },
+		has   => sub { 1 },
+		paths => sub { () },
+		keys  => sub { () },
+		query => sub { ('{}', 0, '') },
+		set   => sub { 1 },
+	);
+	return Genesis::Env::Secrets::Store::Vault->new(
+		$env,
+		service => $service,
+		%overrides,
+	);
+}
+
+subtest 'Defect 1: check() uses read(), not get()' => sub {
+	# check() should call $self->read($secret) to populate the secret,
+	# then return $secret->check_value — NOT $self->get($secret)
+	my $read_called = 0;
+
+	my $secret = Mock->new(
+		has_value              => 0,
+		value                  => undef,
+		path                   => 'certs/server',
+		default_key            => 'certificate',
+		full_path              => 'certs/server:certificate',
+		check_value            => 'ok',
+		set_value              => sub { },
+		promote_value_to_stored => sub { },
+		can                    => sub { 0 },
+	);
+
+	my $service = Mock->new(
+		get   => sub { 'mock-value' },
+		has   => sub { 1 },
+		paths => sub { () },
+		keys  => sub { () },
+		query => sub { ('{}', 0, '') },
+		set   => sub { 1 },
+	);
+
+	my $store = make_store(service => $service);
+
+	# Monkey-patch read to track calls
+	no warnings 'redefine';
+	my $orig_read = \&Genesis::Env::Secrets::Store::Vault::read;
+	local *Genesis::Env::Secrets::Store::Vault::read = sub {
+		$read_called = 1;
+		return $orig_read->(@_);
+	};
+	use warnings 'redefine';
+
+	my @result = $store->check($secret);
+	ok($read_called, "check() calls read() to populate the secret");
+	is($result[0], 'ok', "check() returns result of secret->check_value");
+};
+
+subtest 'Defect 1b: validate() uses read(), not get()' => sub {
+	# validate() should call $self->read($secret) to populate the secret,
+	# then return $secret->validate_value — NOT $secret->validate()
+	my $read_called = 0;
+
+	my $secret = Mock->new(
+		has_value              => 0,
+		value                  => 'some-cert-value',
+		path                   => 'certs/server',
+		default_key            => 'certificate',
+		full_path              => 'certs/server:certificate',
+		validate_value         => sub { return ('ok', '') },
+		# The buggy code calls $secret->validate() instead of
+		# $secret->validate_value — provide it so the test doesn't crash,
+		# but return a sentinel value to detect the wrong call path
+		validate               => sub { return ('WRONG_METHOD_CALLED', '') },
+		set_value              => sub { },
+		promote_value_to_stored => sub { },
+		can                    => sub { 0 },
+	);
+
+	my $service = Mock->new(
+		get   => sub { 'mock-value' },
+		has   => sub { 1 },
+		paths => sub { () },
+		keys  => sub { () },
+		query => sub { ('{}', 0, '') },
+		set   => sub { 1 },
+	);
+
+	my $store = make_store(service => $service);
+
+	# Monkey-patch read to track calls
+	no warnings 'redefine';
+	my $orig_read = \&Genesis::Env::Secrets::Store::Vault::read;
+	local *Genesis::Env::Secrets::Store::Vault::read = sub {
+		$read_called = 1;
+		return $orig_read->(@_);
+	};
+	use warnings 'redefine';
+
+	my @result = $store->validate($secret);
+	ok($read_called, "validate() calls read() to populate the secret");
+	isnt($result[0], 'WRONG_METHOD_CALLED',
+		"validate() calls validate_value, not validate()");
+	is($result[0], 'ok', "validate() returns result of secret->validate_value");
+};
+
+subtest 'Defect 2: keys() cache regex matches paths correctly' => sub {
+	# When cache is populated, keys() should match paths under base()
+	# base() returns '/secret/my/org/my-env/bosh/' (with trailing slash)
+	# The regex should not require a double-slash
+
+	my $store = make_store();
+
+	# Pre-populate cache with sample data
+	$store->{__data} = {
+		'/secret/my/org/my-env/bosh/certs/server' => {
+			certificate => 'cert-data',
+			key         => 'key-data',
+		},
+		'/secret/my/org/my-env/bosh/certs/ca' => {
+			certificate => 'ca-cert-data',
+		},
+	};
+
+	# Verify base() has trailing slash
+	like($store->base, qr/\/$/, "base() ends with trailing slash");
+
+	# Ask for keys at a specific path — should come from cache
+	my @keys = $store->keys('/secret/my/org/my-env/bosh/certs/server');
+	ok(scalar(@keys) > 0, "keys() returns keys from cache (not empty)");
+
+	# Verify we got the right keys
+	my %key_set = map { $_ => 1 } @keys;
+	ok($key_set{certificate}, "keys() includes 'certificate'");
+	ok($key_set{key}, "keys() includes 'key'");
+};
+
+subtest 'Defect 3: stubs accept $self correctly' => sub {
+	# regenerate, remove, remove_all should accept $self
+	# and die with the expected error message
+	my $store = make_store();
+
+	throws_ok { $store->regenerate } qr/Regenerate not implemented/,
+		"regenerate() dies with expected message when called as method";
+
+	throws_ok { $store->remove } qr/Remove not implemented/,
+		"remove() dies with expected message when called as method";
+
+	throws_ok { $store->remove_all } qr/Remove_all not implemented/,
+		"remove_all() dies with expected message when called as method";
+};
+
+subtest 'Defect 5: new() validates options without CORE::keys' => sub {
+	# new() should detect unknown options — this exercises the keys() call
+	my $env = MockEnv->new();
+	throws_ok {
+		Genesis::Env::Secrets::Store::Vault->new(
+			$env,
+			service      => Mock->new(),
+			bogus_option => 'bad',
+		);
+	} qr/Unknown.*bogus_option/,
+		"new() detects unknown options";
+};
+
+subtest 'check() skips read when secret already has value' => sub {
+	my $read_called = 0;
+
+	my $secret = Mock->new(
+		has_value   => 1,
+		check_value => 'ok',
+	);
+
+	my $store = make_store();
+
+	no warnings 'redefine';
+	my $orig_read = \&Genesis::Env::Secrets::Store::Vault::read;
+	local *Genesis::Env::Secrets::Store::Vault::read = sub {
+		$read_called = 1;
+		return $orig_read->(@_);
+	};
+	use warnings 'redefine';
+
+	# The fixed code should return check_value even when skipping read.
+	# The buggy code returns undef ($ok is never set when has_value is true).
+	my @result = $store->check($secret);
+	ok(!$read_called, "check() skips read() when secret has_value");
+	is($result[0], 'ok', "check() returns check_value result even when skipping read");
+};
+
+subtest 'validate() skips read when secret already has value' => sub {
+	my $read_called = 0;
+
+	my $secret = Mock->new(
+		has_value      => 1,
+		validate_value => sub { return ('ok', '') },
+		# Provide validate to prevent crash with buggy code
+		validate       => sub { return ('WRONG_METHOD_CALLED', '') },
+	);
+
+	my $store = make_store();
+
+	no warnings 'redefine';
+	my $orig_read = \&Genesis::Env::Secrets::Store::Vault::read;
+	local *Genesis::Env::Secrets::Store::Vault::read = sub {
+		$read_called = 1;
+		return $orig_read->(@_);
+	};
+	use warnings 'redefine';
+
+	my @result = $store->validate($secret);
+	ok(!$read_called, "validate() skips read() when secret has_value");
+	isnt($result[0], 'WRONG_METHOD_CALLED',
+		"validate() calls validate_value, not validate()");
+	is($result[0], 'ok', "validate() returns validate_value result");
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

Fixes 6 code defects in `Genesis::Env::Secrets::Store::Vault` found during FWT-729 POD review:

- **check()/validate()**: Called `$self->get($secret)` via AUTOLOAD (wrong) instead of `$self->read($secret)`; validate() also called nonexistent `$secret->validate()` instead of `$secret->validate_value`
- **keys() cache regex**: `base()` trailing slash caused double-slash in regex, silently defeating the cache for all key lookups
- **Stub signatures**: `regenerate`, `remove`, `remove_all` missing `my $self = shift`
- **store_data()**: Replaced `//=` with explicit `exists` check; warns on empty vault export instead of silently returning `{}`
- **new()**: Removed unnecessary `CORE::keys` in class method context

Resolves [FWT-730](https://fivetwenty.atlassian.net/browse/FWT-730)

## Test plan

- [x] New unit test file with 8 subtests covering all defects
- [x] TDD red-green verified for defects 1, 1b, 2
- [x] `perl -Ilib -c` syntax check passes
- [x] `prove -l` unit tests pass
- [x] POD renders cleanly via `perldoc -T`
- [ ] Full `make unit-tests` suite passes (requires credhub CLI)