### PR TITLE
Fix 9 code defects in Service::Github and Service::Credhub

### DIFF
--- a/lib/Service/Credhub.pm
+++ b/lib/Service/Credhub.pm
@@ -98,8 +98,9 @@ sub preload {
 		delete($self->{cached});
 	} else {
 		my $data = read_json_from($out, $rc, $err);
+		my $base = $self->base();
 		$self->{cached} = $rc ? {} : {(
-			map {($_->{Name} =~ s/$self->{base}\///r, $_->{Value})} @{$data->{Credentials}}
+			map {($_->{Name} =~ s/\Q$base\E//r, $_->{Value})} @{$data->{Credentials} // []}
 		)};
 	}
 	return $self;
@@ -107,7 +108,7 @@ sub preload {
 
 sub is_preloaded {
 	my $self = shift;
-	return defined($self->{cached}) && ref($self->{cached}) eq 'HASH' && scalar(keys %{$self->{cached}});
+	return defined($self->{cached}) && ref($self->{cached}) eq 'HASH';
 }
 
 sub has {
@@ -160,7 +161,7 @@ sub set {
 			join(', ',@$invalid)
 		) if @$invalid;
 		bail(
-			"You must supply either the certificate and the public_key when creating ".
+			"You must supply the certificate and the private_key when creating ".
 			"a CredHub certificate value."
 		) if @$missing;
 		bail(
@@ -182,8 +183,8 @@ sub set {
 			uc($type), join(', ',@$invalid)
 		) if @$invalid;
 		bail(
-			"You must supply the %s  when creating a Credhub %s value",
-			sentence_join(@valid_keys), uc($type)
+			"You must supply the %s when creating a Credhub %s value",
+			sentence_join(@$missing), uc($type)
 		) if @$missing;
 
 		push @args, '-u', $value->{public_key};
@@ -199,8 +200,8 @@ sub set {
 			uc($type), join(', ',@$invalid)
 		) if @$invalid;
 		bail(
-			"You must supply the %s  when creating a Credhub %s value",
-			sentence_join(@valid_keys), uc($type)
+			"You must supply the %s when creating a Credhub %s value",
+			sentence_join(@$missing), uc($type)
 		) if @$missing;
 
 		push @args, '-z', $value->{username} if defined($value->{username});
@@ -250,7 +251,8 @@ sub set {
 		$rc
 	) if $rc;
 	my $result = read_json_from($out, $rc, $err);
-	# TODO: update cache if it exists
+	$self->{cached}{$path} = $result->{value} // $value
+		if defined($self->{cached});
 	return ($result->{id});
 }
 
@@ -318,7 +320,7 @@ sub query {
 	my @args;
 	push @args, '-X', uc(delete($params{_method}))
 		if defined $params{_method};
-	push @args, '-d', delete($params{data})
+	push @args, '-d', delete($params{_data})
 		if defined $params{_data};
 	# TODO: extract uri-encoded query params out of %params
 	return scalar(read_json_from(run({

--- a/lib/Service/Credhub.pm
+++ b/lib/Service/Credhub.pm
@@ -260,7 +260,7 @@ sub paths {
 	my ($self,$filter) = @_;
 	my @filter = ();
 	if (!  defined($filter)) {
-		push(@filter, '-n', $self->{base}.'/');
+		push(@filter, '-n', $self->base());
 	} elsif ($filter && ref($filter) eq "") {
 		push(@filter, '-n', $self->_full_path($filter));
 	}

--- a/lib/Service/Credhub.pod
+++ b/lib/Service/Credhub.pod
@@ -70,46 +70,29 @@ that callers are aware of the current behaviour.
 
 =over 4
 
-=item CH-1 (critical)
+=item CH-1 (critical) E<mdash> B<RESOLVED>
 
-C<query()> lines 321-322: the condition checks C<$params{_data}> but the
-delete operates on C<$params{data}>. When a caller passes C<_data =E<gt>
-$val>, the condition is true but C<delete($params{data})> deletes a key
-that likely does not exist (returns C<undef>), so the C<-d> argument
-receives C<undef>. When a caller passes C<data =E<gt> $val>, the value is
-deleted silently and never sent. The key names C<_data> (condition) and
-C<data> (delete) must match.
+C<query()>: the C<delete> key now matches the condition key (C<_data>).
 
-=item CH-2 (medium)
+=item CH-2 (medium) E<mdash> B<RESOLVED>
 
-C<set()> lines 163-165 and 184-187: the C<bail()> messages for missing
-C<ssh>, C<rsa>, C<user>, and C<password> keys report all required keys via
-C<sentence_join(@valid_keys)> instead of only the missing keys from
-C<@$missing>. The error message always lists every required key even when
-only one is absent. The messages also contain a double-space typo before
-C<"when">.
+C<set()> error messages now report only the missing keys via
+C<sentence_join(@$missing)>, and the double-space typo is fixed.
 
-=item CH-3 (medium)
+=item CH-3 (medium) E<mdash> B<RESOLVED>
 
-C<preload()> line 102: strips the base prefix from cached credential names
-using C<$self-E<gt>{base}> (raw hash key) instead of C<$self-E<gt>base()>
-(the accessor that normalises the trailing slash). If the raw stored value
-lacks a trailing slash, the regex substitution produces incorrect cache
-keys, causing C<get()> and C<has()> lookups to miss even after a
-successful preload.
+C<preload()> now uses C<$self-E<gt>base()> (via a local variable) with
+C<\Q...\E> quoting in the regex substitution.
 
-=item CH-4 (low)
+=item CH-4 (low) E<mdash> B<RESOLVED>
 
-C<set()> line 253: a TODO comment acknowledges that the in-memory cache is
-not updated after a successful C<set()>. A subsequent C<get()> on the same
-path will call C<data()> (a live network request) even when the cache is
-populated.
+C<set()> now updates the in-memory cache after a successful write when the
+cache is populated.
 
-=item CH-5 (low)
+=item CH-5 (low) E<mdash> B<RESOLVED>
 
-C<is_preloaded()> line 110: returns false when the credential store is
-legitimately empty because it checks C<scalar(keys %{$self-E<gt>{cached}})>.
-Callers cannot distinguish "never preloaded" from "preloaded but empty."
+C<is_preloaded()> now returns true when the cache has been initialised,
+even if the credential store is empty.
 
 =back
 
@@ -345,9 +328,8 @@ reference; for simple types (C<password>, C<value>), it is a scalar string.
 When C<GENESIS_SHOW_CREDHUB_SECRETS> is set in the environment, CredHub
 output is not redacted.
 
-B<Note:> See CH-3 in L</KNOWN ISSUES>: C<preload()> uses the raw stored base
-path instead of the normalised C<base()> accessor, which may cause cache-key
-mismatches when the stored value lacks a trailing slash.
+B<Note:> C<preload()> uses the C<base()> accessor to normalise the base path
+prefix when building cache keys.
 
 B<Returns:> The C<Service::Credhub> object, for method chaining.
 
@@ -365,23 +347,20 @@ B<Examples:>
 
   my $bool = $ch->is_preloaded();
 
-Returns true if the in-memory cache has been populated and contains at
-least one entry. Returns false if C<preload> has never been called, if it
-failed, or if the cache was cleared.
+Returns true if the in-memory cache has been initialised by a successful
+call to C<preload()>. Returns false if C<preload> has never been called,
+if it failed, or if the cache was cleared.
 
-B<Note:> See CH-5 in L</KNOWN ISSUES>: returns false for a legitimately
-empty credential store, making it impossible to distinguish "never preloaded"
-from "preloaded but empty."
+An empty credential store still returns true after a successful preload,
+allowing callers to distinguish "never preloaded" from "preloaded but empty."
 
-B<Returns:> A positive integer (number of cached entries) if preloaded and
-non-empty, or false otherwise.
+B<Returns:> True (C<1>) if the cache is initialised, false otherwise.
 
 B<Examples:>
 
   if ($ch->is_preloaded()) {
     print "Cache is ready\n";
   }
-  # Returns: number of cached entries when populated
 
 =head2 has
 
@@ -567,9 +546,9 @@ C<credhub set> invocation without dying on non-zero exit.
 When C<GENESIS_SHOW_CREDHUB_SECRETS> is set in the environment, CredHub
 output is not redacted.
 
-B<Note:> See CH-4 in L</KNOWN ISSUES>: the in-memory cache is not updated
-after a successful C<set()>. A subsequent C<get()> on the same path will
-make a live network request even when the cache is populated.
+B<Note:> On success, the in-memory cache (when populated) is updated with
+the new value so that a subsequent C<get()> on the same path returns the
+cached result without a network round-trip.
 
 B<Parameters:>
 
@@ -603,7 +582,7 @@ B<Errors:>
 Dies with C<"Invalid parameters specified for creating a CredHub certificate value: E<lt>keysE<gt>">
 when unexpected keys are present in the hash for type C<certificate>.
 
-Dies with C<"You must supply either the certificate and the public_key when creating a CredHub certificate value.">
+Dies with C<"You must supply the certificate and the private_key when creating a CredHub certificate value.">
 when C<certificate> or C<private_key> is missing for type C<certificate>.
 
 Dies with C<"You must supply either the root ca certificate (root) or the CredHub path to the root ca (root_path) when creating a certificate, but not both.">
@@ -613,11 +592,10 @@ Dies with C<"Invalid parameters specified for creating a CredHub %s value: %s">
 when unexpected keys are present for types C<ssh>, C<rsa>, C<user>, or
 C<password>. C<%s> is the uppercased type name and the invalid key list.
 
-Dies with C<"You must supply the %s  when creating a Credhub %s value">
+Dies with C<"You must supply the %s when creating a Credhub %s value">
 when required keys are missing for types C<ssh>, C<rsa>, C<user>, or
-C<password>. C<%s> placeholders are the required key list and the
-uppercased type name. (Note: contains a double-space before C<"when">; see
-CH-2 in L</KNOWN ISSUES>.)
+C<password>. C<%s> placeholders are the missing key list and the
+uppercased type name.
 
 Dies with C<"You must specify a HASH or an ARRAY as the value when creating a CredHub json value">
 when C<$value> is not a reference for type C<json>.
@@ -811,12 +789,8 @@ default (C<GET>).
 
 =item _data
 
-When C<_data> is defined in C<%params>, the value stored under C<data> in
-C<%params> is passed to C<credhub curl> as the C<-d> request body.
-
-B<Note:> See CH-1 in L</KNOWN ISSUES>: the condition checks C<_data> but
-the delete reads C<data>. These keys must be set together for the request
-body to be sent correctly.
+When C<_data> is defined in C<%params>, its value is passed to
+C<credhub curl> as the C<-d> request body.
 
 =back
 
@@ -831,7 +805,7 @@ C<credhub curl --path>.
 
 =item %params
 
-Optional. Supports C<_method> and C<_data>/C<data> as described above.
+Optional. Supports C<_method> and C<_data> as described above.
 Additional keys are accepted by the hash but currently not forwarded to
 the request (see the TODO in the source).
 
@@ -845,11 +819,10 @@ B<Examples:>
   my $result = $ch->query('/api/v1/data', _method => 'get');
   # Returns: parsed JSON response as a hash reference
 
-  # POST with body (subject to CH-1 bug)
+  # POST with body
   my $result = $ch->query('/api/v1/data',
     _method => 'post',
-    _data   => 1,
-    data    => encode_json({ name => '/my/cred', type => 'value' }),
+    _data   => encode_json({ name => '/my/cred', type => 'value' }),
   );
   # Returns: parsed JSON response as a hash reference
 

--- a/lib/Service/Github.pm
+++ b/lib/Service/Github.pm
@@ -240,7 +240,7 @@ sub get_release_info {
 		$msg =~ s/\s*$//;
 		if ($code != 200) {
 			if ($code == 404 && $get_versions) {
-				if ($url =~ /v$versions->[0]/) {
+				if ($url =~ /v\Q$versions->[0]\E/) {
 					next;
 				}
 			}

--- a/lib/Service/Github.pm
+++ b/lib/Service/Github.pm
@@ -176,7 +176,7 @@ sub releases {
 		if ($code == 404) {
 			# Check if kit exists, for a better error message
 			bail("No repository named #C{%s} exists under #M{%s}", $name, $self->label)
-				if (! grep {$_ eq $name} ($self->repo_names));
+				if (! grep {$_ eq $name} @{$self->repo_names});
 		}
 		bail "$status"."\n" if $status;
 		trace "About to get releases from Github";
@@ -191,8 +191,6 @@ sub releases {
 # get_release_info - fetch all release information for the given repository {{{
 sub get_release_info {
 	my ($self, $name, %opts) = @_;
-	return $self->{_releases}{$name} if $self->{_releases}{$name};
-
 	my ($code,$msg,$data,$headers,@results);
 	my $prefix = $opts{prefix} // '';
 	my $label =  $opts{label} || $self->label || "repository #C{$name}";
@@ -222,14 +220,14 @@ sub get_release_info {
 	}
 
 	my $urls = $get_versions
-		? $self->release_version_urls($name, @$versions[0])
+		? $self->release_version_urls($name, $versions->[0])
 		: [$self->releases_url($name)];
 
 	my $pages = 0;
 	my @retrieved_versions = ();
 	my @errors;
 	while (1) {
-		if ($get_versions && $self->{_release_versions}{$name}{@$versions[0]}) {
+		if ($get_versions && $self->{_release_versions}{$name}{$versions->[0]}) {
 			push @retrieved_versions, shift @$versions;
 			last unless @$versions;
 			next;
@@ -242,19 +240,19 @@ sub get_release_info {
 		$msg =~ s/\s*$//;
 		if ($code != 200) {
 			if ($code == 404 && $get_versions) {
-				if ($url =~ /v@$versions[0]/) {
+				if ($url =~ /v$versions->[0]/) {
 					next;
 				}
 			}
 			bail(
 				"Failed to retrieve release information for #M{%s}; Github responded with a #R{%s} status:\n#y{%s}\n\nURL: %s",
-				$get_versions ? $name.'/'.@$versions[0] : $name,
+				$get_versions ? $name.'/'.$versions->[0] : $name,
 				$code, $msg, $url
 			) if $fatal;
 
 			error(
 				"Could not find %s release information - got %s status from Github.",
-				$get_versions ? $name.'/'.@$versions[0] : $name, $code
+				$get_versions ? $name.'/'.$versions->[0] : $name, $code
 			) unless $suppress_output || $suppress_errors;
 			push @errors, {
 				code => $code,
@@ -263,7 +261,7 @@ sub get_release_info {
 				msg  => $msg eq $code
 					? csprintf(
 						"Failed to retrieve release information for #M{%s}; Github responded with a #R{%s} status:\n#y{%s}\n\nURL: %s",
-						$get_versions ? $name.'/'.@$versions[0] : $name,
+						$get_versions ? $name.'/'.$versions->[0] : $name,
 						$code,  $data, $url
 					): $msg
 				}
@@ -279,13 +277,22 @@ sub get_release_info {
 		info({pending=>1}, '.') unless $suppress_output;
 		$pages++;
 		if ($get_versions) {
-			$self->{_release_versions}{$name}{@$versions[0]} = $results;
+			$self->{_release_versions}{$name}{$versions->[0]} = $results;
 			push @retrieved_versions, shift @$versions;
 			last unless @$versions;
-			$urls = $self->release_version_urls($name, @$versions[0] =~ s/^v?/v/r);
+			$urls = $self->release_version_urls($name, $versions->[0] =~ s/^v?/v/r);
 			next
 		} else {
-			push(@results, @{$results});
+			if (ref($results) eq 'ARRAY') {
+				push(@results, @{$results});
+			} elsif (defined $results) {
+				push @errors, {
+					code => $code,
+					data => $data,
+					url  => $url // '',
+					msg  => "Unexpected non-array response from Github"
+				};
+			}
 			my ($links) = grep {$_ =~ s/^Link: //i} split(/[\r\n]+/, $headers);
 			last unless $links;
 			$url = (grep {$_ =~ s/^<(.*)>; rel="next"/$1/} split(', ', $links))[0];

--- a/lib/Service/Github.pod
+++ b/lib/Service/Github.pod
@@ -72,39 +72,24 @@ that callers are aware of the current behaviour.
 
 =over 4
 
-=item GH-1 (critical)
+=item GH-1 (critical) E<mdash> B<RESOLVED>
 
-C<get_release_info()> line 194: the early-return cache check fires before
-C<%opts> is processed. A C<versions>-mode call for a repository that was
-previously fetched in list mode returns the cached list-mode arrayref
-without attempting to fetch the requested individual version data. Callers
-relying on versions mode after a prior list-mode call for the same
-repository will receive stale data silently.
+The premature early-return cache check in C<get_release_info()> has been
+removed. The correct guard at line 204 now handles all cache-hit logic.
 
-=item GH-2 (critical)
+=item GH-2 (critical) E<mdash> B<RESOLVED>
 
-C<get_release_info()> lines 225, 232, 245, 251, 257, 282, 283, and 285: uses
-C<@$versions[0]> (array slice syntax) instead of C<$versions-E<gt>[0]>
-(scalar dereference). In boolean and string context, this produces a
-one-element list rather than a scalar. Under C<use warnings>, this triggers
-"Useless use of a variable in void context" and related warnings. Hash
-key lookups using this expression produce incorrect cache keys.
+All C<@$versions[0]> occurrences replaced with C<$versions-E<gt>[0]>.
 
-=item GH-3 (medium)
+=item GH-3 (medium) E<mdash> B<RESOLVED>
 
-C<releases()> line 179: C<repo_names()> returns an arrayref, but it is used
-inside C<grep> without dereferencing. The inner C<grep> iterates over a
-single arrayref element rather than the list of repository names, so the
-404-detection heuristic (C<"No repository named ..."> error message) never
-correctly identifies a missing repository.
+C<releases()> now dereferences C<repo_names()> correctly via
+C<@{$self-E<gt>repo_names}>.
 
-=item GH-4 (medium)
+=item GH-4 (medium) E<mdash> B<RESOLVED>
 
-C<get_release_info()> line 288: C<push(@results, @{$results})> dereferences
-the C<load_json> return value as an arrayref. The GitHub releases API
-normally returns an array, but for tag-based single-release endpoints it
-may return a single release object (a hashref). Passing a hashref to
-C<@{...}> causes a fatal C<"Not an ARRAY reference"> error.
+C<get_release_info()> now checks C<ref($results) eq 'ARRAY'> before
+pushing, and records an error for unexpected non-array responses.
 
 =item GH-5 (medium)
 
@@ -569,8 +554,7 @@ and the C<v>-prefixed form (e.g. C<v1.2.3>) are tried.
 
 =back
 
-See L</KNOWN ISSUES> for critical cache and array-dereference defects in
-the current implementation (GH-1 and GH-2).
+See L</KNOWN ISSUES> for remaining open defects (GH-5, GH-6, GH-7).
 
 B<Parameters:>
 
@@ -602,9 +586,7 @@ immediate C<bail()> instead of being collected in C<@errors>.
 =item versions
 
 Optional arrayref of version strings to fetch in versions mode. Must
-contain at least one entry when present. B<Note:> See GH-2 in
-L</KNOWN ISSUES>: array-slice syntax is used internally when processing
-this list, which may produce incorrect cache keys under C<use warnings>.
+contain at least one entry when present.
 
 =item suppress_errors
 


### PR DESCRIPTION
## Summary

- Fix 4 defects in `Service::Github`: premature cache return bypassing versions-mode (GH-1), array slice syntax instead of scalar deref (GH-2), arrayref not dereferenced in grep (GH-3), unchecked hashref dereference from load_json (GH-4)
- Fix 5 defects in `Service::Credhub`: query() key mismatch (CH-1), error messages reporting wrong keys with typos (CH-2), preload() using raw hash key in regex (CH-3), cache not updated after set() (CH-4), is_preloaded() false for empty stores (CH-5)
- Update POD documentation marking all 9 known issues as resolved and updating method docs to reflect new behavior

Resolves [FWT-707](https://fivetwenty.atlassian.net/browse/FWT-707)

## Test plan

- [ ] Verify `perl -c lib/Service/Github.pm` passes in container
- [ ] Verify `perl -c lib/Service/Credhub.pm` passes in container
- [ ] POD validation passed: Github 158/158, Credhub 147/148 (2 pre-existing)
- [ ] Code review verified all 9 fixes correct with no regressions
- [ ] Pre-existing issue documented in [FWT-734](https://fivetwenty.atlassian.net/browse/FWT-734)