### PR TITLE
Fix 6 code defects in Deployment.pm

### DIFF
--- a/lib/Genesis/Env/Deployment.pm
+++ b/lib/Genesis/Env/Deployment.pm
@@ -221,7 +221,10 @@ sub completed {
 # duration - Return the duration of the deployment {{{
 sub duration {
 	my ($self) = @_;
-	return $self->{data}{completed} - $self->{data}{started};
+	my ($completed, $started) = @{$self->{data}}{qw(completed started)};
+	return undef unless ref($completed) eq 'Time::Piece'
+	                  && ref($started)   eq 'Time::Piece';
+	return $completed - $started;
 }
 
 # }}}
@@ -364,9 +367,16 @@ sub env {
 sub committed {
 	my ($self) = @_;
 	return 0 unless $self->timestamp();
-	return $self->env->vault->has(
-		'deployments/' . $self->timestamp()
-	);
+	my $result = eval {
+		$self->env->vault->has(
+			'deployments/' . $self->timestamp()
+		);
+	};
+	if ($@) {
+		debug("Could not check deployment commit status in vault: %s", $@);
+		return 0;
+	}
+	return $result;
 }
 
 # }}}
@@ -400,10 +410,16 @@ sub commit {
 			# notation to store the gzipped data in the vault
 			mkfile_or_fail($artifact_file, $artifacts->{data});
 		} elsif ($artifacts->{format} eq 'local-file-hash') {
-			$self->_build_artifacts_file(
-				$artifact_file,
-				%{$artifacts->{data}}
-			);
+			eval {
+				$self->_build_artifacts_file(
+					$artifact_file,
+					%{$artifacts->{data}}
+				);
+			};
+			if ($@) {
+				unlink $artifact_file if -f $artifact_file;
+				die $@;  # Re-throw after cleanup
+			}
 		}
 	}
 
@@ -436,6 +452,7 @@ sub commit {
 		@cmds
 	);
 	$self->env->deployments->reset; # FIXME: This should be more surgical.
+	unlink $artifact_file if $artifact_file && -f $artifact_file;
 	return ($out, $rc, $err) if wantarray;
 	bail(
 		"Failed to set deployment audit data in exodus: %s\n%s",
@@ -527,7 +544,7 @@ sub extract_artifacts_to {
 	# If path is not absolute, make it relative to the directory the user called genesis from
 	my $target_path = absolute_path($path, $ENV{GENESIS_CALLER_DIR});
 	bail(
-		"Path #B{%s} is not a directory", $path
+		"Path #B{%s} is not a directory", $target_path
 	) unless -d $target_path;
 
 	# No artifacts to extract
@@ -659,6 +676,10 @@ sub _build_artifacts_file {
 		$self->_collect_secrets_from_paths(@$secrets)
 	)	if (defined $secrets && ref($secrets) eq 'ARRAY');
 
+	# Bail if no artifacts were added to the archive
+	bail("No artifacts to archive — all artifact files were missing or empty")
+		unless $tar->list_files();
+
 	# Compress and base64 encode the artifacts into a tarball
 	my $compressed_data;
 	open(my $data_fh, '>', \$compressed_data);
@@ -682,8 +703,14 @@ sub _collect_secrets_from_paths {
 
 	my $struct = {};
 	for my $path (@paths) {
+		bail("Invalid vault path in secrets list: empty or undefined")
+			unless defined($path) && length($path);
+		bail("Malformed vault path '%s' in secrets list", $path)
+			if $path =~ m{^:};
 		# Check if we want a path:key or a path
 		my ($p,$key) = $path =~ m{^(.+?)(?::([^/]+))?$};
+		bail("Malformed vault path '%s' in secrets list", $path)
+			unless defined($p) && length($p);
 
 		#my $struct_key = $p =~ s{^/}{.}; -- in case we want to have a deep structure
 		if ($key) {

--- a/lib/Genesis/Env/Deployment.pm
+++ b/lib/Genesis/Env/Deployment.pm
@@ -677,8 +677,8 @@ sub _build_artifacts_file {
 	)	if (defined $secrets && ref($secrets) eq 'ARRAY');
 
 	# Bail if no artifacts were added to the archive
-	bail("No artifacts to archive — all artifact files were missing or empty")
-		unless $tar->list_files();
+	bail("No artifacts to archive -- all artifact files were missing or empty")
+		unless scalar $tar->list_files();
 
 	# Compress and base64 encode the artifacts into a tarball
 	my $compressed_data;
@@ -707,6 +707,8 @@ sub _collect_secrets_from_paths {
 			unless defined($path) && length($path);
 		bail("Malformed vault path '%s' in secrets list", $path)
 			if $path =~ m{^:};
+		bail("Malformed vault path '%s' in secrets list", $path)
+			if $path =~ m{:$};
 		# Check if we want a path:key or a path
 		my ($p,$key) = $path =~ m{^(.+?)(?::([^/]+))?$};
 		bail("Malformed vault path '%s' in secrets list", $path)

--- a/lib/Genesis/Env/Deployment.pod
+++ b/lib/Genesis/Env/Deployment.pod
@@ -471,9 +471,11 @@ B<Examples:>
 =head2 duration()
 
 Returns the duration of the deployment in seconds, computed as
-C<completed - started>.
+C<completed - started>. Returns C<undef> if either timestamp is missing
+or is not a Time::Piece object.
 
-B<Returns:> Numeric — number of seconds between started and completed.
+B<Returns:> Numeric — number of seconds between started and completed, or
+C<undef> if either timestamp is absent or not a Time::Piece object.
 
 =head2 reason()
 
@@ -566,12 +568,15 @@ B<Returns:> A Genesis::Env object.
 =head2 committed()
 
 Returns true if this deployment has been committed to exodus in the vault.
+Returns 0 (not die) if the vault is unreachable or throws an error,
+allowing callers to proceed gracefully.
 
 Note: C<committed()> checks the vault path C<'deployments/' . $self-E<gt>timestamp()>,
 which is a relative path. Due to a known issue (FWT-708), this may not match
 the full exodus path used by C<commit()>.
 
-B<Returns:> True if the vault path exists, false otherwise.
+B<Returns:> True if the vault path exists, 0 if the path does not exist or
+if the vault is unreachable.
 
 =head2 commit()
 
@@ -805,7 +810,7 @@ B<Errors:>
 =item C<"Path #B{%s} is not a directory">
 
 Thrown via C<bail()> if the resolved C<$path> does not exist or is not a
-directory. The C<%s> placeholder is the original (unresolved) C<$path> value.
+directory. The C<%s> placeholder is the resolved absolute C<$target_path>.
 
 =item C<"Invalid artifact filename '#B{%s}'%s - artifact names cannot contain path separators">
 
@@ -909,6 +914,11 @@ B<Errors:>
 
 =over
 
+=item C<"No artifacts to archive — all artifact files were missing or empty">
+
+Thrown via C<bail()> if no files were added to the tar archive (all
+artifact paths were missing or empty on disk).
+
 =item C<"Failed to compress manifest artifacts">
 
 Thrown via C<bail()> if the tar write call fails during gzip compression.
@@ -928,9 +938,26 @@ Collects secrets from the specified vault paths and returns them as a JSON
 string. Each path may be in C<'path:key'> format (to retrieve a single key)
 or plain C<'path'> format (to retrieve all keys at that path via
 C<get_path>). Uses per-path vault reads rather than vault export to avoid
-retrieving subpath contents. Returns C<'{}'> if no secrets are found.
+retrieving subpath contents. Returns C<'{}'> if no paths are provided.
+
+Validates each path before processing: bails on empty, undefined, or
+malformed paths (e.g., paths starting with C<:>).
 
 B<Returns:> JSON string of collected secrets.
+
+B<Errors:>
+
+=over
+
+=item C<"Invalid vault path in secrets list: empty or undefined">
+
+Thrown via C<bail()> if any path in C<@paths> is empty or undefined.
+
+=item C<"Malformed vault path '%s' in secrets list">
+
+Thrown via C<bail()> if a path starts with C<:> or fails to parse.
+
+=back
 
 B<Examples:>
 
@@ -1200,30 +1227,28 @@ mutable from any code that can reach the package namespace.
 
 =item I-2: Error message shows $path instead of $target_path (in extract_artifacts_to(), lines 529-530)
 
-In C<extract_artifacts_to()>, the C<bail()> for a non-directory path displays
-the original C<$path> argument rather than the resolved absolute
-C<$target_path>.
+B<Resolved> (FWT-726). The error now displays the resolved C<$target_path>.
 
 =back
 
-=head3 Additional Issues
+=head3 Additional Issues (Resolved)
 
-The following issues were discovered during the documentation audit and
-tracked as child tickets of FWT-708:
+The following issues were discovered during the documentation audit, tracked
+as child tickets of FWT-708, and resolved:
 
 =over
 
-=item L<FWT-723|https://fivetwenty.atlassian.net/browse/FWT-723>: duration() dies if either timestamp is absent (Major)
+=item L<FWT-723|https://fivetwenty.atlassian.net/browse/FWT-723>: duration() guards missing timestamps (was Major) E<mdash> Fixed
 
-=item L<FWT-724|https://fivetwenty.atlassian.net/browse/FWT-724>: committed() vault call propagates unhandled (Minor)
+=item L<FWT-724|https://fivetwenty.atlassian.net/browse/FWT-724>: committed() handles vault errors gracefully (was Minor) E<mdash> Fixed
 
-=item L<FWT-725|https://fivetwenty.atlassian.net/browse/FWT-725>: Empty/malformed path in _collect_secrets_from_paths (Minor)
+=item L<FWT-725|https://fivetwenty.atlassian.net/browse/FWT-725>: _collect_secrets_from_paths validates paths (was Minor) E<mdash> Fixed
 
-=item L<FWT-726|https://fivetwenty.atlassian.net/browse/FWT-726>: extract_artifacts_to error lacks path specificity (Info)
+=item L<FWT-726|https://fivetwenty.atlassian.net/browse/FWT-726>: extract_artifacts_to shows resolved path (was Info) E<mdash> Fixed
 
-=item L<FWT-727|https://fivetwenty.atlassian.net/browse/FWT-727>: Empty tar can be committed as artifact (Minor)
+=item L<FWT-727|https://fivetwenty.atlassian.net/browse/FWT-727>: _build_artifacts_file rejects empty tar (was Minor) E<mdash> Fixed
 
-=item L<FWT-728|https://fivetwenty.atlassian.net/browse/FWT-728>: Temporary artifact file not cleaned up on bail (Major)
+=item L<FWT-728|https://fivetwenty.atlassian.net/browse/FWT-728>: commit() cleans up temp files on failure (was Major) E<mdash> Fixed
 
 =back
 

--- a/t/unit-tests/genesis_env-deployment.t
+++ b/t/unit-tests/genesis_env-deployment.t
@@ -219,6 +219,14 @@ subtest 'FWT-725: _collect_secrets_from_paths validates paths' => sub {
 		done_testing;
 	};
 
+	subtest 'bails on path: (trailing colon)' => sub {
+		my $d = make_deployment();
+		throws_ok { $d->_collect_secrets_from_paths('secret/path:') }
+			qr/Malformed vault path|Invalid vault path/i,
+			"bails on path ending with colon";
+		done_testing;
+	};
+
 	subtest 'empty @paths returns {}' => sub {
 		my $d = make_deployment();
 		my $result;

--- a/t/unit-tests/genesis_env-deployment.t
+++ b/t/unit-tests/genesis_env-deployment.t
@@ -1,0 +1,394 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+
+use lib 't';
+use helper;
+
+use Test::More;
+use Test::Deep;
+use Test::Exception;
+use File::Temp qw/tempdir/;
+use File::Path qw/mkpath rmtree/;
+use Time::Piece;
+
+use Genesis;
+$Genesis::VERSION = '999.999.999';
+use_ok 'Genesis::Env::Deployment';
+
+# ===========================================================================
+# Helper: create a minimal deployment object by blessing directly
+# (bypasses new() validation to test individual methods in isolation)
+# ===========================================================================
+sub make_deployment {
+	my (%overrides) = @_;
+
+	my $mock_vault = $overrides{vault} // Mock->new(
+		has      => sub { return 0 },
+		get      => sub { return '{"key":"val"}' },
+		get_path => sub { return { key => 'val' } },
+		authenticate => sub { return $_[0] },
+		query    => sub { return ('', 0, '') },
+	);
+
+	my $mock_deployments = $overrides{deployments} // Mock->new(
+		next_sequence_number => sub { return 1 },
+		reset => sub { return 1 },
+	);
+
+	my $mock_env = Mock->new(
+		vault        => sub { return $mock_vault },
+		exodus_base  => $overrides{exodus_base} // '/secret/exodus/test-env',
+		workpath     => sub { return "/tmp/test-$$-$_[1]" },
+		deployments  => sub { return $mock_deployments },
+		name         => 'test-env',
+	);
+
+	my $data = $overrides{data} // {
+		action          => 'deploy',
+		result          => 'success',
+		reason          => 'test deployment',
+		genesis_version => '3.0.0',
+		started         => Time::Piece->strptime('2024-01-15 14:30:00', '%Y-%m-%d %H:%M:%S'),
+		completed       => Time::Piece->strptime('2024-01-15 14:35:22', '%Y-%m-%d %H:%M:%S'),
+		user            => { shell => '/bin/bash' },
+		kit             => { id => 'test/1.0', name => 'test', version => '1.0',
+		                     is_dev => 0, features => [] },
+		manifest        => { type => 'bosh', sha2 => 'abc123' },
+	};
+
+	return bless {
+		env       => $mock_env,
+		timestamp => $overrides{timestamp} // '20240115143000',
+		data      => $data,
+		artifacts => $overrides{artifacts} // undef,
+	}, 'Genesis::Env::Deployment';
+}
+
+
+# ===========================================================================
+# FWT-723: duration() guards missing timestamps
+# ===========================================================================
+subtest 'FWT-723: duration() guards missing timestamps' => sub {
+
+	subtest 'returns correct seconds with both timestamps present' => sub {
+		my $d = make_deployment();
+		my $duration = $d->duration();
+		is($duration, 322, "duration is 5m22s = 322 seconds");
+		done_testing;
+	};
+
+	subtest 'returns undef with missing started' => sub {
+		my $d = make_deployment(data => {
+			action => 'deploy', result => 'success', reason => 'test',
+			genesis_version => '3.0.0',
+			started   => undef,
+			completed => Time::Piece->strptime('2024-01-15 14:35:22', '%Y-%m-%d %H:%M:%S'),
+			user      => { shell => '/bin/bash' },
+			kit       => { id => 'test/1.0', name => 'test', version => '1.0',
+			               is_dev => 0, features => [] },
+			manifest  => { type => 'bosh', sha2 => 'abc123' },
+		});
+		my $result;
+		lives_ok { $result = $d->duration() } "duration() does not die with missing started";
+		is($result, undef, "returns undef when started is missing");
+		done_testing;
+	};
+
+	subtest 'returns undef with missing completed' => sub {
+		my $d = make_deployment(data => {
+			action => 'deploy', result => 'success', reason => 'test',
+			genesis_version => '3.0.0',
+			started   => Time::Piece->strptime('2024-01-15 14:30:00', '%Y-%m-%d %H:%M:%S'),
+			completed => undef,
+			user      => { shell => '/bin/bash' },
+			kit       => { id => 'test/1.0', name => 'test', version => '1.0',
+			               is_dev => 0, features => [] },
+			manifest  => { type => 'bosh', sha2 => 'abc123' },
+		});
+		my $result;
+		lives_ok { $result = $d->duration() } "duration() does not die with missing completed";
+		is($result, undef, "returns undef when completed is missing");
+		done_testing;
+	};
+
+	subtest 'returns undef with non-Time::Piece values' => sub {
+		my $d = make_deployment(data => {
+			action => 'deploy', result => 'success', reason => 'test',
+			genesis_version => '3.0.0',
+			started   => 'not a time::piece',
+			completed => 'also not a time::piece',
+			user      => { shell => '/bin/bash' },
+			kit       => { id => 'test/1.0', name => 'test', version => '1.0',
+			               is_dev => 0, features => [] },
+			manifest  => { type => 'bosh', sha2 => 'abc123' },
+		});
+		my $result;
+		lives_ok { $result = $d->duration() } "duration() does not die with non-Time::Piece values";
+		is($result, undef, "returns undef when timestamps are not Time::Piece");
+		done_testing;
+	};
+
+	done_testing;
+};
+
+
+# ===========================================================================
+# FWT-724: committed() handles vault errors
+# ===========================================================================
+subtest 'FWT-724: committed() handles vault errors' => sub {
+
+	subtest 'returns 0 when vault throws exception' => sub {
+		my $error_vault = Mock->new(
+			has => sub { die "vault connection refused" },
+		);
+		my $d = make_deployment(vault => $error_vault);
+		my $result;
+		lives_ok { $result = $d->committed() } "committed() does not die on vault error";
+		is($result, 0, "returns 0 when vault throws");
+		done_testing;
+	};
+
+	subtest 'returns true when vault->has returns true' => sub {
+		my $ok_vault = Mock->new(
+			has => sub { return 1 },
+		);
+		my $d = make_deployment(vault => $ok_vault);
+		ok($d->committed(), "returns true when vault->has returns true");
+		done_testing;
+	};
+
+	subtest 'returns 0 when no timestamp' => sub {
+		my $d = make_deployment(timestamp => undef);
+		is($d->committed(), 0, "returns 0 when timestamp is undef");
+
+		my $d2 = make_deployment(timestamp => '');
+		is($d2->committed(), 0, "returns 0 when timestamp is empty string");
+		done_testing;
+	};
+
+	done_testing;
+};
+
+
+# ===========================================================================
+# FWT-725: _collect_secrets_from_paths validates paths
+# ===========================================================================
+subtest 'FWT-725: _collect_secrets_from_paths validates paths' => sub {
+
+	subtest 'valid path:key works' => sub {
+		my $mock_vault = Mock->new(
+			get      => sub { return 'secret_value' },
+			get_path => sub { return { key => 'val' } },
+		);
+		my $d = make_deployment(vault => $mock_vault);
+		my $result;
+		lives_ok { $result = $d->_collect_secrets_from_paths('secret/path:mykey') }
+			"path:key format works";
+		ok(defined $result, "returns a defined result");
+		done_testing;
+	};
+
+	subtest 'valid bare path works' => sub {
+		my $mock_vault = Mock->new(
+			get      => sub { return 'secret_value' },
+			get_path => sub { return { key => 'val' } },
+		);
+		my $d = make_deployment(vault => $mock_vault);
+		my $result;
+		lives_ok { $result = $d->_collect_secrets_from_paths('secret/path') }
+			"bare path format works";
+		ok(defined $result, "returns a defined result");
+		done_testing;
+	};
+
+	subtest 'bails on empty string path' => sub {
+		my $d = make_deployment();
+		throws_ok { $d->_collect_secrets_from_paths('') }
+			qr/Invalid vault path|empty or undefined/i,
+			"bails on empty string path";
+		done_testing;
+	};
+
+	subtest 'bails on :key (no path prefix)' => sub {
+		my $d = make_deployment();
+		throws_ok { $d->_collect_secrets_from_paths(':mykey') }
+			qr/Malformed vault path|Invalid vault path/i,
+			"bails on path starting with colon";
+		done_testing;
+	};
+
+	subtest 'empty @paths returns {}' => sub {
+		my $d = make_deployment();
+		my $result;
+		lives_ok { $result = $d->_collect_secrets_from_paths() }
+			"empty paths list does not die";
+		is($result, '{}', "returns empty JSON object for no paths");
+		done_testing;
+	};
+
+	done_testing;
+};
+
+
+# ===========================================================================
+# FWT-726: extract_artifacts_to shows resolved path in errors
+# ===========================================================================
+subtest 'FWT-726: extract_artifacts_to shows resolved path in errors' => sub {
+
+	subtest 'error message contains resolved absolute path' => sub {
+		# Use a relative path that will be resolved to an absolute path
+		# The resolved path should appear in the error, not the raw relative path
+		my $d = make_deployment();
+
+		# Set GENESIS_CALLER_DIR so absolute_path resolves against it
+		local $ENV{GENESIS_CALLER_DIR} = '/tmp';
+
+		# Use a path that doesn't exist as a directory
+		my $nonexistent = "nonexistent-dir-$$";
+		my $expected_resolved = "/tmp/$nonexistent";
+
+		throws_ok { $d->extract_artifacts_to($nonexistent) }
+			qr/\Q$expected_resolved\E/,
+			"error message contains the resolved absolute path, not the raw relative path";
+		done_testing;
+	};
+
+	done_testing;
+};
+
+
+# ===========================================================================
+# FWT-727: _build_artifacts_file rejects empty tar
+# ===========================================================================
+subtest 'FWT-727: _build_artifacts_file rejects empty tar' => sub {
+
+	subtest 'bails when no artifacts would be added' => sub {
+		my $d = make_deployment();
+
+		# Provide artifact files that don't exist on disk — tar will have nothing
+		my $tmpfile = "/tmp/test-artifacts-$$-empty.tgz.b64";
+		throws_ok {
+			$d->_build_artifacts_file(
+				$tmpfile,
+				manifest => "/nonexistent/path/to/manifest-$$",
+				log      => "/nonexistent/path/to/log-$$",
+			)
+		} qr/No artifacts to archive|missing or empty/i,
+			"bails when all artifact files are missing";
+		unlink $tmpfile if -f $tmpfile;
+		done_testing;
+	};
+
+	subtest 'succeeds when at least one artifact file exists' => sub {
+		my $d = make_deployment();
+		my $tmpdir = tempdir(CLEANUP => 1);
+		my $artifact_file = "$tmpdir/artifacts.tgz.b64";
+
+		# Create a real artifact file
+		my $manifest_file = "$tmpdir/test-env.yml";
+		open my $fh, '>', $manifest_file or die "Cannot create $manifest_file: $!";
+		print $fh "---\nname: test-env\n";
+		close $fh;
+
+		lives_ok {
+			$d->_build_artifacts_file(
+				$artifact_file,
+				manifest => $manifest_file,
+			)
+		} "succeeds with at least one real artifact file";
+		ok(-f $artifact_file, "artifact file was created");
+		done_testing;
+	};
+
+	done_testing;
+};
+
+
+# ===========================================================================
+# FWT-728: commit() cleans up temp files on failure
+# ===========================================================================
+subtest 'FWT-728: commit() cleans up temp files on failure' => sub {
+
+	subtest 'temp artifact file cleaned up after successful commit' => sub {
+		my $tmpdir = tempdir(CLEANUP => 1);
+		my $manifest_file = "$tmpdir/test-env.yml";
+		open my $fh, '>', $manifest_file or die "Cannot create: $!";
+		print $fh "---\nname: test-env\n";
+		close $fh;
+
+		# Use Mock::ReferencedValue for query to return list correctly
+		# (Mock AUTOLOAD forces scalar context on CODE refs)
+		my $ok_vault = Mock->new(
+			has          => sub { return 0 },  # not yet committed
+			authenticate => sub { return $_[0] },
+			query        => Mock::ReferencedValue->new(['', 0, '']),  # success
+		);
+		my $mock_deployments = Mock->new(
+			next_sequence_number => sub { return 1 },
+			reset => sub { return 1 },
+		);
+		my $artifact_path;
+		my $d = make_deployment(
+			vault       => $ok_vault,
+			deployments => $mock_deployments,
+			artifacts   => {
+				format => 'local-file-hash',
+				data   => { manifest => $manifest_file },
+			},
+		);
+		# Override workpath to track the temp file location
+		$d->{env}->{workpath} = sub {
+			$artifact_path = "$tmpdir/$_[1]";
+			return $artifact_path;
+		};
+		lives_ok { $d->commit() } "commit succeeds";
+		ok(!-f $artifact_path, "temp artifact file cleaned up after success")
+			if defined $artifact_path;
+		done_testing;
+	};
+
+	subtest 'temp artifact file cleaned up after vault error' => sub {
+		my $tmpdir = tempdir(CLEANUP => 1);
+		my $manifest_file = "$tmpdir/test-env.yml";
+		open my $fh, '>', $manifest_file or die "Cannot create: $!";
+		print $fh "---\nname: test-env\n";
+		close $fh;
+
+		# Use Mock::ReferencedValue for query to return list correctly
+		my $fail_vault = Mock->new(
+			has          => sub { return 0 },
+			authenticate => sub { return $_[0] },
+			query        => Mock::ReferencedValue->new(['vault error output', 1, 'connection refused']),
+		);
+		my $mock_deployments = Mock->new(
+			next_sequence_number => sub { return 1 },
+			reset => sub { return 1 },
+		);
+		my $artifact_path;
+		my $d = make_deployment(
+			vault       => $fail_vault,
+			deployments => $mock_deployments,
+			artifacts   => {
+				format => 'local-file-hash',
+				data   => { manifest => $manifest_file },
+			},
+		);
+		$d->{env}->{workpath} = sub {
+			$artifact_path = "$tmpdir/$_[1]";
+			return $artifact_path;
+		};
+		# commit will bail in scalar context on vault failure
+		dies_ok { $d->commit() } "commit dies on vault error";
+		ok(!-f $artifact_path, "temp artifact file cleaned up after failure")
+			if defined $artifact_path;
+		done_testing;
+	};
+
+	done_testing;
+};
+
+
+done_testing;
+# vim: set ts=2 sw=2 sts=2 noet:


### PR DESCRIPTION
## Summary

- Add unit tests for 6 code defects in `Genesis::Env::Deployment` (FWT-723 through FWT-728)
- Fix all 6 defects: `duration()` timestamp guards, `committed()` vault error handling, `_collect_secrets_from_paths()` input validation, `extract_artifacts_to()` error message, `_build_artifacts_file()` empty tar rejection, `commit()` temp file cleanup
- Update POD KNOWN ISSUES to mark all 6 sub-tickets as resolved

## Test plan

- [x] All 6 new subtests pass (RED→GREEN verified)
- [x] Existing `genesis_env-deployment_cache.t` tests pass (no regression)
- [x] POD validates cleanly