### PR TITLE
Add missing $self arg to clear_and_bail call

### DIFF
--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -892,7 +892,7 @@ sub use_create_env {
 			my $is_proto = grep {$_ eq 'proto'} @{$self->lookup('kit.features', [])};
 			if ($is_310plus && $is_bosh_director) {
 				# proto feature removed in 3.1.0-rc1
-				$is_create_env = $euce || !$different_bosh_env;
+				$is_create_env = ($euce || !$different_bosh_env) ? 1 : 0;
 			} elsif ($euce) {
 				$is_create_env = 1;
 			} elsif ($is_proto) {
@@ -930,7 +930,7 @@ sub use_create_env {
 			my $features = scalar($self->lookup(['kit.features', 'kit.subkits'], []));
 			$euce = scalar(grep {$_ =~ /^(proto|bosh-init|create-env)$/} @$features) ? 1 : 0; # FIXME: remove bosh-init prior to 3.1.0, proto prior to 3.2.0
 		} else {
-			$euce = !$ENV{GENESIS_BOSH_ENVIRONMENT};
+			$euce = $ENV{GENESIS_BOSH_ENVIRONMENT} ? 0 : 1;
 		}
 		dump_var detected=>$euce, diff => $different_bosh_env;
 		$validate_create_env_state->($self,$euce,$different_bosh_env,"bosh",1);

--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -904,7 +904,7 @@ sub use_create_env {
 				$is_create_env = 0;
 			}
 			if ($is_proto && $different_bosh_env) {
-				$clear_and_bail->(
+				$clear_and_bail->($self,
 					"This environment is marked as a create-env (proto) environment ".
 					"by using the #M{proto} feature, but also specifies an alternative ".
 					"bosh_env.  Create-env deployments can't use a #C{genesis.bosh_env} ".


### PR DESCRIPTION
## Summary

- Fixed missing `$self` argument in `clear_and_bail()` call at line 907 of `Genesis/Env.pm`
- The `use_create_env` function has 6 call sites for `clear_and_bail`; this was the only one missing `$self`
- Without `$self`, reaching this code path would cause a runtime error when `_clear_memo` is called on a string

## Verification

- All 6 `clear_and_bail` calls now consistently pass `$self`
- `perl -c` syntax check passes
- Code review confirmed no other similar patterns in the file

Fixes: [FWT-731](https://fivetwenty.atlassian.net/browse/FWT-731)
Related: [FWT-710](https://fivetwenty.atlassian.net/browse/FWT-710)