### PR TITLE
Add POD for Genesis::Commands modules

### DIFF
--- a/lib/Genesis/Commands.pod
+++ b/lib/Genesis/Commands.pod
@@ -1,0 +1,1308 @@
+=encoding utf-8
+
+=head1 NAME
+
+Genesis::Commands - Command infrastructure and dispatch for Genesis CLI
+
+=head1 SYNOPSIS
+
+  # In bin/genesis -- register a command
+  use Genesis::Commands;
+
+  define_command('deploy',
+    {
+      summary        => 'Deploy a Genesis environment',
+      scope          => 'env',
+      function_group => ENVIRONMENT,
+      option_group   => ENV_OPTIONS,
+      options        => [
+        'dry-run|n' => 'Perform a dry run without deploying',
+      ],
+    }
+  );
+
+  # From within a command implementation
+  my %opts = %{get_options()};
+  my @args = get_args();
+  bail "need an environment name" unless @args;
+
+  # CLI invocation (from the shell)
+  genesis deploy my-env
+  genesis --help
+  genesis deploy --help-full
+
+=head1 DESCRIPTION
+
+C<Genesis::Commands> is the procedural backbone of the Genesis CLI.  It
+provides command registration, option parsing, dispatch, help generation,
+and pre-flight validation.  All functions are exported into the caller's
+namespace via C<@EXPORT>.
+
+The module maintains several package-level data structures that track the
+currently active command and its parsed state:
+
+=over 4
+
+=item C<$COMMAND>
+
+The canonical name of the active command (e.g., C<deploy>), set during
+C<prepare_command>.
+
+=item C<$CALLED>
+
+The alias or name actually typed by the user (e.g., C<dep> if the user
+typed an alias), set during C<prepare_command>.
+
+=item C<%RUN>
+
+A dispatch table mapping command names to the closures that execute them.
+Populated by C<define_command>.
+
+=item C<%PROPS>
+
+A property hash mapping command names to their registered metadata
+(scope, option group, aliases, summary, description, options, etc.).
+Populated by C<define_command>.
+
+=item C<%GENESIS_COMMANDS>
+
+Maps every known name (canonical and aliases) to the canonical command
+name.  Populated by C<define_command>.
+
+=item C<@COMMANDS>
+
+An ordered list of canonical command names in registration order.
+Populated by C<define_command>.
+
+=back
+
+=head1 CONSTANTS
+
+=head3 Function-Group Constants
+
+The following constants are hash references used as the C<function_group>
+property in C<define_command>.  Each carries C<order>, C<module>, and
+C<label> keys that drive help output grouping and default dispatch module
+resolution.
+
+=over 4
+
+=item C<ENVIRONMENT>
+
+Order 0.  Module C<Env>.  Label C<Environment Management>.
+
+=item C<BOSH>
+
+Order 1.  Module C<Bosh>.  Label C<BOSH Actions>.
+
+=item C<INFO>
+
+Order 2.  Module C<Info>.  Label C<Informative>.
+
+=item C<REPOSITORY>
+
+Order 3.  Module C<Repo>.  Label C<Repository Management>.
+
+=item C<KIT>
+
+Order 4.  Module C<Kit>.  Label C<Kit Management>.
+
+=item C<PIPELINE>
+
+Order 5.  Module C<Pipelines>.  Label C<Pipeline Management>.
+
+=item C<GENESIS>
+
+Order 6.  Module C<Core>.  Label C<Genesis Management>.  This is the
+default function group for commands that do not specify one.
+
+=item C<UTILITY>
+
+Order -1.  Module C<Utility>.  Label C<Script Callback Helper>.
+
+=item C<DEPRECATED>
+
+Order -2.  Module C<Deprecated>.  Label C<Deprecated>.
+
+=item C<DEV>
+
+Order -3.  Module C<Core>.  Label C<Development>.
+
+=item C<WIP>
+
+Order -4.  Module C<Wip>.  Label C<Work in Progress>.
+
+=back
+
+Commands with a negative order are hidden from the default help output and
+only appear when C<--all> is passed.
+
+=head3 Option-Group Constants
+
+Each constant represents a tier of global options that the command opts
+into.  Higher tiers are supersets of lower ones.
+
+=over 4
+
+=item C<BLANK_OPTIONS> (0)
+
+No global options.  The command receives no pre-defined options from the
+global option set.
+
+=item C<BASE_OPTIONS> (1)
+
+Includes help flags (C<--help>, C<--help-full>, C<--helpful>, C<--globals>),
+logging and verbosity flags (C<--color>, C<--log>, C<--quiet>, C<--debug>,
+C<--trace>, C<--show-stack>).  This is the default for commands that do
+not specify C<option_group>.
+
+=item C<REPO_OPTIONS> (2)
+
+Extends C<BASE_OPTIONS> with C<--cwd|-C> (effective working directory).
+Appropriate for commands that operate on a Genesis deployment repository.
+
+=item C<ENV_OPTIONS> (3)
+
+Extends C<REPO_OPTIONS> with C<--bosh-env|-e>, C<--config|-c>, and
+C<--cpi>.  Appropriate for commands that target a specific environment and
+may interact with a BOSH director.
+
+=back
+
+=head1 FUNCTIONS
+
+=head2 define_command
+
+  define_command($name, \%props, $fn);
+  define_command($name, \%props);
+  define_command($name, $fn);
+  define_command($name);
+
+Registers a Genesis CLI command.  This is the primary entry point for
+adding commands to the dispatch table.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The canonical command name (e.g., C<'deploy'>).  Hyphens are acceptable
+and are translated to underscores when resolving the default function name.
+
+=item C<\%props>
+
+Optional hashref of command properties.  Recognized keys:
+
+=over 4
+
+=item C<summary> - One-line description shown in C<genesis --help> output.
+
+=item C<description> - Full description shown in command-specific help.
+
+=item C<usage> - Usage string shown in command-specific help.
+
+=item C<scope> - Execution context.  A string (C<'any'>, C<'env'>,
+C<'repo'>, C<'kit'>, C<'empty'>, C<'pipeline'>) or an arrayref of scope
+fragments for conditional scoping.  Defaults to C<'any'>.
+
+=item C<no_vault> - Boolean.  When true, sets C<GENESIS_NO_VAULT=1> in the
+environment before running the command.  Defaults to C<0>.
+
+=item C<function_group> - One of the function-group constants
+(C<ENVIRONMENT>, C<BOSH>, etc.).  Controls help grouping and default
+dispatch module resolution.  Defaults to C<GENESIS>.
+
+=item C<option_group> - One of the option-group constants
+(C<BLANK_OPTIONS>, C<BASE_OPTIONS>, C<REPO_OPTIONS>, C<ENV_OPTIONS>).
+Controls which global options are available.  Defaults to C<BASE_OPTIONS>.
+
+=item C<option_passthrough> - Boolean.  When true, unknown options are
+passed through to the command rather than causing an error.  Defaults to
+C<0>.
+
+=item C<option_require_order> - Boolean.  When true, option parsing stops
+at the first non-option argument.  Defaults to false.
+
+=item C<options> - Arrayref of Getopt::Long-style option specifications
+and their descriptions, interleaved: C<[$spec, $desc, $spec, $desc, ...]>.
+
+=item C<deprecated_options> - Arrayref of deprecated option specifications.
+
+=item C<arguments> - Arrayref of positional argument specifications and
+descriptions for help output.
+
+=item C<variables> - Arrayref of environment variable specifications and
+descriptions for help output.
+
+=item C<alias> - A single alias string for the command.
+
+=item C<aliases> - Arrayref of alias strings for the command.
+
+=item C<deprecated> - If set, the command is flagged as deprecated.  The
+value may be a replacement command name string to include in the warning.
+
+=item C<extended_usage> - A coderef returning extended usage text appended
+to command-specific help.
+
+=back
+
+=item C<$fn>
+
+Optional.  Either a coderef to call directly, or a fully qualified
+function name string (e.g., C<'Genesis::Commands::Env::deploy'>).  When
+omitted, the function name is derived from the C<function_group>'s module
+and the command name with hyphens replaced by underscores.
+
+=back
+
+B<Returns:> Nothing.
+
+B<Examples:>
+
+  # Minimal - function resolved from function_group module
+  define_command('status', {
+    summary        => 'Show environment status',
+    function_group => ENVIRONMENT,
+    scope          => 'env',
+  });
+  # Returns: (nothing)
+
+  # Explicit function name
+  define_command('my-cmd', {}, 'Genesis::Commands::Utility::my_cmd');
+  # Returns: (nothing)
+
+  # With an alias and option group
+  define_command('deploy', {
+    alias        => 'dep',
+    scope        => 'env',
+    option_group => ENV_OPTIONS,
+    options      => [
+      'dry-run|n' => 'Perform a dry run without deploying',
+    ],
+  });
+  # Returns: (nothing)
+
+=head2 commands
+
+  my @names = commands();
+
+Returns the ordered list of all registered canonical command names, in
+registration order.
+
+B<Returns:> A list of command name strings.
+
+B<Examples:>
+
+  my @cmds = commands();
+  # Returns: ('status', 'deploy', 'check', ...)
+
+=head2 current_command
+
+  my $name = current_command();
+
+Returns the canonical name of the currently active command as set by
+C<prepare_command>.  Returns C<undef> if no command has been prepared.
+
+B<Returns:> The canonical command name string, or C<undef>.
+
+B<Examples:>
+
+  my $cmd = current_command();
+  # Returns: 'deploy'
+
+=head2 current_command_alias
+
+  my $alias = current_command_alias();
+
+Returns the name the user actually invoked, which may be a registered
+alias rather than the canonical command name.  Set by C<prepare_command>.
+
+B<Returns:> The invoked command name or alias string, or C<undef>.
+
+B<Examples:>
+
+  # User typed: genesis dep
+  my $alias = current_command_alias();
+  # Returns: 'dep'
+
+=head2 known_commands
+
+  my @canonical = known_commands();
+
+Returns a list of the canonical command names -- those where the key equals
+the value in C<%GENESIS_COMMANDS>.  Aliases resolve to their canonical
+target and are excluded from this list.
+
+B<Returns:> A list of canonical command name strings.
+
+B<Examples:>
+
+  my @names = known_commands();
+  # Returns: ('status', 'deploy', 'check', ...)  -- aliases omitted
+
+=head2 prepare_command
+
+  prepare_command($called_name, @args);
+
+Sets up the active command by recording the invoked name, resolving it to
+the canonical command name, parsing command-line options from C<@args>,
+and configuring the logging subsystem.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$called_name>
+
+The command name as typed by the user (canonical or alias).
+
+=item C<@args>
+
+Remaining command-line arguments after the command name.
+
+=back
+
+B<Returns:> C<1> on success.
+
+B<Examples:>
+
+  prepare_command('dep', '--dry-run', 'my-env');
+  # Returns: 1
+  # Sets $COMMAND = 'deploy', $CALLED = 'dep'
+  # Parses --dry-run into %COMMAND_OPTIONS
+  # Remaining 'my-env' goes into @COMMAND_ARGS
+
+=head2 run_command
+
+  run_command();
+
+Dispatches execution to the closure registered for the current command.
+Prints a deprecation warning if the command has a C<deprecated> property,
+then calls the registered function with C<@COMMAND_ARGS> and exits with
+status 0 on success.
+
+If the current command has no registered handler, prints an error via
+C<command_help> and exits with status 1.
+
+B<Returns:> Does not return -- calls C<exit 0> on success.
+
+B<Examples:>
+
+  prepare_command('deploy', 'my-env');
+  run_command();
+  # Calls Genesis::Commands::Env::deploy('my-env') and exits 0
+
+=head2 has_command
+
+  my $bool = has_command($cmd);
+
+Returns true if C<$cmd> is a known command or alias, false otherwise.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$cmd>
+
+Command name or alias to look up.
+
+=back
+
+B<Returns:> C<1> if found, empty string (C<''>) otherwise.
+
+B<Examples:>
+
+  has_command('deploy');
+  # Returns: 1 (if registered)
+
+  has_command('dep');
+  # Returns: 1 (aliases also match)
+
+  has_command('nosuchcmd');
+  # Returns: '' (empty string)
+
+=head2 is_equivalent_command
+
+  my $bool = is_equivalent_command($cmd1, $cmd2);
+
+Returns true if both C<$cmd1> and C<$cmd2> resolve to the same canonical
+command name.  Useful for checking whether an alias or alternate spelling
+refers to the same command.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$cmd1>
+
+First command name or alias.
+
+=item C<$cmd2>
+
+Second command name or alias.
+
+=back
+
+B<Returns:> C<1> if equivalent, empty string otherwise.
+
+B<Examples:>
+
+  is_equivalent_command('dep', 'deploy');
+  # Returns: 1  (if 'dep' is an alias for 'deploy')
+
+  is_equivalent_command('deploy', 'check');
+  # Returns: ''
+
+=head2 equivalent_commands
+
+  my @names = equivalent_commands($cmd);
+  my $aref  = equivalent_commands($cmd);
+
+Returns all names (canonical and aliases) that resolve to the same
+canonical command as C<$cmd>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$cmd>
+
+Any command name or alias.
+
+=back
+
+B<Returns:> In list context, a list of all equivalent names.  In scalar
+context, an arrayref of the same names.  Returns an empty list (or empty
+arrayref) if C<$cmd> is not a known command.
+
+B<Examples:>
+
+  my @all = equivalent_commands('dep');
+  # Returns: ('deploy', 'dep')  -- all names that map to the same command
+
+  my $ref = equivalent_commands('unknown');
+  # Returns: []
+
+=head2 command_properties
+
+  my $props = command_properties();
+  my $props = command_properties($name);
+
+Returns the properties hashref for a command.  When called with no
+argument (or with an empty string), returns the properties for the
+currently active command.  When called with a command name or alias,
+resolves it and returns that command's properties.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Optional.  A command name or alias.  Defaults to the active command.
+
+=back
+
+B<Returns:> A hashref of command properties as registered by
+C<define_command>.
+
+B<Errors:>
+
+=over 4
+
+=item C<"No active or given command -- cannot return command_properties">
+
+Thrown via C<bug()> if no command name is given and no command is
+currently active.
+
+=back
+
+B<Examples:>
+
+  my $props = command_properties();
+  # Returns: { summary => '...', scope => 'env', ... }
+
+  my $props = command_properties('deploy');
+  # Returns: { summary => '...', scope => 'env', ... }
+
+=head2 get_options
+
+  my $href = get_options();
+  my $href = get_options(@keys);
+
+Returns parsed command options from the current command invocation.
+
+When called with no arguments, returns the entire options hashref.  When
+called with a list of key names, returns a hashref containing only those
+keys that were actually set.  Key names containing underscores are also
+tried with underscores converted to dashes (the internal storage format
+used by Getopt::Long).
+
+B<Parameters:>
+
+=over 4
+
+=item C<@keys>
+
+Optional list of option key names to select.
+
+=back
+
+B<Returns:> A hashref of option name-to-value pairs.
+
+B<Examples:>
+
+  # All options
+  my $opts = get_options();
+  # Returns: { 'dry-run' => 1, format => 'json', ... }
+
+  # Selected keys
+  my $opts = get_options('dry-run', 'format');
+  # Returns: { 'dry-run' => 1, format => 'json' }
+
+  # Underscore-to-dash fallback
+  my $opts = get_options('dry_run');
+  # Returns: { dry_run => 1 }  -- equivalent to get_options('dry-run')
+
+=head2 get_args
+
+  my @args = get_args();
+
+Returns the list of positional arguments remaining after option parsing.
+
+B<Returns:> In list context, the list of argument strings from
+C<@COMMAND_ARGS>.  Scalar context is not yet implemented and will throw an
+error.
+
+B<Errors:>
+
+=over 4
+
+=item C<"hashref not yet implemented">
+
+Thrown when called in scalar context.
+
+=back
+
+B<Examples:>
+
+  prepare_command('deploy', '--dry-run', 'my-env', 'other-arg');
+  my @args = get_args();
+  # Returns: ('my-env', 'other-arg')
+
+=head2 has_option
+
+  my $bool = has_option($option);
+  my $bool = has_option($option, $test);
+
+Tests whether a specific option was set, optionally comparing its value
+to a test expression.
+
+When called with only C<$option>, returns C<1> if the option key exists in
+the parsed options hash, C<0> otherwise.
+
+When called with C<$option> and C<$test>:
+
+=over 4
+
+=item If C<$test> is C<undef>, returns true only if the option value is also C<undef>.
+
+=item If C<$test> is a C<Regexp> object, returns C<1> if the option value matches, C<0> otherwise.
+
+=item If C<$test> is any other scalar, returns C<1> if the option value equals C<$test> as a string, C<0> otherwise.
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item C<$option>
+
+The option key name to test.
+
+=item C<$test>
+
+Optional.  C<undef>, a string, or a compiled regexp (C<qr/.../>).
+
+=back
+
+B<Returns:> C<1> or C<0>.
+
+B<Examples:>
+
+  has_option('dry-run');
+  # Returns: 1  (if --dry-run was passed)
+
+  has_option('format', 'json');
+  # Returns: 1  (if --format=json)
+
+  has_option('format', qr/^js/);
+  # Returns: 1  (if format starts with 'js')
+
+  has_option('format', undef);
+  # Returns: 1  (if --format was not given a value)
+
+=head2 option_defaults
+
+  option_defaults(%defaults);
+  option_defaults(key => $value, key2 => $value2);
+
+Sets default values for options that have not yet been assigned a value.
+For each key-value pair in C<%defaults>, if the option key is not already
+defined in the parsed options, it is set to the given value.  Existing
+values are not overwritten.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%defaults>
+
+A flat list of key-value pairs.
+
+=back
+
+B<Returns:> Nothing.
+
+B<Examples:>
+
+  option_defaults(format => 'table', verbose => 0);
+  # Sets 'format' to 'table' only if not already set
+  # Returns: (nothing)
+
+=head2 append_options
+
+  my $href = append_options(%extra);
+
+Merges additional key-value pairs into the parsed options hash, overwriting
+any existing values for those keys.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%extra>
+
+A flat list of key-value pairs to add or overwrite.
+
+=back
+
+B<Returns:> The options hashref (C<$COMMAND_OPTIONS>) after merging.
+
+B<Examples:>
+
+  my $opts = append_options(injected => 1, source => 'internal');
+  # Returns: { injected => 1, source => 'internal', ... }
+
+=head2 command_help
+
+  command_help();
+  command_help($msg);
+  command_help($msg, $rc);
+
+Displays the global Genesis help screen listing all registered commands
+grouped by function area, then exits.
+
+When C<$msg> is provided, it is printed as a fatal error message before
+exiting with the given return code (default C<1>).  When C<$msg> is
+omitted, the help screen is shown and the process exits with code C<0>.
+
+Commands with a function group of negative order (C<DEPRECATED>, C<DEV>,
+C<WIP>, C<UTILITY>) are hidden unless C<--all> was passed as an option.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$msg>
+
+Optional error message to display before exiting.
+
+=item C<$rc>
+
+Optional exit code.  Defaults to C<1> if C<$msg> is set, C<0> otherwise.
+
+=back
+
+B<Returns:> Does not return -- always calls C<exit>.
+
+B<Examples:>
+
+  # Show help and exit 0
+  command_help();
+  # prints: full command listing grouped by function area, then exits 0
+
+  # Show an error message and exit 1
+  command_help("Unrecognized command 'frobnicate'");
+  # prints: error message, then exits 1
+
+  # Show an error with a specific exit code
+  command_help("Bad argument", 2);
+  # prints: error message, then exits 2
+
+=head2 command_usage
+
+  command_usage($rc, $msg, $show_global);
+
+Displays the usage screen for the current command, then exits.
+
+The usage screen includes the command summary, usage line(s), an alias
+note if the command was called by an alias, the full description, and
+sections for arguments, environment variables, options, and optionally
+global options.
+
+When C<$rc> is non-zero and the process is not under test, prints a brief
+usage hint and a fatal error message before exiting.
+
+When C<$rc> is zero, the full usage screen including description and option
+listings is shown.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$rc>
+
+Exit code.  Non-zero triggers error output mode.
+
+=item C<$msg>
+
+Optional error message.  When C<undef> and C<$rc> is non-zero, defaults
+to a message showing how the command was called.
+
+=item C<$show_global>
+
+Optional boolean.  When true, global options are appended to the output.
+When defined and false, a note is added directing users to C<--help-full>.
+When C<undef>, global options are shown if C<--help> was passed.
+
+=back
+
+B<Returns:> Does not return -- always calls C<exit>.
+
+B<Errors:>
+
+=over 4
+
+=item C<"E<lt>typeE<gt> definition for E<lt>commandE<gt> invalid: E<lt>specE<gt>">
+
+Thrown via C<bug()> if a registered option or argument specification
+cannot be parsed.
+
+=back
+
+B<Examples:>
+
+  # Show full usage and exit 0
+  command_usage(0);
+  # prints: full usage screen with description and options, then exits 0
+
+  # Show brief usage and error, then exit 1
+  command_usage(1, "missing required argument");
+  # prints: brief usage hint and error message, then exits 1
+
+  # Show usage with global options included
+  command_usage(0, undef, 1);
+  # prints: full usage screen including global options, then exits 0
+
+=head2 show_global_options
+
+  show_global_options();
+
+Displays the global options screen -- a listing of all options available to
+every Genesis command regardless of the specific command -- then exits with
+status 0.
+
+B<Returns:> Does not return -- always calls C<exit 0>.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Global option definition invalid: E<lt>specE<gt>">
+
+Thrown via C<bug()> if a global option specification cannot be parsed.
+
+=back
+
+B<Examples:>
+
+  # Triggered by: genesis --globals
+  show_global_options();
+  # prints: global options screen, then exits 0
+
+=head2 set_top_path
+
+  my $changed = set_top_path();
+
+Inspects C<@COMMAND_ARGS> and C<$COMMAND_OPTIONS{cwd}> to determine the
+effective working directory, then changes into it via C<chdir_or_fail>.
+
+If no C<--cwd> was given but the first positional argument looks like an
+environment file path (for C<env>-scoped commands) or a directory prefix
+(for the C<create> command), that argument is removed from C<@COMMAND_ARGS>
+and used as the target directory.
+
+If a C<--cwd> was given and it names a file rather than a directory,
+behavior depends on the command scope: for C<env>-scoped commands, the
+basename is prepended back into C<@COMMAND_ARGS> and the dirname is used as
+the working directory; for C<repo>-scoped commands running in search-target
+mode, the dirname is used silently; otherwise an error is raised.
+
+B<Returns:> C<1> if the working directory was changed, C<undef> if no
+change was needed.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Path '%s' specified in -C option does not exist">
+
+Thrown via C<bail()> when the path given via C<--cwd|-C> cannot be resolved
+to an absolute path.  C<%s> is the path as given by the user.
+
+=item C<"#B{%s %s} cannot be called specifying a file as an argument">
+
+Thrown via C<bail()> when a file path is given to a command that does not
+accept file arguments (non-C<env> scope, non-search-target mode).  The
+first C<%s> is the humanized binary name, the second is the command alias.
+
+=back
+
+B<Examples:>
+
+  # After: genesis deploy my-env.yml
+  # @COMMAND_ARGS = ('my-env.yml')
+  set_top_path();
+  # Returns: 1
+  # Chdir to dirname(my-env.yml); @COMMAND_ARGS = ('my-env')
+
+=head2 build_command_environment
+
+  build_command_environment();
+
+Translates parsed command options into environment variables and finalizes
+options consumed by the environment setup layer.  Specifically:
+
+=over 4
+
+=item Processes C<--spruce-log> into C<$ENV{DEBUG}> and C<$ENV{TRACE}>.
+
+=item Sets C<$ENV{GENESIS_EXECUTABLE_ENVS}> from the RC configuration.
+
+=item Moves C<--bosh-env> into C<$ENV{GENESIS_BOSH_ENVIRONMENT}>.
+
+=item Moves C<--cpi> into C<$ENV{GENESIS_TESTING_BOSH_CPI}>.
+
+=item Expands each C<--config> entry into a typed environment variable
+(e.g., C<GENESIS_CLOUD_CONFIG> or C<GENESIS_RUNTIME_CONFIG_myname>).
+
+=back
+
+B<Returns:> Nothing.
+
+B<Errors:>
+
+=over 4
+
+=item C<"--spruce-log is expected to be one of TRACE or DEBUG">
+
+Thrown via C<bail()> when the C<--spruce-log> value does not match C<debug>
+or C<trace> (case-insensitive prefix match).
+
+=item C<"$path: no such file or directory">
+
+Thrown via C<bail()> when a C<--config> path cannot be resolved to an
+absolute path.
+
+=back
+
+B<Examples:>
+
+  # After: genesis deploy my-env --bosh-env c-aws-myenv
+  build_command_environment();
+  # Returns: (nothing)
+  # Sets: $ENV{GENESIS_BOSH_ENVIRONMENT} = 'c-aws-myenv'
+
+=head2 has_scope
+
+  my $bool = has_scope(@scopes);
+
+Returns true if any of the requested C<@scopes> apply to the current
+command given its registered scope specification and current option values.
+
+The command's C<scope> property (set in C<define_command>) may be a simple
+string or an arrayref of scope fragments.  Simple string scopes are matched
+directly.  Array scope fragments allow conditional scoping based on the
+current parsed options: each fragment is a two-element arrayref of
+C<[$conditions, $scopes]>, where conditions are option expressions
+(C<opt_name>, C<!opt_name>, C<opt_name=value>, C<!opt_name=value>) and
+scopes is a string or arrayref of scope names.  The first matching
+fragment determines the active scopes.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@scopes>
+
+One or more scope name strings to test.  Valid values are C<'env'>,
+C<'repo'>, C<'kit'>, C<'empty'>, C<'pipeline'>, and C<'any'>.
+
+=back
+
+B<Returns:> C<1> if any requested scope matches, C<undef> otherwise.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Incorrectly defined scope for command $COMMAND">
+
+Thrown via C<bug()> when an array scope fragment does not have exactly
+two elements.
+
+=back
+
+B<Examples:>
+
+  # In a command registered with scope => 'env'
+  has_scope('env');
+  # Returns: 1
+
+  has_scope('repo');
+  # Returns: undef
+
+  # In a command registered with scope => 'any'
+  has_scope('pipeline');
+  # Returns: undef  ('any' excludes pipeline)
+
+=head2 check_embedded_genesis
+
+  check_embedded_genesis();
+
+Checks whether the current deployment repository contains an embedded
+Genesis binary at C<.genesis/bin/genesis> and, if so, compares its version
+to the running version.
+
+If the embedded version differs from the running version, behavior depends
+on the C<embedded_genesis> RC setting:
+
+=over 4
+
+=item C<'ignore'> - The check is skipped entirely.
+
+=item C<'warn'> (or no C<use> setting) - A warning is printed but execution continues.
+
+=item C<'use'> (and the command does not set C<no_use_embedded_genesis>) -
+The embedded genesis is extracted from the archive and re-executed,
+replacing the current process.
+
+=back
+
+The check is skipped entirely when:
+
+=over 4
+
+=item The C<GENESIS_IS_HELPING_YOU> environment variable is set.
+
+=item The RC setting is C<'ignore'>.
+
+=item The current command is not repo- or env-scoped.
+
+=item No embedded genesis file exists.
+
+=item C<GENESIS_USING_EMBEDDED> is already set (prevents recursive invocation).
+
+=item The embedded binary path matches C<$GENESIS_CALLBACK_BIN>.
+
+=item The embedded version equals the running version.
+
+=back
+
+B<Returns:> Nothing, or does not return if the embedded genesis is re-executed.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Could not use extract embedded Genesis">
+
+Thrown via C<bail()> if the embedded genesis archive cannot be extracted.
+
+=back
+
+B<Examples:>
+
+  check_embedded_genesis();
+  # Returns: (nothing)  -- if versions match or check is skipped
+  # Or: prints a warning and returns  -- version mismatch, warn mode
+  # Or: (does not return)  -- re-execs embedded binary in use mode
+
+=head2 check_prereqs
+
+  check_prereqs();
+
+Validates that all external tools required by Genesis are installed and
+meet minimum version requirements.  Also checks required Perl modules and
+enforces directory scope constraints for the current command.
+
+Checks the following external tools:
+
+=over 4
+
+=item perl E<gt>= 5.20.0
+
+=item curl E<gt>= 7.30.0
+
+=item git E<gt>= 1.8.0
+
+=item jq E<gt>= 1.6
+
+=item spruce E<gt>= 1.28.0
+
+=item safe E<gt>= 1.6.1
+
+=item vault E<gt>= 0.9.0
+
+=item openssl E<gt>= 1.1.1
+
+=item credhub E<gt>= 2.7.0
+
+=item bosh E<gt>= 6.4.4
+
+=back
+
+Checks the following Perl modules:
+
+=over 4
+
+=item MIME::Base64 E<gt>= 3.14
+
+=item IO::Uncompress::Gunzip E<gt>= 2.064
+
+=item IO::Compress::Gzip E<gt>= 2.064
+
+=item Archive::Tar E<gt>= 1.96
+
+=back
+
+After version checks, enforces directory scope:
+
+=over 4
+
+=item Commands with C<repo> or C<env> scope must be run in a Genesis deployment repo.
+
+=item Commands with C<kit> scope must be run in a Genesis kit repo.
+
+=item Commands with C<kit_or_dev> scope must be in a kit repo or a deployment repo with a C<dev/> directory.
+
+=item Commands with C<empty> scope must NOT be in a deployment or kit repo.
+
+=back
+
+The check runs at most once per process (tracked with a static variable).
+It is skipped entirely when C<GENESIS_IS_HELPING_YOU> is set.
+
+B<Returns:> C<1> if prerequisites pass.
+
+B<Errors:>
+
+=over 4
+
+=item C<"check_prereqs called before command selected">
+
+Thrown via C<bug()> if called before C<prepare_command> has been called.
+
+=item C<"#R{GENESIS PRE-REQUISITES CHECKS FAILED!!}\nEncountered the following errors:\n...">
+
+Thrown via C<bail()> if any prerequisite check fails.  The message lists
+all failures encountered.
+
+=back
+
+B<Examples:>
+
+  prepare_command('deploy', @args);
+  check_prereqs();
+  # Returns: 1  (all prerequisites met)
+  run_command();
+
+=head2 at_exit
+
+  at_exit($fn);
+
+Registers a callback to be invoked when the Perl interpreter exits (via the
+C<END> block).  Each registered callback receives the current exit status
+C<$?> as its sole argument.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$fn>
+
+A coderef to call at exit time.
+
+=back
+
+B<Returns:> Nothing.
+
+B<Examples:>
+
+  at_exit(sub {
+    my $status = shift;
+    cleanup_tempfiles() if $status == 0;
+  });
+  # Returns: (nothing)
+
+=head1 INTERNAL FUNCTIONS
+
+These functions are internal to the implementation.  They may change
+without notice and should not be called directly.
+
+=head2 parse_options
+
+  parse_options(\@args);
+
+Parses command-line options from C<\@args> using Getopt::Long.
+Populates C<$COMMAND_OPTIONS> with the parsed option values and
+C<@COMMAND_ARGS> with the remaining positional arguments.  Removes
+consumed items from the referenced array.
+
+Constructs the option specification from the global options up to the
+command's C<option_group> level, plus the command's own C<options> and
+C<deprecated_options>.  If the command's C<option_group> is below
+C<REPO_OPTIONS>, injects a no-op C<cwd|C> spec to silently absorb any
+C<-C> injected by the genesis helper wrapper.
+
+Applies Getopt::Long configuration flags based on the command's
+C<option_passthrough> and C<option_require_order> properties.
+
+On parse failure, calls C<command_usage(1, ...)> with the error messages.
+
+Extracts and side-effects two options from the parsed hash before
+returning:
+
+=over 4
+
+=item C<color> - Sets C<$ENV{NOCOLOR}> if false; removed from options hash.
+
+=item C<quiet> - Sets C<$ENV{QUIET}> if true; removed from options hash.
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item C<\@args>
+
+Arrayref of raw command-line strings to parse.  Modified in place.
+
+=back
+
+B<Returns:> Nothing.
+
+B<Examples:>
+
+  my @argv = ('--dry-run', 'my-env');
+  parse_options(\@argv);
+  # Returns: (nothing)
+  # $COMMAND_OPTIONS{dry-run} = 1; @COMMAND_ARGS = ('my-env')
+
+=head2 set_logging_state
+
+  set_logging_state();
+
+Reads logging-related options (C<--log>, C<--debug>, C<--trace>,
+C<--show-stack>) from C<$COMMAND_OPTIONS>, removes them, and configures
+the C<$Logger> singleton via C<configure_log>.
+
+The resolved log level is determined in this priority order:
+
+=over 4
+
+=item C<--log> value (if set), warns if C<--debug> or C<--trace> also given.
+
+=item C<--trace> maps to C<TRACE>.
+
+=item C<--debug> maps to C<DEBUG>.
+
+=item Default is C<INFO>.
+
+=back
+
+Sets C<$ENV{GENESIS_DEBUG}> and C<$ENV{GENESIS_TRACE}> when the resolved
+level meets or exceeds C<DEBUG> or C<TRACE> respectively.
+
+B<Returns:> Nothing.
+
+=head2 check_version
+
+  my $err = check_version($name, $min, $cmd, $regex, $url, $path_src);
+  my $err = check_version($name, $min, '', $version, $path, $url);
+
+Checks whether a tool meets a minimum version requirement.
+
+When C<$cmd> is provided (non-empty string), runs it to obtain a version
+string, extracts the version with C<$regex>, and finds the tool path
+with C<type -p>.  When C<$cmd> is empty, uses the pre-supplied
+C<$version> and C<$path>.
+
+In development mode (C<GENESIS_DEV_MODE> set) a version string containing
+C<'development'> is accepted unconditionally.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Human-readable tool name (e.g., C<'curl'>).
+
+=item C<$min>
+
+Minimum acceptable version string (e.g., C<'7.30.0'>).
+
+=item C<$cmd>
+
+Shell command to run to get the version output, or empty string.
+
+=item C<@remainder>
+
+When C<$cmd> is non-empty: C<($regex, $url, $path_src)>.
+
+When C<$cmd> is empty: C<($version, $path, $url)>.
+
+=back
+
+B<Returns:> C<undef> on success, or an error message string on failure.
+
+B<Examples:>
+
+  my $err = check_version('curl', '7.30.0',
+    'curl --version 2>/dev/null | head -n1',
+    qr(^curl\s+(\S+)));
+  # Returns: undef  (if curl meets the minimum version)
+  # Returns: "curl v7.29.0 is installed at /usr/bin/curl, ..."  (if too old)
+
+=head1 SEE ALSO
+
+L<Genesis>, L<Genesis::State>, L<Genesis::Log>, L<Genesis::Top>,
+L<Genesis::Commands::Env>, L<Genesis::Commands::Bosh>,
+L<Genesis::Commands::Info>, L<Genesis::Commands::Kit>,
+L<Genesis::Commands::Repo>, L<Genesis::Commands::Pipelines>,
+L<Genesis::Commands::Core>
+
+=head1 AUTHOR
+
+FiveTwenty, LLC
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Commands/Bosh.pod
+++ b/lib/Genesis/Commands/Bosh.pod
@@ -1,0 +1,579 @@
+=encoding utf8
+
+=head1 NAME
+
+Genesis::Commands::Bosh - Command handlers for Genesis BOSH director interaction
+
+=head1 SYNOPSIS
+
+  # Registered in bin/genesis via define_command:
+  genesis <env> bosh [--connect] [bosh-args...]
+  genesis <env> credhub [--raw] <cmd> [credhub-args...]
+  genesis <env> logs [extra-args...]
+  genesis <env> broadcast [--on <instance>] <cmd> [extra-args...]
+  genesis <env> bosh-configs [upload|list|view|compare|delete|summary]
+
+  # In Perl (dispatch layer):
+  use Genesis::Commands::Bosh;
+  Genesis::Commands::Bosh::bosh($env_name, @bosh_args);
+  Genesis::Commands::Bosh::credhub($env_name, $cmd, @args);
+  Genesis::Commands::Bosh::logs($env_name, @extra_args);
+  Genesis::Commands::Bosh::broadcast($env_name, @extra_args);
+  Genesis::Commands::Bosh::bosh_configs($env_name, $action, @extra_args);
+
+=head1 DESCRIPTION
+
+Provides command handler functions for all BOSH-director-related Genesis CLI
+commands.  Each function in this module corresponds to a top-level Genesis CLI
+subcommand and is registered via C<define_command> in the Genesis binary.
+
+The module covers direct BOSH CLI passthrough (C<bosh>), CredHub CLI
+passthrough with Genesis-managed authentication (C<credhub>), VM log retrieval
+(C<logs>), multi-instance SSH broadcast (C<broadcast>), and BOSH config
+management (C<bosh-configs>).
+
+All functions load the named environment from the current directory's Genesis
+top-level and connect to Vault before performing their work.
+
+=head1 FUNCTIONS
+
+=head2 bosh($env_name, @bosh_args)
+
+Entry point for the C<genesis E<lt>envE<gt> bosh> command.  Wraps the C<bosh>
+CLI, routing through the environment's target BOSH director with all
+authentication already configured.
+
+Supports two modes of operation:
+
+=over 4
+
+=item Normal passthrough mode
+
+Executes C<bosh @bosh_args> interactively against the environment's BOSH
+director.  Exit code propagates directly to the shell.
+
+=item C<--connect> mode
+
+When the C<--connect> flag is passed, outputs shell C<export> statements for
+the BOSH environment variables so they can be applied to the current shell via
+C<eval>.  This mode must be invoked as:
+
+  eval "$(genesis <env> bosh --connect)"
+
+If C<--connect> is used but the command is running in a controlling terminal
+(i.e., not under C<eval>), an error is printed explaining the required
+invocation and the process exits with status 1.
+
+=back
+
+Output is automatically redacted when stdout is not a TTY.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env_name>
+
+The Genesis environment name.  Used to load and connect to the environment's
+configured BOSH director.
+
+=item C<@bosh_args>
+
+Arguments passed through verbatim to the C<bosh> CLI.  At least one argument
+is required; the function calls C<command_usage(1)> if C<@_> is empty.
+
+=back
+
+B<Returns:> Does not return.  Calls C<exit> with the BOSH command's exit code,
+or C<exit 0> after exporting environment variables in C<--connect> mode.
+
+B<Examples:>
+
+  # Run 'bosh deployments' for a given environment
+  # prints the BOSH director's deployment list to stdout
+  genesis my-env bosh deployments
+
+  # Set BOSH env vars in the current shell
+  eval "$(genesis my-env bosh --connect)"
+  # Returns: shell export statements applied to current environment
+
+=head2 credhub($env_name, $cmd, @args)
+
+Entry point for the C<genesis E<lt>envE<gt> credhub> command.  Executes a
+C<credhub> CLI command against the CredHub instance associated with the
+environment's BOSH director, using Genesis-managed authentication.
+
+Relative credential names (those not beginning with C</>) are automatically
+prefixed with the environment's CredHub base path, so that users do not need
+to specify full paths for commands that accept C<--name> or C<--path>/C<--prefix>
+options.  This path expansion is skipped when C<--raw> is passed.
+
+The following CredHub subcommands are blocked because Genesis manages
+authentication internally: C<login> (C<l>), C<api> (C<a>), C<logout> (C<o>).
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env_name>
+
+The Genesis environment name.  Used to load the environment and determine the
+target CredHub instance.  At least one argument (the environment name) is
+required; the function calls C<command_usage(1)> if C<@_> is empty.
+
+=item C<$cmd>
+
+The CredHub subcommand to execute (e.g., C<get>, C<set>, C<find>, C<export>).
+
+=item C<@args>
+
+Additional arguments passed to C<credhub $cmd>.  Relative C<--name> and
+C<--path>/C<--prefix> values are automatically expanded to full CredHub paths
+unless C<--raw> is active.
+
+=back
+
+B<Options> (read from parsed command-line flags):
+
+=over 4
+
+=item C<--raw>
+
+Skips automatic base-path expansion for C<--name>/C<--path>/C<--prefix> values.
+Credential paths are passed to CredHub exactly as provided.
+
+=back
+
+B<Errors:>
+
+=over 4
+
+=item C<"Command #C{genesis credhub %s} is not allowed in when Genesis is managing authentication to CredHub">
+
+Raised (via C<bail()>) when C<$cmd> is one of C<login>, C<api>, or C<logout>
+(or their single-letter aliases C<l>, C<a>, C<o>).  The C<%s> placeholder is
+the disallowed command name.
+
+=back
+
+B<Returns:> Does not return.  Calls C<exit> with the CredHub command's exit
+code.
+
+B<Examples:>
+
+  # Retrieve a credential using a relative name (auto-prefixed to base path)
+  # Returns: credential details printed to stdout by the credhub CLI
+  genesis my-env credhub get --name /my-credential
+
+  # Find all credentials under the environment's base path
+  # Returns: list of matching credential paths printed to stdout
+  genesis my-env credhub find
+
+  # Pass a fully-qualified path without auto-prefixing
+  # Returns: credential details printed to stdout
+  genesis my-env credhub --raw get --name /absolute/path/to/credential
+
+=head2 logs($env_name, @extra_args)
+
+Entry point for the C<genesis E<lt>envE<gt> logs> command.  Retrieves BOSH
+logs for the environment by delegating to C<< $env->bosh_logs >>.
+
+Not available for environments deployed with C<create-env>, since those
+environments do not have a separate BOSH director to query for logs.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env_name>
+
+The Genesis environment name.
+
+=item C<@extra_args>
+
+Additional arguments forwarded to C<< $env->bosh_logs >>.
+
+=back
+
+B<Errors:>
+
+=over 4
+
+=item C<"No bosh logs for environments deployed with #M{create-env}">
+
+Raised (via C<bail()>) when the environment is a C<create-env> environment.
+
+=back
+
+B<Returns:> Nothing.  Log output is displayed directly by C<< $env->bosh_logs >>.
+
+B<Examples:>
+
+  # Fetch BOSH logs for an environment
+  # Returns: list of BOSH log entries
+  genesis my-env logs
+
+=head2 broadcast($env_name, @extra_args)
+
+Entry point for the C<genesis E<lt>envE<gt> broadcast> command.  Runs an
+arbitrary command on one or more BOSH VMs by SSHing to each matching instance
+in sequence.
+
+Fetches the full VM list from the BOSH director (C<bosh vms --json>) and
+matches it against the C<--on> filter option.  If no filter is provided, the
+command is broadcast to all VMs in the deployment.  Each matching instance is
+targeted individually via C<bosh ssh>.
+
+Target matching rules:
+
+=over 4
+
+=item *
+
+If the target string contains a C</>, it is matched as an exact instance ID
+(e.g., C<web/0>).
+
+=item *
+
+Otherwise it is matched as an instance type prefix (e.g., C<web> matches
+C<web/0>, C<web/1>, etc.).
+
+=back
+
+Duplicate targets (after resolution) are de-duplicated with C<uniq> before
+SSH execution.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env_name>
+
+The Genesis environment name.
+
+=item C<@extra_args>
+
+The command and its arguments to execute on each target VM via C<bosh ssh>.
+
+=back
+
+B<Options> (read from parsed command-line flags):
+
+=over 4
+
+=item C<on>
+
+An arrayref of target instance specifiers.  Each entry may be an instance type
+(e.g., C<web>) or a fully qualified instance ID (e.g., C<web/0>).  Defaults to
+all VMs in the deployment when not specified.
+
+=back
+
+B<Errors:>
+
+=over 4
+
+=item C<"Failed to fetch VM list: %s">
+
+Raised (via C<bail()>) when the C<bosh vms --json> call fails.  The C<%s>
+placeholder contains the error output from the BOSH CLI.
+
+=item C<"Failed to parse VM list: %s">
+
+Raised (via C<bail()>) when the JSON response from C<bosh vms> cannot be
+parsed.  The C<%s> placeholder contains the Perl C<eval> error string.
+
+=item C<"Errors were encountered while determining broadcast targets:\n%s">
+
+Raised (via C<bail()>) when one or more entries in the C<--on> filter did not
+match any running instance.  The C<%s> placeholder is a newline-joined list of
+per-target error messages.
+
+=back
+
+B<Returns:> Returns after all instances have been targeted.  Individual SSH
+failures are reported via the C<error> function but do not abort the broadcast
+loop.
+
+B<Examples:>
+
+  # Broadcast a command to all VMs in the environment
+  # prints uptime output from each VM separated by dividers
+  genesis my-env broadcast -- uptime
+
+  # Broadcast only to web instances
+  # prints df output from each web/* instance
+  genesis my-env broadcast --on web -- df -h
+
+  # Broadcast to a specific instance
+  # prints syslog output from web/0
+  genesis my-env broadcast --on web/0 -- cat /var/log/syslog
+
+=head2 bosh_configs($env_name, $action, @extra_args)
+
+Entry point for the C<genesis E<lt>envE<gt> bosh-configs> command.  Dispatches
+to one of the C<bosh_configs_*> sub-action functions based on C<$action>.
+
+Valid actions are: C<upload>, C<list>, C<view>, C<compare>, C<delete>,
+C<summary>.  The default action (when C<$action> is omitted) is C<upload>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env_name>
+
+The Genesis environment name.
+
+=item C<$action>
+
+One of C<upload>, C<list>, C<view>, C<compare>, C<delete>, C<summary>.
+Defaults to C<upload> when not supplied.
+
+=item C<@extra_args>
+
+No extra arguments are currently accepted.  The function calls C<bail()> if
+any are provided.
+
+=back
+
+B<Errors:>
+
+=over 4
+
+=item C<"Invalid action: %s - expected one of: %s (leave blank for 'upload')">
+
+Raised (via C<bail()>) when C<$action> is not one of the valid action strings.
+The first C<%s> is the supplied action; the second is the list of valid actions.
+
+=item C<"Too many arguments provided">
+
+Raised (via C<bail()>) when C<@extra_args> is non-empty.
+
+=back
+
+B<Returns:> Returns the result of the dispatched sub-action function.
+
+B<Examples:>
+
+  # Upload BOSH configs for an environment (default action)
+  # Returns: result from bosh_configs_upload
+  genesis my-env bosh-configs
+
+  # List current BOSH configs on the director
+  # Returns: result from bosh_configs_list
+  genesis my-env bosh-configs list
+
+  # Show a summary of environment and director configs
+  # Returns: result from bosh_configs_summary
+  genesis my-env bosh-configs summary
+
+=head1 INTERNAL FUNCTIONS
+
+These functions are internal to the implementation.  They are dispatched by
+C<bosh_configs()> and should not be called directly.
+
+=head2 bosh_configs_summary($env, $bosh, %options)
+
+Displays a summary of BOSH configs provided by the environment or kit and
+their status on the director.  Intended to show which configs are present
+locally (cloud-config, runtime-config hooks), which are provided by the
+director itself, and which director configs are not kit-managed.
+
+This function is a partial implementation.  It retrieves environment config
+names and runs the C<cloud-config> hook but does not yet produce output.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env>
+
+A C<Genesis::Env> object for the target environment.
+
+=item C<$bosh>
+
+A BOSH service object for the target director.
+
+=item C<%options>
+
+Parsed command-line options hash.
+
+=back
+
+B<Returns:> Returns nothing (C<undef>) in its current partial state.
+
+B<Examples:>
+
+  # Dispatched internally by bosh_configs():
+  # Returns: undef (partial implementation)
+  bosh_configs_summary($env, $bosh, %options);
+
+=head2 bosh_configs_upload($env, $bosh, %options)
+
+Stub -- not yet implemented.  Intended to upload BOSH configs from the
+environment to the director.  Currently prints a diagnostic message and
+returns C<1>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env>
+
+A C<Genesis::Env> object.
+
+=item C<$bosh>
+
+A BOSH service object.
+
+=item C<%options>
+
+Parsed command-line options hash.
+
+=back
+
+B<Returns:> Returns C<1> (stub return value).
+
+B<Examples:>
+
+  # Dispatched internally by bosh_configs():
+  # Returns: 1
+  bosh_configs_upload($env, $bosh, %options);
+
+=head2 bosh_configs_list($env, $bosh, %options)
+
+Stub -- not yet implemented.  Intended to list BOSH configs on the director.
+Currently prints a diagnostic message and invokes an interactive Pry debugger
+session before returning C<1>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env>
+
+A C<Genesis::Env> object.
+
+=item C<$bosh>
+
+A BOSH service object.
+
+=item C<%options>
+
+Parsed command-line options hash.
+
+=back
+
+B<Returns:> Returns C<1> (stub return value).
+
+B<Examples:>
+
+  # Dispatched internally by bosh_configs():
+  # Returns: 1
+  bosh_configs_list($env, $bosh, %options);
+
+=head2 bosh_configs_view($env, $bosh, %options)
+
+Stub -- not yet implemented.  Intended to display the content of a specific
+BOSH config.  Currently prints a diagnostic message and returns C<1>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env>
+
+A C<Genesis::Env> object.
+
+=item C<$bosh>
+
+A BOSH service object.
+
+=item C<%options>
+
+Parsed command-line options hash.
+
+=back
+
+B<Returns:> Returns C<1> (stub return value).
+
+B<Examples:>
+
+  # Dispatched internally by bosh_configs():
+  # Returns: 1
+  bosh_configs_view($env, $bosh, %options);
+
+=head2 bosh_configs_compare($env, $bosh, %options)
+
+Stub -- not yet implemented.  Intended to compare BOSH configs between the
+environment and the director.  Currently prints a diagnostic message and
+returns C<1>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env>
+
+A C<Genesis::Env> object.
+
+=item C<$bosh>
+
+A BOSH service object.
+
+=item C<%options>
+
+Parsed command-line options hash.
+
+=back
+
+B<Returns:> Returns C<1> (stub return value).
+
+B<Examples:>
+
+  # Dispatched internally by bosh_configs():
+  # Returns: 1
+  bosh_configs_compare($env, $bosh, %options);
+
+=head2 bosh_configs_delete($env, $bosh, %options)
+
+Stub -- not yet implemented.  Intended to delete a BOSH config from the
+director.  Currently prints a diagnostic message and returns C<1>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env>
+
+A C<Genesis::Env> object.
+
+=item C<$bosh>
+
+A BOSH service object.
+
+=item C<%options>
+
+Parsed command-line options hash.
+
+=back
+
+B<Returns:> Returns C<1> (stub return value).
+
+B<Examples:>
+
+  # Dispatched internally by bosh_configs():
+  # Returns: 1
+  bosh_configs_delete($env, $bosh, %options);
+
+=head1 SEE ALSO
+
+L<Genesis::Commands::Ocfp>, L<Genesis::Commands>, L<Genesis::Env>,
+L<Genesis::Top>
+
+=head1 AUTHOR
+
+FiveTwenty, LLC
+
+=cut

--- a/lib/Genesis/Commands/Core.pod
+++ b/lib/Genesis/Commands/Core.pod
@@ -1,0 +1,364 @@
+=head1 NAME
+
+Genesis::Commands::Core - Command handlers for Genesis core operations
+
+=head1 SYNOPSIS
+
+  # Registered in bin/genesis via define_command:
+  genesis version [<field> ...]
+  genesis version --json [<field> ...]
+  genesis ping
+  genesis update [--version <ver>] [--check] [--pre] [--force] [--details]
+  genesis hack [<env>] [<cmd> [<args> ...]]
+
+=head1 DESCRIPTION
+
+Implements the built-in core commands available to all Genesis invocations
+regardless of environment context: C<version>, C<ping>, C<update>, and
+C<hack>.
+
+C<version> reports or queries structured build metadata for the running
+Genesis executable.  C<ping> is a connectivity probe.  C<update> downloads
+and installs a new Genesis release from GitHub.  C<hack> is a developer
+inspection tool that evaluates Perl expressions, invokes object methods, or
+calls module functions against a live Genesis object graph.
+
+=head1 FUNCTIONS
+
+=head2 version(@fields)
+
+  version()
+  version('semver')
+  version('major', 'minor', 'patch')
+  version('semver', 'build_date', 'commit')
+
+Prints Genesis version and build information.
+
+When called with no arguments and no options, outputs the version string in
+the form C<Genesis vX.Y.ZBuild-Info> and exits.  When called with one or more
+field names, outputs each requested field on a separate line.  With the
+C<--json> option, outputs a JSON object containing the requested fields (or
+all fields if none are specified).
+
+B<Parameters:>
+
+=over 4
+
+=item C<@fields>
+
+Zero or more field names to query.  Valid field names are:
+
+=over 4
+
+=item C<semver> - Full semantic version string (e.g., C<1.2.3> or C<1.2.3-rc.4>)
+
+=item C<is_dev> - Boolean; true when running a development build
+
+=item C<major> - Major version number
+
+=item C<minor> - Minor version number
+
+=item C<patch> - Patch version number
+
+=item C<rc> - Release candidate number, or C<undef> if not an RC
+
+=item C<is_rc> - Boolean; true when the version is a release candidate
+
+=item C<build_epoch> - Build timestamp as a Unix epoch integer
+
+=item C<build_code> - Build timestamp as C<YYYYMMDD.HHMMSS> string
+
+=item C<build_date> - Build timestamp as a human-readable date/time string
+
+=item C<commit> - Git commit hash of the build
+
+=item C<is_dirty> - Boolean; true when the build was made from a dirty working tree
+
+=back
+
+Boolean fields (those beginning with C<is_>) are printed as the literal strings
+C<true> or C<false> in plain output mode.  In JSON mode they are proper JSON
+booleans.
+
+=back
+
+B<Returns:> Does not return; always calls C<exit 0>.
+
+B<Errors:>
+
+=over 4
+
+=item Calls C<bail()> with no message if any supplied field name is not in the
+valid set.  (Note: the error message is currently empty due to a known defect.)
+
+=back
+
+B<Examples:>
+
+  # Print the full version string
+  genesis version
+  # prints: Genesis v3.1.0 (abc1234) build 20240315.120000
+
+  # Query a single field
+  genesis version semver
+  # prints: 3.1.0
+
+  # Query multiple fields
+  genesis version major minor patch
+  # prints:
+  #   3
+  #   1
+  #   0
+
+  # Output all version fields as JSON
+  genesis version --json
+  # Returns: {"semver":"3.1.0","is_dev":false,"major":3,...}
+
+=head2 ping()
+
+  ping()
+
+Connectivity probe.  Prints C<PING!> to standard output and exits.
+
+Accepts no arguments.  Calls C<bail()> with usage help if any arguments are passed.
+
+B<Returns:> Does not return; always calls C<exit 0>.
+
+B<Examples:>
+
+  genesis ping
+  # prints: PING!
+
+=head2 update()
+
+  update()
+
+Downloads and installs a Genesis release from GitHub, replacing the running
+executable in-place.
+
+With no options, finds the latest stable release newer than the current
+version and, after prompting for confirmation, downloads and installs it.
+The installed binary preserves the original file's ownership and permission
+bits.  When the target path is not writable by the current user, a temporary
+shell script is generated and executed via C<sudo>.
+
+After a successful install, clears the C<GENESIS_HOME>, C<GENESIS_LIB>, and
+C<GENESIS_CALLBACK_BIN> environment variables and execs the newly installed
+binary with C<version> to confirm the upgrade.
+
+Accepts no positional arguments.  Calls C<bail()> with usage help if any
+positional arguments are passed.
+
+B<Options> (read from the command-line options hash):
+
+=over 4
+
+=item C<--version E<lt>verE<gt>>
+
+Install a specific version.  The leading C<v> is stripped automatically.
+Fails if the version does not exist on GitHub or if the downloadable
+executable is no longer available.
+
+=item C<--check>
+
+Report whether an update is available without installing it.  Exits 0 when
+already at the latest version; exits 1 when no matching version can be found.
+
+=item C<--pre>
+
+Include pre-release versions when searching for updates.
+
+=item C<--details>
+
+Print release notes for each available version before prompting.
+
+=item C<--force>
+
+Skip the interactive confirmation prompt and install without asking.
+
+=back
+
+B<Returns:> Does not return; always calls C<exit 0> on success or C<exec>s
+the new binary.
+
+B<Errors:>
+
+=over 4
+
+=item C<"$err - cannot update."> - The requested version does not exist, the
+executable is unavailable, or no newer version is available (not in C<--check>
+mode).  C<$err> contains the specific reason.
+
+=item C<"Aborted!"> - The user declined the confirmation prompt.
+
+=back
+
+B<Examples:>
+
+  # Check whether an update is available
+  genesis update --check
+  # prints: SUCCESS: You are on the latest version of Genesis (currently v3.1.0).
+
+  # Update to the latest stable release
+  genesis update
+  # prompts for confirmation, then installs and verifies
+
+  # Install a specific version
+  genesis update --version 3.0.5
+
+  # Install the latest pre-release
+  genesis update --pre
+
+=head2 hack($cmd, @args)
+
+  hack()
+  hack('pry')
+  hack('$Genesis::VERSION')
+  hack('$top', '->', 'load_env', '(', 'my-env', ')')
+  hack('Genesis::Env::some_func', 'arg1')
+  hack('Genesis::Env->class_method', 'arg1')
+  hack('<env-name>', '$top', '->', 'load_env', '(', '<env-name>', ')')
+
+Developer inspection tool.  Evaluates Perl expressions, invokes chains of
+object methods, or calls module functions against the live Genesis object
+graph.  Intended for debugging and exploration during development.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$cmd>
+
+The command or expression to evaluate.  Interpretation depends on the value:
+
+=over 4
+
+=item C<undef> or C<'pry'>
+
+Loads L<Pry> and drops into an interactive Pry debugging session.
+
+=item A string beginning with C<$> (e.g., C<$Genesis::VERSION>)
+
+Evaluates the string as a Perl expression using C<eval()>.  The result is
+printed using C<dump_var>.  If C<@args> are present they are interpreted as a
+method-chain continuation (see below).
+
+=item A string in the form I<Module>::I<func> or I<Module>-E<gt>I<method>
+
+Loads the named module and calls the specified function or class method with
+C<@args> as positional arguments.  The result is printed using C<dump_var>.
+
+=back
+
+=item C<@args>
+
+When C<$cmd> is a Perl expression (C<$...>), C<@args> encodes a method chain
+to execute on the result.  Tokens are interpreted as follows:
+
+=over 4
+
+=item C<-E<gt>> - Chain operator; begins a new method call
+
+=item A bare word following C<-E<gt>> - Method name
+
+=item C<(> - Opens argument list for the current method
+
+=item A bare word inside C<(...)> - Argument value passed to the method
+
+=item C<)> - Closes argument list and triggers the call
+
+=back
+
+The chain is executed left-to-right; each call's return value becomes the
+receiver for the next.  If the method name is C<pry>, drops into an
+interactive Pry session with C<$obj> bound to the current receiver.
+
+When C<$cmd> is a module function or method call, C<@args> are passed directly
+as positional arguments.
+
+=back
+
+B<Returns:>
+
+=over 4
+
+=item C<1> - When dispatching to a module function or class method.
+
+=item The result of C<defined($obj)> - After executing a Perl expression with
+a method chain.  Returns true if the final result is defined.
+
+=item Does not return (C<exit 0>) - When C<$cmd> is C<undef> or C<'pry'>.
+
+=back
+
+B<Context detection:> If the current directory contains C<.genesis/kits/> or
+C<dev/>, a C<Genesis::Top> object is constructed automatically.  If C<$cmd>
+matches an environment file name in that top-level directory (with or without
+the C<.yml> extension), the corresponding environment is loaded into C<$env>
+and the next element of C<@args> becomes the new C<$cmd>.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Attempted to load environment from %s, but encountered error: %s"> -
+Loading the environment file failed.  The first C<%s> is the C<.yml> file
+path; the second is the caught exception.
+
+=item C<"Attempted to load Pry, but encountered error: %s"> - The Pry module
+could not be loaded.  The C<%s> is the caught exception.
+
+=item C<"Attempted to evaluate Perl expression, but encountered error: %s"> -
+C<eval()> of the C<$cmd> expression raised an exception.  The C<%s> is the
+caught exception.
+
+=item C<"Improperly formatted expression: no method specified for call"> -
+A closing parenthesis was encountered before a method name was set.
+
+=item C<"Improperly formatted expression: expecting a -> operator, but found '%s'"> -
+A C<-E<gt>> token appeared where a C<-E<gt>> was not expected.  (Note: the
+C<%s> placeholder is present in the format string but no value is substituted,
+due to a known defect.)
+
+=item C<"Improperly formatted expression: unexpected argument '%s' while waiting for %s"> -
+An argument token appeared while the parser was not expecting one.  The first
+C<%s> is the unexpected token; the second is the parser state description.
+
+=item C<"Improperly formatted expression: unexpected opening parenthesis while waiting for %s"> -
+An opening parenthesis appeared while the parser expected a method name.
+The C<%s> is the parser state description.
+
+=item C<"Improperly formatted expression: unexpected opening parenthesis while waiting for argment"> -
+An opening parenthesis appeared while an argument was already being collected.
+(Note: "argment" is a typo in the source for "argument".)
+
+=back
+
+B<Examples:>
+
+  # Drop into a Pry debugging session
+  genesis hack pry
+
+  # Inspect a package variable
+  genesis hack '$Genesis::VERSION'
+  # Returns: result = "3.1.0"
+
+  # Call a method chain on an evaluated expression
+  genesis hack '$top' -> load_env '(' my-env ')'
+
+  # Call a package function directly
+  genesis hack 'Genesis::Env::some_func' arg1 arg2
+
+  # Call a class method
+  genesis hack 'Service::Github->new'
+
+=head1 SEE ALSO
+
+L<Genesis::Commands>, L<Genesis::Top>, L<Genesis::Env>,
+L<Service::Github>
+
+=head1 AUTHOR
+
+FiveTwenty, LLC
+
+=cut

--- a/lib/Genesis/Commands/Deprecated.pod
+++ b/lib/Genesis/Commands/Deprecated.pod
@@ -11,7 +11,7 @@ Genesis::Commands::Deprecated - Redirect handler for deprecated Genesis CLI comm
   }, "Genesis::Commands::Deprecated::redirect");
 
   # CLI invocation (deprecated command still works, but warns):
-  genesis <env> download my-kit/1.0.0
+  genesis download my-kit/1.0.0
 
 =head1 DESCRIPTION
 
@@ -64,7 +64,7 @@ B<Examples:>
 
 =head1 SEE ALSO
 
-L<Genesis::Commands>, L<Genesis::Commands::Kits>
+L<Genesis::Commands>, L<Genesis::Commands::Kit>
 
 =head1 AUTHOR
 

--- a/lib/Genesis/Commands/Deprecated.pod
+++ b/lib/Genesis/Commands/Deprecated.pod
@@ -1,0 +1,73 @@
+=head1 NAME
+
+Genesis::Commands::Deprecated - Redirect handler for deprecated Genesis CLI commands
+
+=head1 SYNOPSIS
+
+  # Registered in bin/genesis via define_command:
+  define_command("download", {
+    deprecated => 'fetch-kit',
+    ...
+  }, "Genesis::Commands::Deprecated::redirect");
+
+  # CLI invocation (deprecated command still works, but warns):
+  genesis <env> download my-kit/1.0.0
+
+=head1 DESCRIPTION
+
+Provides the single shared entry point used by deprecated Genesis CLI commands.
+When a deprecated command is invoked, C<redirect> re-initializes the command
+context as the replacement command, emits a deprecation warning, and then
+runs the replacement command's handler with the original arguments.
+
+Each deprecated command is registered in C<bin/genesis> via C<define_command>
+with a C<deprecated> property naming the replacement command, and with
+this module's C<redirect> function as its handler.  The function is generic
+and works for any such registration.
+
+See L<Genesis::Commands> for the C<prepare_command>, C<run_command>, and
+C<command_properties> functions that this module relies on.
+
+=head1 FUNCTIONS
+
+=head2 redirect(@args)
+
+Entry point registered as the handler for deprecated commands.  Re-prepares
+the command context using the replacement command name stored in the
+C<deprecated> property of the active command, then runs the replacement
+command's handler.
+
+  redirect(@args);
+
+B<Parameters:>
+
+=over 4
+
+=item C<@args>
+
+The original command-line arguments passed to the deprecated command.  These
+are forwarded to C<prepare_command> and ultimately to the replacement
+command's handler unchanged.
+
+=back
+
+B<Returns:> Does not return.  Calls C<run_command>, which exits the process
+after the replacement command completes.
+
+B<Examples:>
+
+  # When "genesis download my-kit/1.0.0" is invoked, this handler is called:
+  redirect("my-kit/1.0.0");
+  # Emits: [DEPRECATED] The download command has been deprecated...
+  #        It has been replaced by fetch-kit
+  # Then runs the fetch-kit handler with ("my-kit/1.0.0")
+
+=head1 SEE ALSO
+
+L<Genesis::Commands>, L<Genesis::Commands::Kits>
+
+=head1 AUTHOR
+
+FiveTwenty, LLC
+
+=cut

--- a/lib/Genesis/Commands/Env.pod
+++ b/lib/Genesis/Commands/Env.pod
@@ -1,0 +1,1217 @@
+=head1 NAME
+
+Genesis::Commands::Env - Command handlers for Genesis environment lifecycle management
+
+=head1 SYNOPSIS
+
+  # Loaded automatically by bin/genesis command dispatch
+  use Genesis::Commands::Env;
+
+  # CLI invocations (scope: <env> is an environment name or .yml file):
+
+  genesis <env> create [<options>]
+  genesis <env> edit   [<options>]
+  genesis <env> check  [<options>]
+  genesis <env> manifest [<options>]
+  genesis <env> deploy [<options>] [<reason>]
+  genesis <env> terminate [<options>] [<reason>]
+  genesis <env> do <action> [<addon-options-and-args>]
+  genesis <env> check-secrets [<options>] [<paths...>]
+  genesis <env> secrets [<options>] [<filters...>]
+  genesis <env> add-secrets [<options>] [<paths...>]
+  genesis <env> rotate-secrets [<options>] [<paths...>]
+  genesis <env> remove-secrets [<options>] [<paths...>]
+  genesis <env> env-shell [<options>]
+
+=head1 DESCRIPTION
+
+C<Genesis::Commands::Env> implements the command handlers that back the core
+environment lifecycle CLI commands in C<bin/genesis>.  Each function in this
+module is registered with C<define_command> in the Genesis binary and is
+called directly with the parsed command-line arguments.
+
+This module is procedural: there is no object constructor.  Each exported
+subroutine receives positional arguments that correspond to CLI arguments
+as described in each function's B<Parameters> section.
+
+Options are accessed via the C<get_options> and C<has_option> helpers
+from L<Genesis::Commands>.
+
+=head1 FUNCTIONS
+
+=head2 create($name)
+
+  genesis <env> create [--kit <kit>] [--vault <vault>] [--root-ca-path <path>] [<options>]
+
+Create a new Genesis deployment environment.  Prompts the user with
+kit-supplied questions, writes the environment YAML file, and generates
+all required secrets and certificates in Vault.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Environment name string (e.g., C<us-east-prod>).  A C<.yml> suffix is
+stripped automatically.  Exactly one argument is required.
+
+=back
+
+B<Options (via get_options):>
+
+=over 4
+
+=item C<--kit|-k>
+
+Name (and optionally, version) of the Genesis Kit to use (e.g.,
+C<shield/6.3.0>).  Defaults to the latest locally available version.
+Use C<dev> to use the dev kit.
+
+=item C<--vault>
+
+The name of a C<safe> target (a Vault) to store newly generated credentials
+in.  Overrides the vault specified in the deployment repository.  Use C<?>
+to select a vault interactively.
+
+=item C<--root-ca-path>
+
+Vault path to a root CA certificate that will sign all generated certificates
+that do not specify their own CA.
+
+=item C<--create-env!>
+
+For kits that allow but do not require C<create-env>-style deployment,
+force or suppress C<create-env> mode.
+
+=item C<--secrets-path|-P>
+
+Override the default secrets path (C<secret/E<lt>env-nameE<gt>/E<lt>kitE<gt>>).
+
+=item C<--secrets-mount>
+
+Use an alternative base location other than C<secret/> for secrets.
+
+=item C<--exodus-mount>
+
+Use an alternative base path for exodus data.
+
+=item C<--ci-mount>
+
+Use an alternative base path for concourse-provided secrets.
+
+=item C<--force|-f>
+
+Create a new environment file even if one already exists.
+
+=back
+
+B<Returns:>
+
+Nothing.  Prints a success message with the C<genesis deploy> command to
+run next, then exits normally.
+
+B<Errors:>
+
+=over 4
+
+=item C<"No environment name specified!">
+
+Raised when C<$name> is empty after stripping the C<.yml> suffix.
+
+=item C<"Unable to determine the correct version of the Genesis Kit to use.  Perhaps you should specify it with the `--kit` flag.">
+
+Raised when no kit is found and no kit identifier was provided.
+
+=item C<"No dev/ kit found in current working directory.  Did you forget to `genesis decompile-kit` first?">
+
+Raised when C<--kit dev> is requested but no C<dev/> directory is present.
+
+=item C<"Kit '$kit_id' not found in compiled kit cache.  Do you need to `genesis fetch-kit $kit_id`?">
+
+Raised when the requested compiled kit version is not cached locally.
+C<$kit_id> is the kit name and version string provided by the user.
+
+=item C<"No CA certificate found in vault under '#C{%s}'">
+
+Raised when C<--root-ca-path> is given but no valid x509 CA is found at
+that Vault path.  C<%s> is the path supplied by the user.
+
+=item C<"Failed to create environment $name">
+
+Raised when C<< Genesis::Top->create_env >> returns a false value.
+C<$name> is the environment name.
+
+=back
+
+B<Examples:>
+
+  # Create a new BOSH environment using the latest bosh kit
+  genesis my-env create --kit bosh/10.2.0
+  # prints: Setting up new environment my-env based on kit bosh/10.2.0 ...
+
+  # Create with an explicit vault target
+  genesis my-env create --vault prod-vault
+  # prints: New environment my-env provisioned!
+
+=head2 edit($name)
+
+  genesis <env> edit [--editor <cmd>] [--kit <kit>] [--manual!] [--ancestors!]
+
+Open the environment file in your configured editor.  When the editor is
+vi-based (C<vi>, C<vim>, C<mvim>, C<nvim>, C<gvim>) or C<emacs>, the kit's
+C<MANUAL.md> and any existing ancestor YAML files are opened alongside the
+environment file in a split-window layout.  VSCode (C<code>) opens all
+files as separate tabs.
+
+If the kit referenced by the environment file is not locally available,
+the user is prompted to select an alternate local kit, download the
+required version, or continue without a manual.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Environment name string.
+
+=back
+
+B<Options (via get_options):>
+
+=over 4
+
+=item C<--editor|-e>
+
+Editor command to use.  Defaults to the C<EDITOR> environment variable, or
+C<vim> if C<EDITOR> is not set.
+
+=item C<--kit|-k>
+
+Kit name and version to use when displaying the manual, in
+C<name/version> format.
+
+=item C<--manual!>
+
+Include (or suppress with C<--no-manual>) the kit C<MANUAL.md> in the
+editor split window.  Enabled by default for vi-based editors, emacs, and
+VSCode.
+
+=item C<--ancestors!>
+
+Include (C<--ancestors>) all possible hierarchical ancestor YAML files in
+the editor, even those that do not yet exist.  Suppress with
+C<--no-ancestors> to open only the environment file.  By default, existing
+ancestor files are opened.
+
+=back
+
+B<Returns:>
+
+Nothing.  Prints a completion notice after the editor exits.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Cannot specify #Y{--manual} unless the editor is vi-based (vi,vim,mvim,nvim,gvim), vscode (code) or emacs: Pull request are welcome for other editors.">
+
+Raised when C<--manual> is specified with an unsupported editor.
+
+=item C<"Cannot specify #Y{--include-all-ancestors} unless the editor is vi-based (vi,vim,mvim,nvim,gvim) or vscode (code): Pull request are welcome for other editors.">
+
+Raised when C<--ancestors> is specified with an unsupported editor.
+
+=item C<"Failed to download Genesis Kit #C{$kitsig}">
+
+Raised when the user chooses to download a kit but the download fails.
+C<$kitsig> is the kit name and version string.
+
+=item C<"Aborted by user">
+
+Raised when the user declines to continue after warnings, or selects
+C<abort> from the kit selection prompt.
+
+=item C<"Failed to edit environment %s">
+
+Raised when the editor exits with a non-zero exit code.  C<%s> is the
+environment name.
+
+=back
+
+B<Examples:>
+
+  # Edit with the default editor
+  genesis my-env edit
+  # prints: Editing environment file ~/deployments/my-env.yml
+
+  # Edit without showing the manual
+  genesis my-env edit --no-manual
+  # prints: Editing environment file ~/deployments/my-env.yml
+
+  # Edit with a specific editor
+  genesis my-env edit --editor code
+  # prints: Editing environment file ~/deployments/my-env.yml
+
+=head2 check($name)
+
+  genesis <env> check [--no-config] [--secrets!] [--manifest!] [--stemcells!]
+
+Run preflight checks against the environment manifest, secrets, and
+stemcell availability to verify that the environment can be successfully
+deployed.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Environment name string.  Exactly one argument is required.
+
+=back
+
+B<Options (via get_options):>
+
+=over 4
+
+=item C<--no-config>
+
+Skip cloud config tests.  Cannot be combined with the default
+C<--manifest> check (requires C<--no-manifest>).
+
+=item C<--secrets!>
+
+Include or suppress secrets validation.  Enabled by default.
+
+=item C<--manifest!>
+
+Include or suppress manifest build and validation.  Enabled by default.
+
+=item C<--stemcells!>
+
+Include or suppress stemcell availability checks.  Disabled by default.
+
+=back
+
+B<Returns:>
+
+Nothing.  Exits with code C<0> on success, or dies with a preflight-failed
+message on any check failure.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Cannot specify --no-config without also specifying --no-manifest">
+
+Raised when C<--no-config> is used but C<--manifest> is still enabled.
+
+=item C<"\n[#M{%s}] #R{PREFLIGHT FAILED}">
+
+Raised when one or more checks fail.  C<%s> is the environment name.
+
+=back
+
+B<Examples:>
+
+  # Run all default checks
+  genesis my-env check
+  # prints: [my-env] All Checks Succeeded
+
+  # Check only secrets, skip manifest and config
+  genesis my-env check --no-manifest --no-config
+  # prints: [my-env] All Checks Succeeded
+
+=head2 manifest($name)
+
+  genesis <env> manifest [--type <type>] [--subset <subset>] [--list]
+
+Generate the BOSH deployment manifest for the environment and print it to
+STDOUT.  If C<--list> is specified, print the valid manifest types and
+subsets instead.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Environment name string.  Exactly one argument is required.
+
+=back
+
+B<Options (via get_options):>
+
+=over 4
+
+=item C<--list|-l>
+
+List valid manifest types and subsets for this environment, then return.
+All other options are ignored when C<--list> is specified.
+
+=item C<--type|-t>
+
+Manifest type to generate.  Defaults to C<deployment>.  Use C<--list> to
+see valid types.
+
+=item C<--subset|-s>
+
+Subset of manifest content to return.  Defaults to the full manifest.  Use
+C<--list> to see valid subsets.
+
+=back
+
+B<Returns:>
+
+Returns C<1> when C<--list> is used.  Otherwise prints the manifest YAML
+to STDOUT and does not return a meaningful value.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Unknown manifest type %s - use --list option to show valid types">
+
+Raised when C<--type> specifies a type not supported by this environment's
+manifest provider.  C<%s> is the requested type string.
+
+=item C<"Unknown manifest subset %s - use --list option to show valid subsets">
+
+Raised when C<--subset> specifies a subset not supported by this
+environment's manifest provider.  C<%s> is the requested subset string.
+
+=item C<"Manifest type %s is not supported by this environment">
+
+Raised when the manifest provider does not implement the requested type
+method.  C<%s> is the resolved type string.
+
+=back
+
+B<Examples:>
+
+  # Print the default deployment manifest
+  genesis my-env manifest
+  # prints: (YAML manifest content to STDOUT)
+
+  # List available types and subsets
+  genesis my-env manifest --list
+  # prints: Valid manifest types: ...
+
+  # Print the unredacted manifest
+  genesis my-env manifest --type unredacted
+  # prints: (unredacted YAML manifest content to STDOUT)
+
+=head2 deploy($env_name, $reason)
+
+  genesis <env> deploy [<options>] [<reason>]
+
+Deploy the environment to its BOSH director (or via C<create-env> for
+bootstrap environments).  Before deploying, this function orchestrates
+cloud config generation and upload, network claims locking, secrets
+validation and repair, manifest validation, stemcell checks, and CPI
+config management.  After a successful deploy it exits with code C<0>;
+on failure it calls C<bail()>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env_name>
+
+Environment name string.
+
+=item C<$reason>
+
+Optional free-text reason for the deployment.  Required when the
+environment's policy specifies a minimum reason length.  Defaults to
+C<'unknown'> if not provided and not required.
+
+=back
+
+B<Options (via get_options):>
+
+=over 4
+
+=item C<--dry-run|-n>
+
+Build and validate the manifest without making changes to the BOSH director.
+
+=item C<--yes|-y>
+
+Suppress all interactive prompts; assume yes.
+
+=item C<--reactions!>
+
+Process reactions from the environment file after deployment (default: enabled).
+
+=item C<--redact!>
+
+Redact sensitive values from diff output (default: redact when not writing
+to a live terminal).
+
+=item C<--fix>
+
+Recreate unresponsive VMs rather than raising an error.  Mutually exclusive
+with C<--recreate> and C<--dry-run>.
+
+=item C<--fix-releases>
+
+Re-upload releases and replace corrupt or missing jobs and packages.
+
+=item C<--fix-stemcells>
+
+Re-upload stemcells and replace corrupt or missing ones.  Not applicable
+to C<create-env> environments.
+
+=item C<--fix-secrets>
+
+Rotate problematic secrets (expired, invalid, or missing) before deploying.
+
+=item C<--fix-checks|-F>
+
+Shorthand for C<--fix-stemcells> and C<--fix-secrets>, as applicable.
+
+=item C<--clear>
+
+Clear the deployment cache before starting.  Required if a prior
+deployment was interrupted and left cached files behind.
+
+=item C<--recreate>
+
+Recreate all VMs instead of applying only the changed configuration.
+
+=item C<--recreate-persistent-disks|--rpd>
+
+Recreate all persistent disks even when the deployment is a no-op.
+
+=item C<--skip-drain>
+
+Skip drain scripts for specific instance groups.  May be specified
+multiple times.
+
+=item C<--canaries>
+
+Override the default number of canary VMs per instance group.
+
+=item C<--max-in-flight>
+
+Override the default maximum number of VMs in flight per instance group.
+
+=item C<--STATE-FILE-PATH>
+
+Path to a state file to use for this deployment, overriding the one
+fetched from exodus or C<.genesis/manifests>.
+
+=back
+
+B<Returns:>
+
+Nothing.  Exits with code C<0> on success.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Cannot deploy environment #C{%s} without a reason (minimum length is %d characters)", "Please provide a reason after any options on the command line">
+
+Raised when the environment's policy requires a reason but none was given,
+or the given reason is shorter than the minimum.  C<%s> is the environment
+name; C<%d> is the minimum character count.
+
+=item C<"The following options cannot be specified for #M{create-env}: %s">
+
+Raised when C<--fix>, C<--dry-run>, or C<--fix-stemcells> are passed to a
+C<create-env> environment.  C<%s> is the comma-separated list of invalid
+options.
+
+=item C<"\nCowardly refusing to clear deployment cache files in #C{%s} without user confirmation.\n\nUse the #Y{--clear} option to clear them, or run the command without the #Y{--yes} option in an interactive terminal to be prompted.">
+
+Raised when cached deployment files exist and C<--yes> is specified in a
+non-interactive terminal without C<--clear>.  C<%s> is the cache directory.
+
+=item C<"Genesis kit #C{%s} does not support the IaaS type #C{%s} - you will need to use a different kit/version.">
+
+Raised when the kit's C<supports> metadata list does not include the
+environment's IaaS type.  The first C<%s> is the kit id; the second is the
+IaaS type.
+
+=item C<"Cannot provide the required CPI config: %s">
+
+Raised when the CPI config check reports a fatal error.  C<%s> is the
+error message from the check result.
+
+=item C<"Could not update required CPI config: %s">
+
+Raised when fixing the CPI config fails.  C<%s> is the error message from
+the fix result.
+
+=item C<"Network claims are currently locked -- cannot proceed with deployment!">
+
+Raised when another deployment holds an active network claims lock on the
+BOSH director.
+
+=item C<"Network claims lock was lost since last checked (may have become stale and removed) -- cannot proceed with deployment!">
+
+Raised when the network claims lock is lost between the cloud config upload
+and the network map update steps.
+
+=item C<"Error generating cloud config for diff: %s">
+
+Raised when C<spruce merge> fails while preparing the cloud config for
+comparison.  C<%s> is the error or output text.
+
+=item C<"Error comparing cloud configs: %s">
+
+Raised when C<spruce diff> fails while comparing old and new cloud configs.
+C<%s> is the error text.
+
+=item C<"Failed to upload cloud config %s to BOSH director: %s\n\nContent:\n%s">
+
+Raised when C<bosh upload-config> fails.  The first C<%s> is the cloud
+config name; the second is the error; the third is the cloud config YAML.
+
+=item C<"\nCannot continue without a valid network map:\n\n%s">
+
+Raised when the vault update for the network map fails.  C<%s> is the
+error detail.
+
+=item C<"Failed to fix secrets: %s">
+
+Raised when the pre-deploy secrets repair step fails fatally.  C<%s> is
+the error message.
+
+=item C<"Cannot prompt user for confirmation of release version overrides - not in a controlling terminal.  Please specify #Y{-y|--yes} to bypass this prompt.">
+
+Raised when release version overrides require confirmation but there is no
+interactive terminal and C<--yes> was not specified.
+
+=item C<"Failed to fix stemcells: %s">
+
+Raised when the stemcell upload repair step fails fatally.  C<%s> is the
+error message.
+
+=item C<"Stemcell check failed: %s">
+
+Raised when stemcells are missing or corrupt and C<--fix-stemcells> was
+not specified.  C<%s> is the check result message.
+
+=item C<"Preflight checks failed; deployment operation halted.">
+
+Raised when one or more preflight checks fail and the deploy cannot
+proceed.
+
+=item C<"Aborted by user">
+
+Raised when the user declines to clear the deployment cache during the
+pre-deploy cache check (without C<--yes>).
+
+=item C<"Aborted by user!">
+
+Raised when the user declines an interactive prompt during cloud config
+comparison or release version override confirmation.
+
+=item C<"[#M{%s}] #R{Deployment Failed}">
+
+Raised when the underlying C<< $env->deploy >> call returns false.  C<%s>
+is the environment name.
+
+=back
+
+B<Examples:>
+
+  # Deploy interactively
+  genesis my-env deploy
+  # prints: my-env/bosh deployed successfully.
+
+  # Deploy non-interactively with auto-fix checks
+  genesis my-env deploy --yes --fix-checks
+  # prints: my-env/bosh deployed successfully.
+
+  # Dry run to validate without changing anything
+  genesis my-env deploy --dry-run
+  # prints: (dry-run output; no changes made)
+
+  # Deploy with a reason for audit purposes
+  genesis my-env deploy "Quarterly patching cycle"
+  # prints: my-env/bosh deployed successfully.
+
+=head2 terminate($env, $reason, @extras)
+
+  genesis <env> terminate [<options>] [<reason>]
+
+Terminate the environment on its BOSH director.  By default, all
+associated resources are removed: VMs, persistent disks, cloud configs,
+BOSH resources, secrets, user-provided secrets, CredHub data, and network
+claims.  Individual categories can be preserved with C<--no-*> options, or
+all preserved at once with C<--no-cleanup>.
+
+C<create-env> environments do not have BOSH director resources or
+networking claims; the corresponding prompts and cleanup steps are skipped.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env>
+
+Environment name string.
+
+=item C<$reason>
+
+Optional free-text reason for termination.  Required when the environment
+policy specifies a minimum reason length.
+
+=item C<@extras>
+
+Must be empty; any extra arguments cause the command usage to be printed.
+
+=back
+
+B<Options (via get_options):>
+
+=over 4
+
+=item C<--yes|-y>
+
+Skip the interactive confirmation prompt.
+
+=item C<--dry-run|-n>
+
+Show what would be removed without making any changes.
+
+=item C<--force|-f>
+
+For director-deployed environments, ignore errors while deleting the
+deployment.  For C<create-env> deployments, skip drain and pre-stop scripts.
+
+=item C<--resources!>
+
+Remove (default) or keep BOSH director resources.
+
+=item C<--secrets!>
+
+Remove (default) or keep generated secrets in Vault.
+
+=item C<--user-secrets!>
+
+Remove (default) or keep user-provided secrets in Vault.
+
+=item C<--credhub!>
+
+Remove (default) or keep CredHub data.
+
+=item C<--networking!>
+
+Remove (default) or keep network claims on the BOSH director.
+
+=item C<--no-cleanup|-K>
+
+Invert the defaults for all cleanup options: keep everything that would
+otherwise be removed.  Individual C<--no-*> flags still override this.
+
+=back
+
+B<Returns:>
+
+Nothing.  Exits with code C<0> on success.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Cannot terminate environment #C{%s} without a reason (minimum length is %d characters).", "Please provide a reason after any options on the command line">
+
+Raised when the environment's policy requires a reason but none was given,
+or the given reason is shorter than the minimum.  C<%s> is the environment
+name; C<%d> is the minimum character count.
+
+=item C<"Undefined options passed in from the Genesis command handler: %s">
+
+Internal error raised when unrecognized option keys remain after parsing.
+C<%s> is the comma-separated list of unrecognized keys.
+
+=item C<"Aborted by user!">
+
+Raised when the user declines the interactive confirmation prompt.
+
+=item C<"\n#M{%s}/#c{%s} #R{termination failed!}">
+
+Raised when the underlying C<< $env->terminate >> call returns false.  The
+first C<%s> is the environment name; the second is the deployment type.
+
+=back
+
+B<Examples:>
+
+  # Terminate interactively (prompts for confirmation)
+  genesis my-env terminate
+  # prints: my-env/bosh terminated successfully.
+
+  # Dry run to see what would be removed
+  genesis my-env terminate --dry-run
+  # prints: my-env/bosh termination dry-run completed successfully.
+
+  # Terminate non-interactively, keeping secrets
+  genesis my-env terminate --yes --no-secrets
+  # prints: my-env/bosh terminated successfully.
+
+  # Keep everything (redeploy scenario)
+  genesis my-env terminate --yes --no-cleanup
+  # prints: my-env/bosh terminated successfully.
+
+=head2 addon($name, $script, @args)
+
+  genesis <env> do <action> [<addon-options-and-args>]
+
+Run a kit addon script against the environment.  This is also registered
+as C<genesis E<lt>envE<gt> addon>, C<genesis E<lt>envE<gt> apply>, and
+C<genesis E<lt>envE<gt> run>.
+
+If C<$script> is C<--help>, C<-h>, or missing, it defaults to C<'help'>,
+which causes the kit to list available addons.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Environment name string.
+
+=item C<$script>
+
+Name of the addon script to run (e.g., C<smoke-tests>).  Defaults to
+C<'help'> if omitted or if C<--help>|C<-h> is given.
+
+=item C<@args>
+
+Additional positional arguments passed through to the addon script.
+
+=back
+
+B<Returns:>
+
+Nothing.  Exits with code C<1> if the addon hook fails.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Cannot use the kit specified by %s.\n">
+
+Raised when the kit fails its prerequisite checks.  C<%s> is the
+environment name.
+
+=item C<"#R{Kit %s does not provide an addon hook!}">
+
+Raised when the kit does not implement the C<addon> hook.  C<%s> is the
+kit identifier.
+
+=back
+
+B<Examples:>
+
+  # List available addons
+  genesis my-env do help
+  # prints: (list of available addons from the kit)
+
+  # Run the smoke-tests addon
+  genesis my-env do smoke-tests
+  # prints: Running smoke-tests addon for my-env bosh deployment
+
+  # Pass extra arguments to an addon
+  genesis my-env do configure --force
+  # prints: Running configure addon for my-env bosh deployment
+
+=head2 check_secrets($name, @paths)
+
+  genesis <env> check-secrets [<options>] [<paths...>]
+
+Validate the secrets for the named environment.  When no paths are given,
+all secrets are checked.  The C<--exists> flag switches from full
+structural validation to an existence-only check.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Environment name string.
+
+=item C<@paths>
+
+Optional list of specific secret paths to check.  If empty, all secrets
+are checked.
+
+=back
+
+B<Options (via get_options):>
+
+=over 4
+
+=item C<--exists>
+
+Check only that secrets exist (and their required keys are present) rather
+than fully validating their structure and values.
+
+=back
+
+B<Returns:>
+
+Nothing.  Exits with code C<0> when all secrets pass, or code C<1> when
+any secrets are missing or invalid.  Emits a success, warning, or fatal
+notification depending on results.
+
+B<Examples:>
+
+  # Validate all secrets for an environment
+  genesis my-env check-secrets
+  # prints: [my-env] validated secrets successfully!
+
+  # Check only that specific secrets exist
+  genesis my-env check-secrets --exists secret/my-env/bosh/admin
+  # prints: [my-env] checked secrets successfully!
+
+=head2 list_secrets($name, @filters)
+
+  genesis <env> secrets [<options>] [<filters...>]
+
+List the secrets available for the named environment.  Optional filters
+narrow the results by full or partial path, property expression, or regular
+expression.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Environment name string.
+
+=item C<@filters>
+
+Optional list of filter strings.  Each filter is matched against secret
+paths to select a subset of secrets.
+
+=back
+
+B<Options (via get_options):>
+
+=over 4
+
+=item C<--verbose|-v>
+
+List each secret with its associated metadata (type, description, source).
+Specify twice (C<-vv>) to also include the current secret value.
+
+=item C<--relative|-r>
+
+Show paths relative to the environment's secrets base path rather than the
+full Vault path.
+
+=item C<--json|-j>
+
+Output in JSON array format.  When combined with C<--verbose>, each entry
+is a hash object with C<path>, C<type>, C<description>, and C<source>
+fields (and C<value> when C<-vv>).
+
+=back
+
+B<Returns:>
+
+Nothing.  Prints the list of secrets to STDOUT, then emits a success
+notification with the count of secrets found.
+
+B<Examples:>
+
+  # List all secrets
+  genesis my-env secrets
+  # prints: Secrets in my-env: (list of paths)
+
+  # List secrets with metadata
+  genesis my-env secrets --verbose
+  # prints: Secrets in my-env: (paths with type and description)
+
+  # List in JSON format with full metadata
+  genesis my-env secrets --json --verbose
+  # prints: [ { "path": "...", "type": "...", ... }, ... ]
+
+  # Filter to SSL-related secrets
+  genesis my-env secrets ssl
+  # prints: Secrets in my-env: (only paths matching 'ssl')
+
+=head2 add_secrets($name, @paths)
+
+  genesis <env> add-secrets [<options>] [<paths...>]
+
+Generate and store any missing secrets for the named environment.  Secrets
+that already exist in Vault are skipped.  Supports import from CredHub for
+environments that use it; secrets that cannot be imported are generated
+locally instead.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Environment name string.
+
+=item C<@paths>
+
+Optional list of specific secret paths to add.  If empty, all missing
+secrets are added.
+
+=back
+
+B<Returns:>
+
+Nothing.  Emits a success, warning, or fatal notification depending on
+results, then exits with code C<0> on success or C<1> on error.
+
+B<Errors:>
+
+=over 4
+
+=item C<"- errors encountered while adding secrets">
+
+Fatal notification emitted when the add operation reports errors.
+
+=back
+
+B<Examples:>
+
+  # Add all missing secrets
+  genesis my-env add-secrets
+  # prints: [my-env] all secrets were added successfully!
+
+  # Add a specific missing secret
+  genesis my-env add-secrets secret/my-env/bosh/admin
+  # prints: [my-env] all missing secrets were added successfully!
+
+=head2 rotate_secrets($name, @paths)
+
+  genesis <env> rotate-secrets [<options>] [<paths...>]
+
+Rotate (regenerate) secrets for the named environment.  By default all
+secrets are rotated; supply paths to rotate only specific ones.  The
+deprecated C<--force> flag is rejected with an error.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Environment name string.
+
+=item C<@paths>
+
+Optional list of specific secret paths to rotate.  If empty, all secrets
+are rotated.
+
+=back
+
+B<Options (via get_options):>
+
+=over 4
+
+=item C<--invalid>
+
+Rotate only secrets with the specified validation level.  A value of C<1>
+means invalid secrets only; C<2> means problematic (invalid or expired).
+
+=item C<--problematic>
+
+Rotate only secrets that are problematic (expired or invalid).  Internally
+translated to C<--invalid 2>.
+
+=back
+
+B<Returns:>
+
+Nothing.  Emits a success, warning, or fatal notification depending on
+results, then exits with code C<0> on success or C<1> on error.
+
+B<Errors:>
+
+=over 4
+
+=item C<"--force option no longer valid. See `genesis rotate-secrets -h` for more details">
+
+Raised when the deprecated C<--force> flag is supplied.
+
+=back
+
+B<Examples:>
+
+  # Rotate all secrets
+  genesis my-env rotate-secrets
+  # prints: [my-env] all rotated successfully!
+
+  # Rotate only problematic secrets
+  genesis my-env rotate-secrets --problematic
+  # prints: [my-env] all rotated successfully!
+
+  # Rotate a specific secret
+  genesis my-env rotate-secrets secret/my-env/bosh/admin
+  # prints: [my-env] specified rotated successfully!
+
+=head2 remove_secrets($name, @paths)
+
+  genesis <env> remove-secrets [<options>] [<paths...>]
+
+Remove secrets for the named environment from Vault.  Multiple removal
+strategies are supported: named paths, all secrets, invalid/problematic
+secrets, and unused secrets.  Strategies are mutually exclusive in various
+combinations.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Environment name string.
+
+=item C<@paths>
+
+Optional list of specific secret paths to remove.  Must be empty when
+C<--all> or C<--unused> is specified.
+
+=back
+
+B<Options (via get_options):>
+
+=over 4
+
+=item C<--all>
+
+Remove all secrets for the environment.  Cannot be combined with path
+arguments or the C<--invalid>, C<--problematic>, C<--interactive>, or
+C<--unused> options.
+
+=item C<--invalid>
+
+Remove only invalid or expired secrets.
+
+=item C<--problematic>
+
+Remove only problematic secrets.  Internally translated to C<--invalid 2>.
+Cannot be combined with C<--unused>.
+
+=item C<--unused>
+
+Remove only secrets that are no longer referenced by the environment.
+Cannot be combined with path arguments, C<--invalid>, or C<--problematic>.
+
+=item C<--interactive>
+
+Prompt for confirmation before removing each secret.
+
+=back
+
+B<Returns:>
+
+Nothing.  Emits a success, warning, or fatal notification depending on
+results, then exits with code C<0> on success or C<1> on error.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Cannot specify secret paths when using the --all option.">
+
+Raised when path arguments are provided with C<--all>.
+
+=item C<"Cannot use --invalid, --problematic, --interactive or --unused at the same time as the --all option.">
+
+Raised when C<--all> is combined with incompatible filtering options.
+
+=item C<"Cannot specify secret paths or filters when using the --unused option.">
+
+Raised when path arguments are provided with C<--unused>.
+
+=item C<"Cannot use --invalid or --problematic at the same time as the --unused option.">
+
+Raised when C<--unused> is combined with C<--invalid> or C<--problematic>.
+
+=back
+
+B<Examples:>
+
+  # Remove all secrets for an environment
+  genesis my-env remove-secrets --all
+  # prints: [my-env] all removed successfully!
+
+  # Remove only unused secrets
+  genesis my-env remove-secrets --unused
+  # prints: [my-env] all unused secrets removed successfully!
+
+  # Remove a specific secret
+  genesis my-env remove-secrets secret/my-env/bosh/admin
+  # prints: [my-env] specified removed successfully!
+
+  # Remove invalid/expired secrets interactively
+  genesis my-env remove-secrets --invalid --interactive
+  # prints: (prompts per secret, then) [my-env] all removed successfully!
+
+=head2 env_shell($name)
+
+  genesis <env> env-shell [--no-bosh] [<options>]
+
+Open an interactive shell with the environment's credentials and context
+variables pre-loaded.  By default, BOSH director credentials are also
+sourced; use C<--no-bosh> to skip this.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Environment name string.  Exactly one argument is required.
+
+=back
+
+B<Options (via get_options):>
+
+=over 4
+
+=item C<--no-bosh>
+
+Do not load BOSH director credentials into the shell environment.
+
+=item C<--redact!>
+
+Redact sensitive values (default: redact when not writing to a live terminal).
+
+=back
+
+B<Returns:>
+
+Nothing.  Returns when the user exits the shell.
+
+B<Examples:>
+
+  # Open a shell with vault and BOSH credentials loaded
+  genesis my-env env-shell
+  # prints: (spawns an interactive shell with environment credentials loaded)
+
+  # Open a shell with only vault credentials (no BOSH)
+  genesis my-env env-shell --no-bosh
+  # prints: (spawns an interactive shell with vault credentials only)
+
+=head1 SEE ALSO
+
+L<Genesis::Commands>, L<Genesis::Env>, L<Genesis::Top>,
+L<Genesis::Commands::Bosh>, L<Genesis::Commands::Secrets>
+
+=head1 AUTHOR
+
+FiveTwenty, LLC
+
+=cut

--- a/lib/Genesis/Commands/Env.pod
+++ b/lib/Genesis/Commands/Env.pod
@@ -1208,7 +1208,7 @@ B<Examples:>
 =head1 SEE ALSO
 
 L<Genesis::Commands>, L<Genesis::Env>, L<Genesis::Top>,
-L<Genesis::Commands::Bosh>, L<Genesis::Commands::Secrets>
+L<Genesis::Commands::Bosh>
 
 =head1 AUTHOR
 

--- a/lib/Genesis/Commands/Info.pod
+++ b/lib/Genesis/Commands/Info.pod
@@ -1,0 +1,621 @@
+=head1 NAME
+
+Genesis::Commands::Info - Command handlers for Genesis information and inspection
+
+=head1 SYNOPSIS
+
+  # Registered in bin/genesis via define_command:
+  genesis <env> info [<timestamp>]
+  genesis <env> lookup <key> [<default>]
+  genesis <env> yamls
+  genesis <env> vault-paths
+  genesis <env> deployments
+  genesis <env> kit-manual [<name-or-version>]
+  genesis environments [@<type>:<env>]
+
+  # Import (not typically used directly):
+  use Genesis::Commands::Info;
+
+=head1 DESCRIPTION
+
+Provides the command handler functions for Genesis information and inspection
+commands.  Each function in this module is registered as a command handler via
+C<define_command> in the Genesis CLI dispatcher.
+
+The module covers six user-facing commands:
+
+=over 4
+
+=item C<genesis info>
+
+Display detailed deployment information for an environment, including the last
+successful deployment timestamp, the deploying user, the kit used, Genesis
+version, kit features, and an index of archived deployment artifacts.  Accepts
+an optional timestamp to inspect a specific historical deployment.
+
+=item C<genesis lookup>
+
+Query configuration values from an environment's YAML manifests, deployed
+exodus data, environment variables, or partial manifests.  Supports a legacy
+C<key/name> argument-order fallback for backward compatibility.
+
+=item C<genesis yamls>
+
+List the YAML files that Genesis merges to produce the final manifest for an
+environment.  Optionally view the contents of an individual file.
+
+=item C<genesis vault-paths>
+
+Print the Vault secret paths that the environment's manifest references.
+Optionally show the manifest keys that reference each path.
+
+=item C<genesis deployments>
+
+List deployment audit entries for an environment.  Requires the environment to
+use the C<exodus> or C<hybrid> manifest store.
+
+=item C<genesis kit-manual>
+
+Display the C<MANUAL.md> for a locally installed kit.  Accepts an environment
+name, kit name, or kit version as a lookup hint.
+
+=item C<genesis environments>
+
+Enumerate all Genesis environments found under the current and parent
+deployment roots.  Supports filtering by environment name and kit type,
+grouping by environment or repository, and JSON output.
+
+=back
+
+=head1 FUNCTIONS
+
+=head2 information($name, $timestamp)
+
+  information($env_name);
+  information($env_name, $timestamp);
+
+Handler for C<genesis info>.  Displays deployment information for the named
+environment.  When C<$timestamp> is provided the function locates the
+historical deployment whose timestamp matches (after stripping separator
+characters); otherwise it uses the most recent successful deployment, falling
+back to a synthesized record from current exodus data if no audit log entry
+exists.
+
+When the C<--print-artifact> option is set, retrieves and prints a single
+named artifact from the deployment, then exits.  When C<--fetch-artifacts-to>
+is set, downloads all deployment artifacts to the specified directory, then
+exits.  When C<--history> is set, appends the full deployment history to the
+output.  When the kit defines an C<info> hook and neither C<$timestamp> nor
+C<--history> is active, the hook is invoked after the standard output block.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The environment name string.
+
+=item C<$timestamp>
+
+Optional.  A timestamp string in any format that identifies a specific
+historical deployment.  Separator characters (spaces, slashes, colons, and
+C<T>) are stripped before matching.
+
+=back
+
+B<Errors:>
+
+=over 4
+
+=item C<"Cannot use timestamp arguement with environments that do not have deployment audit logs.  Please ensure the environment file specifies genesis.minimum_version of at least 3.1.0, and that the manifest_store is set to exodus or hybrid in the <repo>/.genesis/config file.">
+
+Raised when C<$timestamp> is given but the environment uses the C<repository>
+manifest store, which does not maintain an audit log.
+
+=item C<"Could not find a deployment with timestamp matching %s in environment %s.  Please ensure the timestamp is correct.">
+
+Raised when C<$timestamp> matches no deployment records.  C<%s> is the
+supplied timestamp string; the second C<%s> is the environment name.
+
+=item C<"Aborted!">
+
+Raised when the user cancels the interactive disambiguation prompt (shown when
+multiple deployments match the given timestamp) or when the user declines the
+overwrite confirmation during artifact fetch.
+
+=item C<"Artifact '%s' not found in deployment %s.  Please confirm the artifact exists.">
+
+Raised when the artifact type named by C<--print-artifact> does not exist in
+the selected deployment.  The first C<%s> is the artifact name; the second
+C<%s> is the deployment timestamp.
+
+=item C<"Deployment #%d has no artifacts to fetch.">
+
+Raised when C<--fetch-artifacts-to> is given but the selected deployment has
+no stored artifacts.  C<%d> is the deployment sequence number.
+
+=item C<"Currently Genesis does not support manifest validation for environments that store manifests in the repository.  Please set manifest_store in the environment's .genesis/config to exodus or hybrid to enable manifest validation.">
+
+Raised when the environment uses the C<repository> manifest store during the
+post-deployment output phase (manifest validation is not yet implemented for
+that store mode).
+
+=back
+
+B<Returns:> Nothing.  Outputs deployment information to the terminal and
+exits on early-exit paths (artifact print, artifact fetch).
+
+B<Examples:>
+
+  # Show information for the most recent deployment:
+  # CLI: genesis prod-us-east info
+  # prints: deployment summary to the terminal
+
+  # Show information for a specific historical deployment:
+  # CLI: genesis prod-us-east info "2025/03/01 14:32:00"
+  # prints: deployment summary for the matching audit record
+
+  # Print a specific deployment artifact:
+  # CLI: genesis prod-us-east info --print-artifact manifest
+  # prints: raw content of the stored manifest artifact
+
+  # Fetch all deployment artifacts to a directory:
+  # CLI: genesis prod-us-east info --fetch-artifacts-to ./artifacts
+  # prints: progress messages; artifacts written to ./artifacts/
+
+  # Show full deployment history:
+  # CLI: genesis prod-us-east info --history
+  # prints: deployment summary followed by a chronological history list
+
+=head2 lookup($name, $key, $default)
+
+  lookup($env_name, $key);
+  lookup($env_name, $key, $default);
+
+Handler for C<genesis lookup>.  Looks up C<$key> in the configuration source
+selected by the active option flag and prints the value.  Supports a legacy
+argument order where C<$name> and C<$key> were reversed; if C<$name> is not a
+known environment but C<$key> is, the two are swapped automatically.
+
+The lookup source is selected by exactly one of the following option flags:
+
+=over 4
+
+=item C<--merged>
+
+Query the fully merged manifest.  Sets the C<GENESIS__LOOKUP_MERGED_MANIFEST>
+environment variable to detect circular calls.
+
+=item C<--partial>
+
+Query the partially merged manifest (pre-operator-processing).  Also sets
+C<GENESIS__LOOKUP_MERGED_MANIFEST>.
+
+=item C<--deployed>
+
+Query the last deployed manifest as stored in the exodus data.
+
+=item C<--exodus> / C<--exodus-for>
+
+Query the environment's exodus metadata.  C<--exodus-for> implicitly sets
+C<--exodus> and scopes the lookup to the named sub-key.
+
+=item C<--env>
+
+Query environment variables, preferring the environment's own computed
+variables (from C<get_environment_variables>) over the process environment.
+An empty key returns all variables as a JSON object.
+
+=back
+
+When none of these flags is set the lookup is performed against the
+environment's YAML params (the default source).
+
+When C<--defined> is active the function exits with code C<0> if the key
+exists in the source or code C<4> if it does not; no value is printed.
+C<--defined> is incompatible with supplying a C<$default> value.
+
+When C<--entombed> is active, entombed (encrypted-at-rest) secrets are
+included in the lookup source.  This flag is incompatible with C<--exodus>,
+C<--exodus-for>, and C<--deployed>.
+
+If the resolved value is a reference (hash or array) it is serialized as
+JSON before output.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The environment name.  Swapped with C<$key> automatically when legacy
+argument order is detected.
+
+=item C<$key>
+
+The dotted-path key to look up (e.g., C<params.bosh_env> or C<kit.version>).
+
+=item C<$default>
+
+Optional.  Returned when the key is not found.  Incompatible with C<--defined>.
+
+=back
+
+B<Errors:>
+
+=over 4
+
+=item C<"Cannot use --entombed option with --exodus, --exodus-for or --deployed">
+
+Raised when C<--entombed> is combined with an exodus or deployed source flag.
+
+=item C<"Circular reference detected while trying to lookup merged manifest of $name">
+
+Raised when C<genesis lookup --merged> or C<--partial> is invoked recursively
+(e.g., from within a kit hook that itself calls C<genesis lookup --merged>).
+
+=back
+
+B<Returns:> Nothing.  Prints the resolved value to standard output and exits
+with code C<0>.  When C<--defined> is active, exits with code C<0> (found) or
+C<4> (not found) without printing.
+
+B<Examples:>
+
+  # Look up a param value from environment YAML:
+  # CLI: genesis prod-us-east lookup params.bosh_env
+  # Returns: prod-us-east
+
+  # Look up a value from the fully merged manifest:
+  # CLI: genesis prod-us-east lookup --merged instance_groups.0.name
+  # Returns: web
+
+  # Look up a value from exodus metadata:
+  # CLI: genesis prod-us-east lookup --exodus kit.version
+  # Returns: 2.3.1
+
+  # Check whether a key is defined (exits 0 or 4):
+  # CLI: genesis prod-us-east lookup --defined params.optional_key
+
+  # Look up with a default value:
+  # CLI: genesis prod-us-east lookup params.missing_key default-value
+  # Returns: default-value
+
+=head2 yamls($name)
+
+  yamls($env_name);
+
+Handler for C<genesis yamls>.  Lists the YAML files that Genesis assembles
+into the final manifest for the named environment.  By default kit files are
+included (controlled by the C<include-kit> option, which defaults to C<1>).
+
+When the C<--view> option is set, instead of listing all files, the function
+locates the named file and prints its contents.  The C<--view> value is checked
+against the special genesis meta-files C<init.yml> and C<fin.yml> first, then
+against the environment path, and finally against the kit path.  If the file
+is not found in any location, the function exits with an error.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The environment name string.
+
+=back
+
+B<Errors:>
+
+=over 4
+
+=item C<"File '%s' not found in environment '%s' or kit '%s'.">
+
+Raised when the file named by C<--view> does not exist in the environment
+path or the kit path.  The first C<%s> is the file name, the second is the
+environment name, and the third is the kit identifier.
+
+=back
+
+B<Returns:> Nothing.  Outputs a newline-separated list of file paths (or file
+contents when C<--view> is set) to standard output, then exits.
+
+B<Examples:>
+
+  # List all YAML files for an environment:
+  # CLI: genesis prod-us-east yamls
+  # Returns:
+  #   /path/to/kit/base.yml
+  #   /path/to/kit/addons/feature.yml
+  #   /path/to/prod.yml
+  #   /path/to/prod-us.yml
+  #   /path/to/prod-us-east.yml
+
+  # View the contents of a specific YAML file:
+  # CLI: genesis prod-us-east yamls --view prod-us-east.yml
+  # Returns: (raw YAML content of the file)
+
+=head2 vault_paths($name)
+
+  vault_paths($env_name);
+
+Handler for C<genesis vault-paths>.  Resolves the Vault secret paths referenced
+by the environment's merged manifest and prints them, sorted, one per line.
+
+When the C<--references> option is set (off by default), each path is followed
+by a bulleted list of the manifest keys that reference it.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The environment name string.
+
+=back
+
+B<Returns:> Nothing.  Outputs the list of Vault paths to standard output.
+
+B<Examples:>
+
+  # List all Vault paths used by the manifest:
+  # CLI: genesis prod-us-east vault-paths
+  # Returns:
+  #   secret/prod/us/east/bosh/admin
+  #   secret/prod/us/east/bosh/nats
+
+  # List Vault paths with referencing manifest keys:
+  # CLI: genesis prod-us-east vault-paths --references
+  # Returns:
+  #   secret/prod/us/east/bosh/admin:
+  #     - admin_password
+
+=head2 deployments($name)
+
+  deployments($env_name);
+
+Handler for C<genesis deployments>.  Lists deployment audit entries for the
+named environment.  The environment must use the C<exodus> or C<hybrid>
+manifest store; environments using the C<repository> store do not maintain a
+deployment audit log and cause the function to exit with an error.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The environment name string.
+
+=back
+
+B<Errors:>
+
+=over 4
+
+=item C<"This environment is configured to store manifests in the repository, which does not support deployment tracking.  Set the manifest_store in the environment's .genesis/config to exodus to move the manifests to the exodus store, or hybrid to store them in both.">
+
+Raised when the environment's manifest store is C<repository>.
+
+=back
+
+B<Returns:> Nothing.  (Implementation is currently incomplete; the collected
+deployment entry list is not yet output.)
+
+B<Examples:>
+
+  # List deployment history for an environment:
+  # CLI: genesis prod-us-east deployments
+  # prints: deployment audit entries (implementation pending)
+
+=head2 kit_manual($name)
+
+  kit_manual($name);
+  kit_manual();
+
+Handler for C<genesis kit-manual>.  Locates and displays the C<MANUAL.md> for
+a kit.  The C<$name> argument is used to resolve the kit:
+
+=over 4
+
+=item *
+
+If C<$name> matches a known environment, the kit used by that environment is
+resolved.
+
+=item *
+
+If C<$name> is C<"dev">, the local dev kit is used.
+
+=item *
+
+If C<$name> is a semantic version string and only one local kit is present,
+that kit at the given version is used.
+
+=item *
+
+Otherwise, C<$name> is parsed as C<< <kit-name>/<version> >> or C<< <kit-name> >>.
+
+=back
+
+When C<--raw> is set the Markdown content is printed without rendering.
+When C<--pager> is set the output is piped through C<less -R>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+Optional.  An environment name, kit name, C<"dev">, a semantic version string,
+or a C<< name/version >> composite.  When omitted and only one local kit exists,
+that kit is used.
+
+=back
+
+B<Errors:>
+
+=over 4
+
+=item C<"No local kits found; you must specify the name of the kit to fetch">
+
+Raised when no locally installed kits exist in the current deployment root.
+
+=item C<"More than one local kit found; please specify the kit to get the manual for">
+
+Raised when C<$name> is a bare version string and multiple local kits are
+present (ambiguous without a kit name).
+
+=item C<"Can't open pager: $!">
+
+Raised when the function cannot spawn C<less -R> for paged output.
+
+=back
+
+B<Returns:> Nothing.  Outputs the kit manual to standard output (or through the
+pager) and exits with code C<0> on success, or C<1> if the kit was not found
+or has no C<MANUAL.md>.
+
+B<Examples:>
+
+  # Display the manual for the kit used by an environment:
+  # CLI: genesis prod-us-east kit-manual prod-us-east
+  # prints: rendered MANUAL.md for the environment's kit
+
+  # Display the manual for a specific kit version:
+  # CLI: genesis prod-us-east kit-manual bosh/2.3.1
+  # prints: rendered MANUAL.md for the bosh kit at version 2.3.1
+
+  # Display the manual for the dev kit:
+  # CLI: genesis prod-us-east kit-manual dev
+  # prints: rendered MANUAL.md for the local dev kit
+
+  # Display raw Markdown without rendering:
+  # CLI: genesis prod-us-east kit-manual --raw
+  # prints: raw MANUAL.md content without color or formatting
+
+  # Display through a pager:
+  # CLI: genesis prod-us-east kit-manual --pager
+  # prints: rendered MANUAL.md piped through less -R
+
+=head2 environments()
+
+  environments();
+
+Handler for C<genesis environments>.  Enumerates all Genesis environments found
+under the deployment roots relative to the current directory.  The function
+builds a root map containing the current directory (labeled C<@current>) and its
+parent directory (labeled C<@parent>), then scans each root for Genesis
+repositories.
+
+Output is controlled by the following options:
+
+=over 4
+
+=item C<--details>
+
+Show extended information for each environment: kit version, last deployment
+date and user, BOSH director name, and vault status.  Enables a progress
+indicator during the scan.
+
+=item C<--group-by-env>
+
+Group output by environment name across all repositories (default is to group
+by repository/kit type).
+
+=item C<--json>
+
+Emit the full environment data as a JSON object instead of human-readable
+output.
+
+=back
+
+When the C<GENESIS_PREFIX_TYPE> environment variable is C<"search">, the
+function reads the search pattern from C<GENESIS_PREFIX_SEARCH>.  The pattern
+is parsed as C<< @<env-pattern>:<type-pattern> >> and used to filter the list
+of environments and repository types.
+
+B<Parameters:> None.
+
+B<Returns:> Nothing.  Outputs environment information to the terminal (or JSON
+to standard output when C<--json> is set).
+
+B<Examples:>
+
+  # List all environments grouped by repository:
+  # CLI: genesis environments
+
+  # List all environments with extended details:
+  # CLI: genesis environments --details
+
+  # Group environments by name instead of repository:
+  # CLI: genesis environments --group-by-env
+
+  # Emit JSON output:
+  # CLI: genesis environments --json
+
+=head1 INTERNAL METHODS
+
+These functions are internal to the implementation.  They may change without
+notice and should not be called directly.
+
+=head2 __processing($block, $total, $strobe, $strobe_size)
+
+  __processing($block, $total, $strobe);
+  __processing($block, $total, $strobe, $strobe_size);
+
+Renders an animated progress bar to the terminal during multi-step scans such
+as the C<environments --details> scan.  The bar shows a percentage of
+completion and a bouncing strobe indicator.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$block>
+
+The number of items processed so far.
+
+=item C<$total>
+
+The total number of items to process.
+
+=item C<$strobe>
+
+A monotonically increasing counter used to animate the strobe position.
+
+=item C<$strobe_size>
+
+Optional.  The width of the strobe window in characters.  Defaults to C<7>.
+
+=back
+
+B<Returns:> Nothing.  Writes the progress bar directly to the terminal using
+the C<info> function with C<pending =E<gt> 1>.
+
+B<Examples:>
+
+  # Called during an environments --details scan:
+  __processing(5, 20, 3);
+  # prints:   Processing:  25%: [  ***   ]
+
+  # With a custom strobe window size:
+  __processing(10, 20, 4, 5);
+  # prints:   Processing:  50%: [  *  ]
+
+=head1 SEE ALSO
+
+L<Genesis::Commands>, L<Genesis::Commands::Ocfp>, L<Genesis::Top>,
+L<Genesis::Env>, L<Genesis::Env::Deployment>
+
+=head1 AUTHOR
+
+FiveTwenty, LLC
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Commands/Kit.pod
+++ b/lib/Genesis/Commands/Kit.pod
@@ -1,0 +1,809 @@
+=head1 NAME
+
+Genesis::Commands::Kit - Command handlers for Genesis kit management
+
+=head1 SYNOPSIS
+
+  # Registered in bin/genesis via define_command:
+  genesis create-kit --name <name> [--dev]
+  genesis build-kit [options]
+  genesis list-kits [name] [options]
+  genesis decompile-kit <kit> [options]
+  genesis fetch-kit [name[/version]] [options]
+  genesis compare-kits [release[/job] ...] [options]
+
+  # From Perl (called by Genesis command dispatch):
+  use Genesis::Commands::Kit;
+  Genesis::Commands::Kit::create_kit();
+  Genesis::Commands::Kit::build_kit();
+  Genesis::Commands::Kit::list_kits(@args);
+  Genesis::Commands::Kit::decompile_kit(@args);
+  Genesis::Commands::Kit::fetch_kit(@kits);
+  Genesis::Commands::Kit::compare_kits(@filters);
+
+=head1 DESCRIPTION
+
+Provides the command handler functions for Genesis kit management operations.
+Each function in this module corresponds to a C<genesis> CLI subcommand and is
+registered via C<define_command> in the Genesis binary.
+
+Kit management covers the full lifecycle of Genesis kits: scaffolding new kit
+source trees, compiling kit source into distributable tarballs, listing local
+and remote kit versions, decompiling kit archives back into editable
+directories, fetching kits from remote providers, and comparing BOSH release
+inventories between two kit versions.
+
+All functions read CLI options via the C<get_options> function from
+L<Genesis::Commands> and resolve the current directory context via
+L<Genesis::Top>.
+
+=head1 FUNCTIONS
+
+=head2 create_kit()
+
+  genesis create-kit --name <name> [--dev]
+
+Scaffolds a new Genesis kit source directory.  Reads the kit name from the
+C<--name> option and delegates to L<Genesis::Kit::Compiler/scaffold>.
+
+B<Options (via get_options):>
+
+=over 4
+
+=item C<name> (required)
+
+The name of the new kit.  The directory is created at C<< <name>-genesis-kit/ >>
+in the current directory, or at C<dev/> if C<--dev> is also specified.
+
+=item C<dev>
+
+When set, the kit is scaffolded into the C<dev/> directory instead of the
+standard C<< <name>-genesis-kit/ >> directory.
+
+=back
+
+Exits with usage if C<--name> is not provided.
+
+B<Returns:> Nothing.  Prints a confirmation message on success.
+
+B<Examples:>
+
+  # Create a new kit named "my-app"
+  genesis create-kit --name my-app
+  # prints: Created new Genesis kit 'my-app' in /path/to/my-app-genesis-kit
+
+  # Scaffold into the dev/ directory of a deployment repo
+  genesis create-kit --name my-app --dev
+  # prints: Created new Genesis kit 'my-app' in /path/to/dev
+
+=head2 build_kit()
+
+  genesis build-kit [--name <name>] [--version <ver>|--major|--minor|--final]
+                    [--target <dir>] [--dev] [--force]
+
+Compiles a Genesis kit source directory into a distributable C<.tar.gz>
+archive.  Determines the kit name and source directory from options or the
+current directory layout.  Checks both local and remote kit versions to
+propose the next semver, then prompts for confirmation before compiling.
+
+B<Options (via get_options):>
+
+=over 4
+
+=item C<name>
+
+Kit name.  If omitted, inferred from the current directory name.  When run
+from inside a deployment repo with a C<dev/> directory containing
+C<kit.yml>, the kit name is derived from the repo directory name.  When run
+from a C<< <name>-genesis-kit >> directory, the kit name is derived from the
+directory name.
+
+=item C<version>
+
+Explicit semver string for the build (e.g., C<1.2.3> or C<v1.2.3>).  Cannot
+be combined with C<--final>, C<--major>, or C<--minor>.
+
+=item C<major>
+
+Bump the major version component.  Cannot be combined with C<--minor>.
+
+=item C<minor>
+
+Bump the minor version component.  Cannot be combined with C<--major>.
+
+=item C<final>
+
+Build a final (non-RC) release.  When omitted, the build version receives an
+C<-rcNNNNN> pre-release suffix.
+
+=item C<target>
+
+Output directory for the compiled archive.  Defaults to C<.>.  If the target
+directory contains a C<.genesis/config> file (a deployment repo), the archive
+is placed in C<.genesis/kits/> within that directory.
+
+=item C<dev>
+
+Compile from the C<dev/> directory rather than the kit source root.
+
+=item C<force>
+
+Allow overwriting an existing version.
+
+=back
+
+Takes no positional arguments.  Exits with usage if any arguments are
+provided.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Current directory is a kit -- cannot specify dev mode\n">
+
+Raised when C<--dev> is combined with a run from a named kit directory.
+
+=item C<"Version #C{$options{version}} is not in a valid semver format">
+
+Raised when the value passed to C<--version> does not parse as semver.
+The C<#C{...}> markup highlights the version string in terminal output.
+
+=item C<"Cannot specify --version|-v if also specifying --final|-F, --major|-M or --minor|-m">
+
+Raised when C<--version> is combined with any automatic version-bump option.
+
+=item C<"Version %s already exists: use --force to recreate a potentially different one locally.">
+
+Raised when the specified version already exists remotely or locally and
+C<--force> was not provided.  The C<%s> placeholder is the version string.
+
+=item C<"Cannot specify both --major|-M and --minor|-m">
+
+Raised when C<--major> and C<--minor> are both provided.
+
+=item C<"Aborted by user.\n">
+
+Raised when the user declines the version confirmation prompt.
+
+=item C<"%s does not exist -- cannot continue compiling dev kit.\n">
+
+Raised when C<--dev> is in effect but the C<dev/> directory is absent.
+The C<%s> placeholder is the directory path.
+
+=item C<"Unable to compile v%s of %s Genesis Kit.\n">
+
+Raised when L<Genesis::Kit::Compiler/compile> fails.  The first C<%s> is
+the version string and the second is the kit name.
+
+=back
+
+B<Returns:> Nothing.  Prints the path of the compiled archive on success.
+
+B<Examples:>
+
+  # Auto-detect name and bump patch version (from kit source dir)
+  cd my-app-genesis-kit
+  genesis build-kit
+  # prints: Compiled my-app v0.1.1-rc00001 to ./my-app-0.1.1-rc00001.tar.gz
+
+  # Build a final minor-bumped release to a specific deployment repo
+  genesis build-kit --minor --final --target /path/to/my-deployments
+  # prints: Compiled my-app v0.2.0 to /path/to/my-deployments/.genesis/kits/my-app-0.2.0.tar.gz
+
+  # Build an explicit version, forcing overwrite
+  genesis build-kit --version 1.2.3 --force
+  # prints: Compiled my-app v1.2.3 to ./my-app-1.2.3.tar.gz
+
+=head2 list_kits()
+
+  genesis list-kits [name] [--remote|-r] [--updates|-u] [--all|-a]
+                    [--filter <regex>] [--latest <n>]
+                    [--prereleases] [--drafts] [--details]
+
+Lists Genesis kits.  By default, lists locally cached kits from the current
+deployment repo.  With C<--remote>, queries the configured remote kit provider
+instead.  With C<--updates>, lists only remote versions newer than the locally
+installed version.
+
+B<Arguments:>
+
+=over 4
+
+=item C<name> (optional)
+
+Restrict output to a single kit by name.  Cannot be combined with
+C<--filter> or C<--all>.
+
+=back
+
+B<Options (via get_options):>
+
+=over 4
+
+=item C<remote> / C<-r>
+
+List remote kit versions instead of local.  Cannot be combined with
+C<--updates>.
+
+=item C<updates> / C<-u>
+
+List only remote versions newer than the locally installed version.  Cannot
+be combined with C<--remote>.
+
+=item C<all> / C<-a>
+
+When used with C<--remote>, list all remote kits rather than limiting to
+locally installed kit names.  Cannot be combined with a positional name or
+C<--filter>.
+
+=item C<filter>
+
+Regex pattern to filter kit names when listing remote kits.  Cannot be
+combined with a positional name argument.
+
+=item C<latest>
+
+Limit output to the most recent N versions per kit.
+
+=item C<prereleases>
+
+Include pre-release versions when listing remote kits.
+
+=item C<drafts>
+
+Include draft releases when listing remote kits.
+
+=item C<details>
+
+Show release notes and publication dates alongside version listings.
+Enabled automatically when C<--updates> is used.
+
+=back
+
+Must be run from a Genesis deployment repo, or C<--remote> must be specified.
+Exits with status 1 if neither condition is met.
+
+B<Returns:> Nothing.  Writes kit and version listings to standard output.
+
+B<Examples:>
+
+  # List all locally cached kits in the current deployment repo
+  genesis list-kits
+  # prints: Kit: cf
+  #           * v1.5.0
+
+  # List all available remote versions of the "cf" kit
+  genesis list-kits cf --remote
+  # prints: Kit: cf
+  #           * v1.5.0
+
+  # Check for updates to all locally installed kits
+  genesis list-kits --updates
+  # prints: There is 1 update for the cf kit (currently using v1.4.0):
+
+  # List latest 3 versions of all remote kits with release notes
+  genesis list-kits --remote --all --latest 3 --details
+  # prints: Kit: cf
+  #           * Release Notes for v1.5.0 ...
+
+=head2 decompile_kit()
+
+  genesis decompile-kit <kit> [--directory <dir>] [--force]
+
+Extracts a compiled kit archive into an editable source directory.  The kit
+argument may be:
+
+=over 4
+
+=item *
+
+A path to a C<.tar.gz> archive file
+
+=item *
+
+An environment name (C<.yml> extension allowed), in which case the kit used
+by that environment is resolved automatically
+
+=item *
+
+A kit name (resolves to the locally installed latest version)
+
+=item *
+
+A C<name/version> pair (e.g., C<cf/1.2.3>)
+
+=item *
+
+The keyword C<latest> (resolves to the latest locally installed kit version)
+
+=back
+
+B<Arguments:>
+
+=over 4
+
+=item C<$kit> (required)
+
+Kit specifier.  Exactly one argument must be provided.
+
+=back
+
+B<Options (via get_options):>
+
+=over 4
+
+=item C<directory>
+
+Target directory for extraction.  Defaults to C<dev/>.
+
+=item C<force>
+
+Allow overwriting an existing C<dev/> directory.
+
+=back
+
+B<Errors:>
+
+=over 4
+
+=item C<"#C{%s} directory already exists (and --force not specified).\nWill not continue.">
+
+Raised when the target directory is C<dev/>, a dev kit already exists there,
+and C<--force> was not provided.  The C<#C{...}> markup highlights the
+directory path in terminal output.
+
+=item C<"#R{[ERROR]} #C{%s} should be an environment YAML file, but could not be loaded">
+
+Raised when the kit argument matches an environment name but the environment
+file cannot be loaded.  The C<#C{...}> markup highlights the file path in
+terminal output.
+
+=item C<"Environment #C{%s} is already using a dev kit, and we don't want to get into metaphysical absurities...">
+
+Raised when the resolved environment is already using a dev kit.  The
+C<#C{...}> markup highlights the environment name in terminal output.
+
+=item C<"There are multiple kits have the given version - please be explicit">
+
+Raised when the version string matches more than one locally installed kit.
+
+=item C<"Unable to find Kit archive %s\n">
+
+Raised when no matching kit archive can be located.  The C<%s> placeholder
+is the original kit specifier provided by the caller.
+
+=back
+
+B<Returns:> Nothing.  Extracts the kit archive and prints a confirmation message.
+
+B<Examples:>
+
+  # Decompile the kit used by the "us-east-prod" environment
+  genesis decompile-kit us-east-prod
+  # prints: Decompiling kit archive cf/1.5.0 into dev/
+
+  # Decompile the latest locally installed "cf" kit into dev/
+  genesis decompile-kit cf
+  # prints: Decompiling kit archive cf/1.5.0 (latest) into dev/
+
+  # Decompile a specific version into an alternate directory
+  genesis decompile-kit cf/1.5.0 --directory /tmp/kit-work
+  # prints: Decompiling kit archive cf/1.5.0 into /tmp/kit-work/
+
+  # Overwrite an existing dev/ directory
+  genesis decompile-kit latest --force
+  # prints: Decompiling kit archive cf/1.5.0 (latest) into dev/
+
+=head2 fetch_kit()
+
+  genesis fetch-kit [name[/version] ...] [--as-dev] [--force] [--to <dir>]
+
+Downloads one or more Genesis kit archives from the configured remote
+provider.  If no kit names are specified, all locally known kits are fetched.
+Each kit may optionally include a version specifier (e.g., C<cf/1.2.3>); if
+omitted, the latest available version is fetched.
+
+When C<--as-dev> is specified, the downloaded kit is also decompiled into the
+C<dev/> directory of the current deployment repo.
+
+B<Arguments:>
+
+=over 4
+
+=item C<@kits> (optional)
+
+List of kit specifiers in the form C<name> or C<name/version>.  A bare
+version string (semver) is also accepted when only one local kit is present,
+in which case that kit's name is used automatically.
+
+=back
+
+B<Options (via get_options):>
+
+=over 4
+
+=item C<as-dev>
+
+Decompile the fetched kit into C<dev/> after downloading.  Only one kit may
+be fetched at a time when this option is set.
+
+=item C<force>
+
+Allow overwriting an existing C<dev/> directory when C<--as-dev> is used.
+
+=item C<to>
+
+Override the download destination directory.
+
+=back
+
+B<Errors:>
+
+=over 4
+
+=item C<"No local kits found; you must specify the name of the kit to fetch">
+
+Raised when no kits are specified and no locally installed kits exist, or
+when a bare version is provided but no local kits exist.
+
+=item C<"Cannot specify multiple kits to fetch with --as-dev option">
+
+Raised when more than one kit specifier is provided together with C<--as-dev>.
+
+=item C<"More than one local kit found; please specify the kit to fetch">
+
+Raised when a bare version string is provided but more than one local kit
+exists.
+
+=item C<"dev/ directory already exists (and --force not specified).  Bailing out.">
+
+Raised when C<--as-dev> is set, a dev kit already exists, and C<--force> was
+not provided.
+
+=item C<"Failed to download Genesis Kit %s">
+
+Raised when the remote download fails.  The C<%s> placeholder is the
+C<name/version> signature of the kit being fetched.
+
+=back
+
+B<Returns:> Nothing.  Prints a confirmation line for each kit downloaded.
+
+B<Examples:>
+
+  # Fetch the latest version of all locally known kits
+  genesis fetch-kit
+  # prints: Downloaded version 1.5.0 of the cf kit
+
+  # Fetch a specific version of the "cf" kit
+  genesis fetch-kit cf/1.5.0
+  # prints: Downloaded version 1.5.0 of the cf kit
+
+  # Fetch and decompile the latest "bosh" kit into dev/
+  genesis fetch-kit bosh --as-dev
+  # prints: Downloaded version 2.1.0 of the bosh kit and decompiled it into dev/
+
+  # Fetch multiple kits by name (latest of each)
+  genesis fetch-kit cf bosh
+  # prints: Downloaded version 1.5.0 of the cf kit
+  # prints: Downloaded version 2.1.0 of the bosh kit
+
+=head2 compare_kits()
+
+  genesis compare-kits [release[/job] ...] [--compare-to <ref>]
+                       [--show-unchanged-jobs]
+
+Compares the BOSH release inventory and job specifications between the current
+dev kit and a reference kit version.  Must be run from a Genesis deployment
+repo containing a C<dev/> kit, or from a Genesis kit source directory.
+
+The comparison reference (C<--compare-to>) may be a semver string, a
+directory path, or a C<.tar.gz> path.  When omitted, defaults to the latest
+locally installed version of the kit (in a deployment repo) or the latest
+remote version (in a kit directory).
+
+For each changed release, job C<spec> files are fetched from the upstream
+GitHub repository and compared using C<spruce diff>.  A C<spec_cache_dir>
+setting in C<~/.genesis/config> is used to cache downloaded spec archives and
+avoid repeated network fetches.
+
+B<Arguments:>
+
+=over 4
+
+=item C<@filters> (optional)
+
+One or more filter expressions limiting comparison output to specific releases
+or jobs.  Each filter is a release name or a C<release/job> pair.
+
+=back
+
+B<Options (via get_options):>
+
+=over 4
+
+=item C<compare-to>
+
+Reference to compare against.  Accepts a semver version string (e.g.,
+C<1.2.3> or C<v1.2.3>), a directory path to a kit source tree, or a path to
+a compiled C<.tar.gz> kit archive.
+
+=item C<show-unchanged-jobs>
+
+When set, unchanged job specs are also reported in the output.
+
+=back
+
+B<Errors:>
+
+=over 4
+
+=item C<"No kit found -- must be in a Genesis deployment repo or kit directory">
+
+Raised when the current directory is neither a Genesis deployment repo with a
+C<dev/> kit nor a Genesis kit source directory.
+
+=item C<"No local #M{%s} kits found to compare against\n">
+
+Raised when no C<--compare-to> reference is given while in a deployment repo
+and no locally installed versions of the kit are found.  The C<#M{...}>
+markup highlights the kit name in terminal output.
+
+=item C<"Failed to download Genesis Kit %s">
+
+Raised when fetching the comparison kit from the remote provider fails.  The
+C<%s> placeholder is the C<name/version> string.
+
+=item C<"Cannot compare kit against %s -- must be a directory, tarball, or version">
+
+Raised when C<--compare-to> is provided but is neither a valid semver, a
+directory, nor a C<.tar.gz> file.  The C<%s> placeholder is the value
+provided to C<--compare-to>.
+
+=back
+
+B<Returns:> Nothing.  Prints categorized output sections for removed,
+unchanged, added, and changed releases, followed by per-job spec diffs for
+changed releases.  Exits 0 on completion.
+
+B<Examples:>
+
+  # Compare dev/ kit against the latest locally installed version
+  cd my-deployments
+  genesis compare-kits
+  # prints: Unchanged Releases: ...  Changed Releases: ...
+
+  # Compare against a specific remote version
+  genesis compare-kits --compare-to 1.4.0
+  # prints: Changed Releases: cf-routing (1.4.0 -> 1.5.0)
+
+  # Compare only the "cf-routing" release
+  genesis compare-kits cf-routing
+  # prints: Changed Releases: cf-routing ...
+
+  # Compare specific jobs within a release
+  genesis compare-kits cf-routing/route_registrar cf-routing/gorouter
+  # prints: Spec Changes in Changed Releases: ...
+
+  # Compare against a local tarball
+  genesis compare-kits --compare-to /tmp/cf-1.5.0.tar.gz
+  # prints: Removed Releases: ...  Added Releases: ...
+
+=head1 INTERNAL METHODS
+
+These functions are internal to the implementation.  They may change without
+notice and should not be called directly.
+
+=head2 _get_kit_releases($kit, @filters)
+
+  _get_kit_releases($kit, @filters)
+
+Scans all YAML files in a kit's directory tree to extract BOSH release
+entries.  Processes both C<spruce merge>-style release blocks (files
+containing a top-level C<releases:> key) and BOSH op-patch-style files
+(files containing C<path: /releases/...> entries).  Release entries with
+both a C<name> and a C<version> are indexed; entries missing either field
+are collected separately.
+
+When C<@filters> is non-empty, limits results to the release names named in
+the filter list.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$kit>
+
+A kit object (L<Genesis::Kit::Dev> or L<Genesis::Kit::Compiled>) with a
+C<path> method for resolving kit file paths.
+
+=item C<@filters>
+
+Optional list of release or C<release/job> filter expressions.  Only the
+release-name component (before C</>) is used for filtering.
+
+=back
+
+B<Returns:> A three-element list:
+
+=over 4
+
+=item C<$releases>
+
+Hashref keyed by release name, then version.  Each leaf is a release data
+hashref with at minimum C<name>, C<version>, C<__src> (source file path
+relative to the kit root), and C<__type> (C<merge> or C<patch>).
+
+=item C<$release_versions>
+
+Hashref keyed by release name.  Each value is an arrayref of single-key
+hashrefs mapping version string to the release data hashref.
+
+=item C<\%duplicate_releases>
+
+Hashref containing only those release names that appear with more than one
+distinct version within the kit.
+
+=back
+
+B<Examples:>
+
+  my ($releases, $versions, $dups) = _get_kit_releases($kit);
+  # Returns: ({cf-routing => {1.5.0 => {...}}}, {...}, {})
+
+  my ($releases, $versions, $dups) = _get_kit_releases($kit, 'cf-routing');
+  # Returns: ({cf-routing => {1.5.0 => {...}}}, {...}, {})
+
+=head2 _get_spec_url($release)
+
+  _get_spec_url($release)
+
+Resolves the GitHub repository URL for a BOSH release given its release data
+hashref.  Normalizes download URLs from S3, Google Cloud Storage, bosh.io,
+and GitHub into a bare C<https://github.com/E<lt>orgE<gt>/E<lt>repoE<gt>> URL.
+
+For S3 and GCS URLs, the resolution consults the C<repos> list in the
+C<repo> (and optionally C<alt_repo>) field of the release hashref to find a
+matching GitHub URL by release name.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$release>
+
+Hashref with keys C<name>, C<version>, C<url> (the BOSH release download
+URL), and C<repo> (the upstream repo map hashref, which contains a C<repos>
+arrayref of C<< {name, repo} >> entries).
+
+=back
+
+B<Returns:> A GitHub repository URL string, or C<undef> if no mapping can be
+found.
+
+B<Examples:>
+
+  my $url = _get_spec_url({
+    name    => 'cf-routing',
+    version => '1.5.0',
+    url     => 'https://github.com/cloudfoundry/routing-release/releases/download/v1.5.0/routing-1.5.0.tgz',
+    repo    => {repos => []},
+  });
+  # Returns: 'https://github.com/cloudfoundry/routing-release'
+
+=head2 _get_spec_tarball($release, $path)
+
+  _get_spec_tarball($release, $path)
+
+Downloads the source tarball for a BOSH release from its GitHub repository
+so that job C<spec> files can be extracted.  Caches the downloaded tarball
+under C<$path> using the pattern
+C<< <org>--<repo>/<name>-<version>-src.tar.gz >>.
+Returns the cached file path immediately on a cache hit.
+
+When the GitHub Releases API returns 404, falls back to checking the
+repository's tag archive endpoints for both C<v<version>> and bare
+C<<version>> tag names.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$release>
+
+Hashref with keys C<name>, C<version>, and C<spec_url> (the bare GitHub
+repository URL from C<_get_spec_url()>).
+
+=item C<$path>
+
+Base directory under which the tarball cache is stored.
+
+=back
+
+B<Returns:> A two-element list C<($file, $error)>.
+
+=over 4
+
+=item On success: C<($file, undef)>
+
+C<$file> is the absolute path to the downloaded (or cached) tarball.
+
+=item On failure: C<(undef, $error)>
+
+C<$error> is a human-readable error string describing what went wrong.
+
+=back
+
+B<Examples:>
+
+  my ($file, $err) = _get_spec_tarball($release, '/tmp/spec-cache');
+  # Returns: ('/tmp/spec-cache/cloudfoundry--routing-release/cf-routing-1.5.0-src.tar.gz', undef)
+
+  my ($file, $err) = _get_spec_tarball($bad_release, '/tmp/spec-cache');
+  # Returns: (undef, 'Failed to fetch release information for cf-routing/v1.5.0 ...')
+
+=head2 _decompile_kit($top, $file, $dir)
+
+  _decompile_kit($top, $file, $dir)
+
+Extracts a compiled kit C<.tar.gz> archive into a writable directory.
+Validates that the archive contains exactly one top-level directory (a
+requirement of the Genesis kit format) and that the target directory either
+does not exist or is already a valid kit directory (contains C<kit.yml>).
+
+B<Parameters:>
+
+=over 4
+
+=item C<$top>
+
+A L<Genesis::Top> object providing path resolution for the repository root.
+
+=item C<$file>
+
+Path to the compiled kit C<.tar.gz> archive.
+
+=item C<$dir>
+
+Target directory for extraction.  Defaults to the C<dev/> subdirectory of
+the top-level repository root when not provided.
+
+=back
+
+B<Errors:>
+
+=over 4
+
+=item C<"#C{%s} already exists, but does not appear to be a kit directory.\nCowardly refusing to continue...">
+
+Raised when the target directory exists but does not contain C<kit.yml>.
+The C<#C{...}> markup highlights the directory path in terminal output.
+
+=item C<"#C{%s} does not look like a valid compiled kit">
+
+Raised when the archive does not contain exactly one top-level directory.
+The C<#C{...}> markup highlights the archive file path in terminal output.
+
+=back
+
+B<Returns:> Nothing.  The archive contents are extracted into C<$dir> with the
+top-level directory component stripped.
+
+B<Examples:>
+
+  _decompile_kit($top, '/path/to/cf-1.5.0.tar.gz', '/path/to/dev');
+  # Returns: nothing; extracts kit files into /path/to/dev/
+
+  _decompile_kit($top, '/path/to/cf-1.5.0.tar.gz');
+  # Returns: nothing; extracts kit files into $top->path('dev')
+
+=head1 SEE ALSO
+
+L<Genesis::Kit::Compiler>, L<Genesis::Kit::Compiled>, L<Genesis::Kit::Dev>,
+L<Genesis::Top>, L<Genesis::Commands>, L<Service::Github>
+
+=head1 AUTHOR
+
+FiveTwenty, LLC
+
+=cut

--- a/lib/Genesis/Commands/Pipelines.pod
+++ b/lib/Genesis/Commands/Pipelines.pod
@@ -1,0 +1,878 @@
+=head1 NAME
+
+Genesis::Commands::Pipelines - Command handlers for Genesis CI/CD pipeline management
+
+=head1 SYNOPSIS
+
+  # Registered in bin/genesis via define_command:
+  genesis embed
+  genesis repipe [layout] [--config ci.yml] [--target <fly-target>] [--dry-run] [--yes] [--paused]
+  genesis graph  [layout] [--config ci.yml]
+  genesis describe [layout] [--config ci.yml]
+
+  # Invoked automatically by Concourse CI pipeline tasks:
+  genesis ci-pipeline-deploy
+  genesis ci-show-changes
+  genesis ci-generate-cache
+  genesis ci-pipeline-run-errand
+
+=head1 DESCRIPTION
+
+Provides command handlers for Genesis CI/CD pipeline management.  There are
+two distinct groups of commands in this module:
+
+=over 4
+
+=item Pipeline management (operator-facing)
+
+C<embed>, C<repipe>, C<graph>, and C<describe> are run by a Genesis operator
+to embed the Genesis binary, configure a Concourse pipeline, visualize the
+pipeline dependency graph, or display a human-readable pipeline description.
+
+=item Pipeline task handlers (Concourse-facing)
+
+C<ci_pipeline_deploy>, C<ci_show_changes>, C<ci_generate_cache>, and
+C<ci_pipeline_run_errand> are invoked by Concourse pipeline tasks.  They read
+configuration from environment variables and perform deployment, cache
+management, errand execution, and change display operations on behalf of the
+CI pipeline.
+
+=back
+
+The pipeline task handlers authenticate to Vault via AppRole credentials
+(C<VAULT_ROLE_ID> and C<VAULT_SECRET_ID>) and interact with a remote
+Vault server via L<Service::Vault::Remote>.  Git operations are performed
+using credentials supplied via C<GIT_PRIVATE_KEY> (SSH) or
+C<GIT_USERNAME>/C<GIT_PASSWORD> (HTTPS).
+
+=head1 FUNCTIONS
+
+=head2 embed()
+
+    genesis embed
+
+Embeds the current Genesis binary into the deployment repository under
+C<.genesis/>.  This ensures that all pipeline tasks use the same Genesis
+version that was present when the pipeline was configured.
+
+The binary to embed is taken from the C<GENESIS_CALLBACK_BIN> environment
+variable, falling back to C<$0> (the currently executing Genesis binary).
+
+Takes no arguments.  Prints usage and exits if any arguments are supplied.
+
+B<Returns:> The return value of C<Genesis::Top-E<gt>embed>.
+
+B<Examples:>
+
+  # Embed the currently running genesis binary into the deployment repo
+  genesis embed
+
+=head2 repipe([$layout])
+
+    genesis repipe
+    genesis repipe sandbox
+    genesis repipe --config ci.yml --target my-concourse --dry-run
+
+Generates and uploads a Concourse pipeline configuration from the genesis
+CI config file.  Parses the pipeline definition, generates Concourse YAML,
+then pauses, sets, unpauses, and exposes or hides the pipeline via the
+C<fly> CLI.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$layout> (optional)
+
+The pipeline layout to use.  Defaults to the layout inferred from the CI
+config file when omitted.
+
+=back
+
+B<Options (via C<get_options>):>
+
+=over 4
+
+=item C<--config> (default: C<ci.yml>)
+
+Path to the CI config file to parse.
+
+=item C<--target>
+
+The Concourse C<fly> target to use.  Defaults to the layout name when not
+specified.
+
+=item C<--dry-run>
+
+Print the generated Concourse YAML to standard output and exit without
+uploading.
+
+=item C<--yes>
+
+Pass the C<-n> flag to C<fly set-pipeline> to skip interactive confirmation.
+
+=item C<--paused>
+
+Leave the pipeline paused after uploading instead of unpausing it.
+
+=back
+
+B<Returns:> Nothing.  Exits 0 on success.  When C<--dry-run> is specified,
+prints the Concourse YAML to standard output and exits 0 without uploading.
+
+B<Errors:>
+
+Calls C<bail()> with C<"No vault specified or configured."> if no Vault is
+configured.
+
+Calls C<bail()> with C<"Could not pause %s pipeline: %s"> (where the first
+C<%s> is the pipeline name and the second is the command output) if
+C<fly pause-pipeline> fails with an error other than
+C<pipeline '...' not found>.
+
+Calls C<bail()> via C<onfailure> if C<fly set-pipeline>,
+C<fly unpause-pipeline>, C<fly expose-pipeline>, or C<fly hide-pipeline>
+fails.
+
+B<Examples:>
+
+  # Upload pipeline using defaults
+  genesis repipe
+  # Returns: exits 0 on success
+
+  # Preview the generated pipeline YAML without uploading
+  genesis repipe --dry-run
+  # Prints: Concourse YAML to standard output
+
+  # Upload with a specific Concourse target
+  genesis repipe --target prod-concourse
+  # Returns: exits 0 on success
+
+=head2 graph([$layout])
+
+    genesis graph
+    genesis graph sandbox
+
+Generates and prints a Graphviz DOT-format representation of the pipeline
+dependency graph.  The DOT output can be piped to C<dot> or rendered with any
+Graphviz tool.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$layout> (optional)
+
+The pipeline layout to use.  Defaults to the layout inferred from the CI
+config file when omitted.
+
+=back
+
+B<Options (via C<get_options>):>
+
+=over 4
+
+=item C<--config> (default: C<ci.yml>)
+
+Path to the CI config file to parse.
+
+=back
+
+B<Returns:> Prints the Graphviz DOT source to standard output.
+
+B<Examples:>
+
+  # Print DOT graph for the default pipeline
+  genesis graph
+
+  # Render pipeline graph as PNG
+  genesis graph | dot -Tpng -o pipeline.png
+
+=head2 describe([$layout])
+
+    genesis describe
+    genesis describe sandbox
+
+Parses the pipeline configuration and prints a human-readable description
+of the environments and their pass/trigger relationships.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$layout> (optional)
+
+The pipeline layout to use.  Defaults to the layout inferred from the CI
+config file when omitted.
+
+=back
+
+B<Options (via C<get_options>):>
+
+=over 4
+
+=item C<--config> (default: C<ci.yml>)
+
+Path to the CI config file to parse.
+
+=back
+
+B<Returns:> Prints the pipeline description to standard output.
+
+B<Examples:>
+
+  # Describe the default pipeline
+  genesis describe
+
+  # Describe a specific pipeline layout
+  genesis describe sandbox
+
+=head2 ci_pipeline_deploy()
+
+    genesis ci-pipeline-deploy
+
+Concourse pipeline task handler that authenticates to Vault, propagates
+cached files from the previous pipeline environment (if any), then deploys
+the environment named by C<CURRENT_ENV>.
+
+For proto-BOSH (C<create-env>) deployments, fetches the latest state file
+from the Git origin before deploying.  On failure, commits the updated state
+file back to the Git repository before exiting.  On success, commits all
+deployment changes back to Git.
+
+If C<PREVIOUS_ENV> is set, resets the local copies of C<.genesis/config>,
+C<.genesis/kits>, and C<.genesis/cached> to the versions from Git after
+deploying, to avoid stale cache state.
+
+Takes no arguments.  Prints usage and exits if any arguments are supplied.
+
+B<Required environment variables:>
+
+=over 4
+
+=item C<CURRENT_ENV>
+
+Name of the environment to deploy.
+
+=item C<GIT_BRANCH>
+
+Git branch to push post-deployment commits to.
+
+=item C<OUT_DIR>
+
+Path to the output directory for the Git commit.
+
+=item C<WORKING_DIR>
+
+Path to the directory containing the deployment repository.
+
+=item C<VAULT_ROLE_ID>
+
+Vault AppRole role ID for authentication.
+
+=item C<VAULT_SECRET_ID>
+
+Vault AppRole secret ID for authentication.
+
+=item C<VAULT_ADDR>
+
+URL of the Vault server.
+
+=back
+
+B<Optional environment variables:>
+
+=over 4
+
+=item C<PREVIOUS_ENV>
+
+Name of the previous pipeline environment whose cache to propagate.  When
+set, C<CACHE_DIR> is also required.
+
+=item C<CACHE_DIR>
+
+Path to the cached directory from C<PREVIOUS_ENV>.  Required when
+C<PREVIOUS_ENV> is set.
+
+=item C<GIT_PRIVATE_KEY>
+
+SSH private key for Git operations (mutually exclusive with
+C<GIT_USERNAME>/C<GIT_PASSWORD>).
+
+=item C<GIT_USERNAME> / C<GIT_PASSWORD>
+
+HTTPS credentials for Git operations (mutually exclusive with
+C<GIT_PRIVATE_KEY>).
+
+=item C<GIT_GENESIS_ROOT>
+
+Subdirectory within C<WORKING_DIR> where the Genesis deployment root lives.
+Appended to C<WORKING_DIR> when set and non-empty.
+
+=item C<GIT_AUTHOR_NAME> / C<GIT_AUTHOR_EMAIL>
+
+Git commit author identity.  Defaults to C<Concourse Bot> /
+C<concourse@pipeline>.
+
+=item C<CI_NO_REDACT>
+
+When set, disables manifest redaction during deployment output.
+
+=item C<VAULT_SKIP_VERIFY>
+
+Skip TLS verification when connecting to Vault.
+
+=item C<VAULT_NAMESPACE>
+
+Vault namespace for enterprise Vault deployments.
+
+=item C<VAULT_NO_STRONGBOX>
+
+Set to disable Strongbox integration for non-Genesis Vault deployments.
+
+=item C<VAULT_SECRETS_MOUNT>
+
+Vault secrets mount path when secrets are not under C</secret>.
+
+=back
+
+B<Errors:>
+
+Exits with status 1 after printing a list of missing variables if any
+required environment variables are unset.
+
+Calls C<bail()> with C<"The pipeline must specify either GIT_PRIVATE_KEY,
+or GIT_USERNAME and GIT_PASSWORD"> if no Git credentials are provided.
+
+Exits with status 1 if deployment fails.
+
+B<Examples:>
+
+  # Typically invoked by a Concourse task; environment variables
+  # are set by the pipeline resource:
+  CURRENT_ENV=us-east-prod \
+  GIT_BRANCH=main \
+  OUT_DIR=/tmp/out \
+  WORKING_DIR=/tmp/work \
+  VAULT_ROLE_ID=<role-id> \
+  VAULT_SECRET_ID=<secret-id> \
+  VAULT_ADDR=https://vault.example.com \
+  GIT_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" \
+  genesis ci-pipeline-deploy
+  # Returns: exits 0 on success, exits 1 on failure
+
+=head2 ci_show_changes()
+
+    genesis ci-show-changes
+
+Concourse pipeline task handler that shows what will change in the next
+deployment without actually deploying.  Authenticates to Vault, propagates
+cached files from the previous pipeline environment (if any), generates the
+prospective deployment manifest and BOSH variables file, then runs a dry-run
+shell script that diffs the current and new manifests using C<bosh diff-config>.
+
+For proto-BOSH (C<create-env>) environments, prints a notice that change
+detection is not available and exits cleanly.
+
+After running the diff, checks for mismatches between cached files from the
+previous environment and the current working directory.  If missing or
+unexpected files are found, calls C<bail()> with a descriptive message listing
+the affected files.
+
+Takes no arguments.  Prints usage and exits if any arguments are supplied.
+
+B<Required environment variables:>
+
+=over 4
+
+=item C<CURRENT_ENV>
+
+Name of the environment to inspect.
+
+=item C<GIT_BRANCH>
+
+Git branch to use for state file operations.
+
+=item C<WORKING_DIR>
+
+Path to the directory containing the deployment repository.
+
+=item C<OUT_DIR>
+
+Path to the output directory for Git commits.
+
+=item C<VAULT_ROLE_ID>
+
+Vault AppRole role ID for authentication.
+
+=item C<VAULT_SECRET_ID>
+
+Vault AppRole secret ID for authentication.
+
+=item C<VAULT_ADDR>
+
+URL of the Vault server.
+
+=back
+
+B<Optional environment variables:>
+
+The same optional variables as C<ci_pipeline_deploy> apply:
+C<PREVIOUS_ENV>, C<CACHE_DIR>, C<GIT_PRIVATE_KEY>, C<GIT_USERNAME>,
+C<GIT_PASSWORD>, C<GIT_GENESIS_ROOT>, C<GIT_AUTHOR_NAME>,
+C<GIT_AUTHOR_EMAIL>, C<VAULT_SKIP_VERIFY>, C<VAULT_NAMESPACE>,
+C<VAULT_NO_STRONGBOX>, C<VAULT_SECRETS_MOUNT>.
+
+When C<GENESIS_TRACE> is set, the generated dry-run script is run with
+C<set -ex> for verbose tracing.
+
+B<Errors:>
+
+Exits with status 1 after printing a list of missing variables if any
+required environment variables are unset.
+
+Calls C<bail()> with C<"The pipeline must specify either GIT_PRIVATE_KEY,
+or GIT_USERNAME and GIT_PASSWORD"> if no Git credentials are provided.
+
+Calls C<bail()> with C<"Failed to determine changes."> if the dry-run
+diff script exits non-zero.
+
+Calls C<bail()> with a detailed message listing missing or extra cached
+files if cache mismatches are detected.
+
+B<Examples:>
+
+  # Invoked by a Concourse task to show pending changes:
+  CURRENT_ENV=us-east-prod \
+  GIT_BRANCH=main \
+  WORKING_DIR=/tmp/work \
+  OUT_DIR=/tmp/out \
+  VAULT_ROLE_ID=<role-id> \
+  VAULT_SECRET_ID=<secret-id> \
+  VAULT_ADDR=https://vault.example.com \
+  GIT_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" \
+  genesis ci-show-changes
+  # Prints: diff output or "No differences found."
+
+=head2 ci_generate_cache()
+
+    genesis ci-generate-cache
+
+Concourse pipeline task handler that generates the environment cache
+directory (C<.genesis/cached/CURRENT_ENV>) from the files applicable
+to the current environment.  This cache is passed as an input to downstream
+pipeline tasks for environments that depend on the current one.
+
+Determines the set of files to cache using C<Genesis::Env> environment
+relationships, optionally seeding from the previous environment's cache.
+Also copies C<kit-overrides.yml>, C<ops/>, and C<bin/> from the common
+path if they exist.  Commits the generated cache to Git.
+
+When C<GENESIS_TESTING> is set, skips the final Git commit and returns early.
+
+Takes no arguments.  Prints usage and exits if any arguments are supplied.
+
+B<Required environment variables:>
+
+=over 4
+
+=item C<CURRENT_ENV>
+
+Name of the environment whose cache to generate.
+
+=item C<GIT_BRANCH>
+
+Git branch to push the cache commit to.
+
+=item C<WORKING_DIR>
+
+Path to the directory containing the deployment repository.
+
+=item C<OUT_DIR>
+
+Path to the output directory for the Git commit.
+
+=back
+
+B<Optional environment variables:>
+
+=over 4
+
+=item C<PREVIOUS_ENV>
+
+Name of the previous pipeline environment.  When set, seeds the cache from
+C<CACHE_DIR/.genesis/cached/PREVIOUS_ENV>.  C<CACHE_DIR> is required when
+C<PREVIOUS_ENV> is set.
+
+=item C<CACHE_DIR>
+
+Path to the cached directory from C<PREVIOUS_ENV>.
+
+=item C<GIT_PRIVATE_KEY>
+
+SSH private key for Git operations (mutually exclusive with
+C<GIT_USERNAME>/C<GIT_PASSWORD>).
+
+=item C<GIT_USERNAME> / C<GIT_PASSWORD>
+
+HTTPS credentials for Git operations.
+
+=item C<GIT_GENESIS_ROOT>
+
+Subdirectory within C<WORKING_DIR> (and C<CACHE_DIR>) where the Genesis
+deployment root lives.
+
+=item C<GENESIS_TESTING>
+
+When set, skips the Git commit step and returns early.
+
+=back
+
+B<Errors:>
+
+Exits with status 1 after printing a list of missing variables if any
+required environment variables are unset.
+
+Calls C<bail()> with C<"The pipeline must specify either GIT_PRIVATE_KEY,
+or GIT_USERNAME and GIT_PASSWORD"> if no Git credentials are provided.
+
+B<Examples:>
+
+  # Invoked by a Concourse task to generate the environment cache:
+  CURRENT_ENV=us-east-sandbox \
+  GIT_BRANCH=main \
+  WORKING_DIR=/tmp/work \
+  OUT_DIR=/tmp/out \
+  GIT_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" \
+  genesis ci-generate-cache
+  # Creates: .genesis/cached/us-east-sandbox/ and commits it to git
+
+=head2 ci_pipeline_run_errand()
+
+    genesis ci-pipeline-run-errand
+
+Concourse pipeline task handler that authenticates to Vault and runs a named
+BOSH errand against the environment specified by C<CURRENT_ENV>.  The errand
+to run is taken from C<ERRAND_NAME>.
+
+Takes no arguments.  Prints usage and exits if any arguments are supplied.
+
+B<Required environment variables:>
+
+=over 4
+
+=item C<CURRENT_ENV>
+
+Name of the environment against which to run the errand.
+
+=item C<ERRAND_NAME>
+
+Name of the BOSH errand to run.
+
+=item C<VAULT_ROLE_ID>
+
+Vault AppRole role ID for authentication.
+
+=item C<VAULT_SECRET_ID>
+
+Vault AppRole secret ID for authentication.
+
+=item C<VAULT_ADDR>
+
+URL of the Vault server.
+
+=back
+
+B<Optional environment variables:>
+
+=over 4
+
+=item C<VAULT_SKIP_VERIFY>
+
+Skip TLS verification when connecting to Vault.
+
+=item C<VAULT_NAMESPACE>
+
+Vault namespace for enterprise Vault deployments.
+
+=item C<VAULT_NO_STRONGBOX>
+
+Set to disable Strongbox integration for non-Genesis Vault deployments.
+
+=item C<VAULT_SECRETS_MOUNT>
+
+Vault secrets mount path when secrets are not under C</secret>.
+
+=back
+
+B<Errors:>
+
+Exits with status 1 after printing a list of missing variables if any
+required environment variables are unset.
+
+B<Examples:>
+
+  # Invoked by a Concourse task to run a smoke-test errand:
+  CURRENT_ENV=us-east-prod \
+  ERRAND_NAME=smoke-tests \
+  VAULT_ROLE_ID=<role-id> \
+  VAULT_SECRET_ID=<secret-id> \
+  VAULT_ADDR=https://vault.example.com \
+  genesis ci-pipeline-run-errand
+  # Returns: exits 0 on success
+
+=head1 INTERNAL METHODS
+
+These functions are internal to the implementation.  They may change without
+notice and should not be called directly.
+
+=head2 _vault_auth()
+
+Validates that C<VAULT_ADDR>, C<VAULT_ROLE_ID>, and C<VAULT_SECRET_ID> are
+all defined in the environment, then creates and validates a
+L<Service::Vault::Remote> connection using AppRole authentication.
+
+Honors the optional environment variables C<VAULT_SKIP_VERIFY>,
+C<VAULT_NAMESPACE>, C<VAULT_NO_STRONGBOX>, and C<VAULT_SECRETS_MOUNT>.
+
+B<Returns:> Nothing.
+
+B<Errors:>
+
+Calls C<bail()> with C<"Pipeline requires the following missing environment
+variables: %s"> (where C<%s> is a comma-separated list of variable names) if
+any of the three required variables are absent.
+
+B<Examples:>
+
+  # Called internally before any Vault-dependent operation:
+  _vault_auth();
+  # Returns: nothing; dies if required vars are missing or Vault auth fails
+
+=head2 _bail_on_missing_pipeline_environment_variables(@missing)
+
+    _bail_on_missing_pipeline_environment_variables(@undefined)
+
+Checks whether any environment variable names were passed in as missing.
+If so, prints each missing variable name, prints a message to check the CI
+pipeline configuration, and exits with status 1.  Does nothing when the list
+is empty.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@missing>
+
+List of environment variable names that were expected but not defined.
+
+=back
+
+B<Returns:> Nothing.  Exits with status 1 when C<@missing> is non-empty.
+
+B<Examples:>
+
+  my @undefined = grep { !$ENV{$_} } qw/CURRENT_ENV GIT_BRANCH/;
+  _bail_on_missing_pipeline_environment_variables(@undefined);
+  # Returns: nothing when @undefined is empty; exits 1 otherwise
+
+=head2 _propagate_previous_passed_files()
+
+Copies cached Genesis files from the previous pipeline environment's cache
+directory into the working directory, then computes and returns a report of
+file mismatches.
+
+Returns immediately (C<undef>) when C<PREVIOUS_ENV> is not set.
+
+The following directories are removed from C<WORKING_DIR> and replaced with
+copies from C<CACHE_DIR>:
+
+=over 4
+
+=item C<.genesis/cached>
+
+=item C<.genesis/config>
+
+=item C<.genesis/kits>
+
+=back
+
+After copying, computes the set of files that relate the current environment
+to the previous one, then identifies files that are present in one location
+but absent in the other.
+
+B<Returns:> C<undef> when C<PREVIOUS_ENV> is not set.  Otherwise a hashref
+with keys:
+
+=over 4
+
+=item C<missing>
+
+Arrayref of file paths present in C<WORKING_DIR> but absent in C<CACHE_DIR>.
+
+=item C<extra>
+
+Arrayref of file paths present in C<CACHE_DIR> but absent in C<WORKING_DIR>.
+
+=back
+
+B<Errors:>
+
+Calls C<bail()> with C<"No CACHE_DIR set - cannot propagate passed values">
+if C<CACHE_DIR> is unset when C<PREVIOUS_ENV> is set.
+
+Calls C<bail()> with C<"No WORKING_DIR set - cannot propagate passed values">
+if C<WORKING_DIR> is unset when C<PREVIOUS_ENV> is set.
+
+B<Examples:>
+
+  my $mismatches = _propagate_previous_passed_files();
+  # Returns: undef if PREVIOUS_ENV not set
+  # Returns: { missing => [...], extra => [...] } otherwise
+
+=head2 _get_git_env($env_dir)
+
+    my %git_env = _get_git_env($tmp);
+    my $git_env = _get_git_env($tmp);
+
+Builds a hash of environment variables suitable for running Git commands in a
+Concourse task.  Creates a temporary home directory under C<$env_dir/home>
+and configures Git credentials based on the available authentication method:
+
+=over 4
+
+=item SSH key authentication
+
+When C<GIT_PRIVATE_KEY> is set, writes the key to
+C<$env_dir/home/.ssh/key> with mode C<0600>, writes an SSH config that
+disables host-key checking, and sets C<GIT_SSH_COMMAND>.
+
+=item HTTPS credential authentication
+
+When C<GIT_USERNAME> is set, writes a credential helper script to
+C<$env_dir/home/credential-helper.sh> and registers it via
+C<git config credential.helper>.
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env_dir>
+
+Path to a temporary working directory under which the C<home> subtree is
+created.
+
+=back
+
+B<Returns:>
+
+In list context: a flat hash of environment variable name/value pairs.
+
+In scalar context: a hashref of the same pairs.
+
+The returned hash always includes: C<HOME>, C<GIT_AUTHOR_NAME>,
+C<GIT_AUTHOR_EMAIL>, C<GIT_COMMITTER_NAME>, C<GIT_COMMITTER_EMAIL>,
+C<GIT_ASKPASS>.  C<GIT_SSH_COMMAND> is added when C<GIT_PRIVATE_KEY> is set.
+
+B<Examples:>
+
+  my $tmp = workdir();
+  my $git_env = _get_git_env($tmp);
+  # Returns: hashref of git-related env vars configured for the task
+
+  my %git_env = _get_git_env($tmp);
+  # Returns: flat hash of git-related env vars
+
+=head2 _commit_changes($indir, $outdir, $branch, $message[, $filter])
+
+    _commit_changes($ENV{WORKING_DIR}, $ENV{OUT_DIR}, $ENV{GIT_BRANCH},
+                    "deployed to $ENV{CURRENT_ENV}");
+    _commit_changes($ENV{WORKING_DIR}, $ENV{OUT_DIR}, $ENV{GIT_BRANCH},
+                    "state file update", qr{^\.genesis/manifest/.*\.state$});
+
+Copies the input directory to the output directory, resets the output
+directory to the latest origin commit on C<$branch>, detects changed files in
+the input directory via C<git status --porcelain>, applies those changes
+(copies or removes) to the output directory, then commits if any changes
+remain.
+
+Files matched by the optional C<$filter> regex are the only ones applied when
+C<$filter> is provided; all other changed files are skipped.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$indir>
+
+Path to the source directory (e.g., C<WORKING_DIR>).
+
+=item C<$outdir>
+
+Path to the output directory (e.g., C<OUT_DIR>).  Removed and recreated on
+each call to avoid merge conflicts.
+
+=item C<$branch>
+
+Git branch name to reset to and commit on.
+
+=item C<$message>
+
+Commit message body.  The final commit message is prefixed with
+C<"CI commit: ">.
+
+=item C<$filter> (optional)
+
+A compiled regexp (C<qr/.../>).  When provided, only files whose paths match
+this pattern are included in the commit.
+
+=back
+
+B<Returns:> Nothing.  Exits 1 if the initial directory copy fails.
+
+B<Examples:>
+
+  _commit_changes('/tmp/work', '/tmp/out', 'main', 'deployed to sandbox');
+  # Returns: nothing; commits changed files to the out git repo
+
+=head1 ENVIRONMENT VARIABLES SUMMARY
+
+=over 4
+
+=item CI pipeline authentication
+
+C<VAULT_ADDR>, C<VAULT_ROLE_ID>, C<VAULT_SECRET_ID>,
+C<VAULT_SKIP_VERIFY>, C<VAULT_NAMESPACE>, C<VAULT_NO_STRONGBOX>,
+C<VAULT_SECRETS_MOUNT>
+
+=item CI pipeline deployment targeting
+
+C<CURRENT_ENV>, C<PREVIOUS_ENV>, C<ERRAND_NAME>
+
+=item CI pipeline Git operations
+
+C<GIT_BRANCH>, C<GIT_PRIVATE_KEY>, C<GIT_USERNAME>, C<GIT_PASSWORD>,
+C<GIT_AUTHOR_NAME>, C<GIT_AUTHOR_EMAIL>, C<GIT_GENESIS_ROOT>
+
+=item CI pipeline directory layout
+
+C<WORKING_DIR>, C<OUT_DIR>, C<CACHE_DIR>
+
+=item CI pipeline behavior flags
+
+C<CI_NO_REDACT>, C<GENESIS_TESTING>, C<GENESIS_TRACE>
+
+=back
+
+=head1 SEE ALSO
+
+L<Genesis::CI::Legacy>, L<Genesis::Top>, L<Genesis::Env>,
+L<Service::Vault::Remote>, L<Genesis::Commands>
+
+=head1 AUTHOR
+
+FiveTwenty, LLC
+
+=cut

--- a/lib/Genesis/Commands/Repo.pod
+++ b/lib/Genesis/Commands/Repo.pod
@@ -1,0 +1,296 @@
+=head1 NAME
+
+Genesis::Commands::Repo - Command handlers for Genesis repository management
+
+=head1 SYNOPSIS
+
+  # Registered in bin/genesis via define_command:
+  genesis init [options] [<name>]
+  genesis secrets-provider [options] [<target>]
+  genesis kit-provider [options]
+
+  # Perl import (for testing or internal dispatch):
+  use Genesis::Commands::Repo;
+  Genesis::Commands::Repo::init(@ARGV);
+  Genesis::Commands::Repo::secrets_provider(@ARGV);
+  Genesis::Commands::Repo::kit_provider(@ARGV);
+
+=head1 DESCRIPTION
+
+Implements the Genesis CLI commands that manage the repository lifecycle and
+its provider configuration.  The three commands handled here correspond
+directly to top-level genesis subcommands:
+
+=over 4
+
+=item C<genesis init>
+
+Create a new Genesis deployment repository on disk, optionally installing or
+linking a kit at the same time.
+
+=item C<genesis secrets-provider>
+
+Display or change the Vault/Safe target used by the current deployment
+repository for secrets storage.
+
+=item C<genesis kit-provider>
+
+Display or change the kit provider (source from which kits are downloaded)
+for the current deployment repository.
+
+=back
+
+Each function reads global command-line options via C<get_options> /
+C<append_options> and then delegates persistence and resolution to
+L<Genesis::Top>.
+
+=head1 FUNCTIONS
+
+=head2 init([$name])
+
+  genesis init [options] [<name>]
+
+Creates a new Genesis deployment repository named C<$name> in the current
+working directory.  Validates git identity, creates the repository directory
+structure via L<Genesis::Top>, embeds the genesis binary, sets up
+the chosen kit, initializes a git repository, and commits the initial state.
+
+C<$name> is optional when a C<--kit> or C<--link-dev-kit> option is
+provided, because the name can be inferred from the kit name or the
+development link target path.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name> (optional)
+
+The deployment repository name.  May be omitted when C<--kit> or
+C<--link-dev-kit> is supplied; required otherwise.
+
+=back
+
+B<Options> (parsed from C<@_> via C<Genesis::Kit::Provider> and C<get_options>):
+
+=over 4
+
+=item C<--kit|-k> I<spec>
+
+Kit to install.  Accepts a kit name, a C<name/version> specifier, or a path
+to a locally compiled C<.tar.gz> kit archive.
+
+=item C<--link-dev-kit|-L> I<path>
+
+Symlink a local kit directory as C<./dev> inside the new repository.  Mutually
+exclusive with C<--kit>.
+
+=item C<--kits-path> I<dir>
+
+Override the local kits cache directory (defaults to C<~/.genesis/kits>).
+
+=back
+
+B<Returns:>
+
+Does not return to the caller -- calls C<exit 0> on success.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Link target '%s' cannot be found from $pwd!">
+
+The path given to C<--link-dev-kit> could not be resolved to an absolute path
+from the current working directory.  C<%s> is the value of C<--link-dev-kit>.
+
+=item C<"Local compiled kit file %s not found">
+
+The C<--kit> value looks like a local archive path but the file does not exist
+on disk.  C<%s> is the kit path.
+
+=back
+
+Additional errors are propagated from L<Genesis::Top> (repository creation,
+kit download) and from C<git init> / C<git commit> failures.  If any
+post-directory-creation step fails, the partially created directory is removed
+before re-raising the error.
+
+B<Examples:>
+
+  # Create a repo named "my-env" with a kit from the default provider
+  genesis init --kit cf my-env
+  # prints: Initialized empty Genesis repository in my-env
+
+  # Create a repo, linking a local dev kit; name inferred from link target
+  genesis init --link-dev-kit ~/src/cf-genesis-kit
+  # prints: Initialized empty Genesis repository in cf-genesis-kit
+
+  # Create a repo with an explicit name, no kit (empty ./dev directory created)
+  genesis init my-env
+  # prints: Initialized empty Genesis repository in my-env
+
+=head2 secrets_provider([$target])
+
+  genesis secrets-provider [--interactive|-i] [--clear|-c] [<target>]
+
+Displays the Vault/Safe secrets provider configured for the current deployment
+repository.  When options are supplied, updates the configuration first, then
+displays the new state.
+
+Exactly one of C<$target>, C<--interactive>, or C<--clear> may be specified
+at a time.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$target> (optional)
+
+A Vault target alias or URL.  Sets the repository's secrets provider to this
+target.
+
+=back
+
+B<Options> (read via C<get_options>):
+
+=over 4
+
+=item C<--interactive|-i>
+
+Prompt the user interactively to select or configure the Vault target.
+
+=item C<--clear|-c>
+
+Remove the repository's secrets provider configuration, reverting to the
+system-default safe target (legacy mode).
+
+=back
+
+B<Returns:>
+
+Does not return to the caller -- calls C<exit 0> on success or C<exit 1>
+when the provider update fails.
+
+B<Errors:>
+
+=over 4
+
+=item C<"You can only specify one of target, -i|--interactive or -c|--clear">
+
+More than one of the mutually exclusive options was supplied.
+
+=back
+
+Output is written directly to the terminal.  When a vault is configured, the
+display includes the type, URL, local alias, and authentication status.  When
+no vault is configured, a notice is shown that legacy mode is active.
+
+B<Examples:>
+
+  # Show the current secrets provider
+  genesis secrets-provider
+  # prints: Secrets provider for cf deployment at /path/to/repo:
+
+  # Set the secrets provider to a named safe target
+  genesis secrets-provider my-vault
+  # prints: Secrets provider for cf deployment at /path/to/repo:
+
+  # Interactively choose the secrets provider
+  genesis secrets-provider --interactive
+  # prints: (interactive vault selection prompt)
+
+  # Remove the secrets provider configuration (revert to legacy mode)
+  genesis secrets-provider --clear
+  # prints: Not set - legacy mode enabled (will use current safe target on system)
+
+=head2 kit_provider()
+
+  genesis kit-provider [options]
+
+Displays the kit provider currently configured for the deployment repository.
+When provider options are supplied, updates the configuration first, then
+displays the provider status and the list of available kits.
+
+The C<--export-config> flag is mutually exclusive with all other flags; when
+used, it emits the provider configuration as JSON and exits.
+
+B<Options> (parsed via C<Genesis::Kit::Provider> and C<get_options>):
+
+=over 4
+
+=item C<--kit-provider> I<spec>
+
+Set the kit provider to the given provider specifier string.
+
+=item C<--default>
+
+Set the kit provider to the Genesis Community default (C<genesis-community>).
+
+=item C<--export-config>
+
+Output the current kit provider configuration as a JSON object to stdout, then
+exit.  Cannot be combined with any other option.
+
+=item C<--verbose|-v>
+
+Request verbose kit provider information when querying the provider.
+
+=back
+
+B<Returns:>
+
+Exits C<0> after C<--export-config> or exits C<1> when the provider update
+fails.  On the normal display path, returns to the caller after printing
+the provider status and kit list.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Option #M{--export-config} cannot be used with any other options">
+
+C<--export-config> was combined with at least one other option.
+
+=item C<"$@"> (dynamic)
+
+Any exception raised inside the C<eval> block that queries kit provider
+information is re-thrown via C<bail()>.  The message content depends on
+the underlying provider error.
+
+=back
+
+Errors encountered while changing the kit provider are printed and cause an
+immediate C<exit 1>.  Errors from provider information lookup are propagated
+via C<bail()>.
+
+B<Examples:>
+
+  # Show the current kit provider and available kits
+  genesis kit-provider
+  # prints: Type: genesis-community
+
+  # Switch to the Genesis Community provider
+  genesis kit-provider --default
+  # prints: Type: genesis-community
+
+  # Export the current kit provider configuration as JSON
+  genesis kit-provider --export-config
+  # prints: {"type":"genesis-community",...}
+
+  # Set a custom provider and show verbose info
+  genesis kit-provider --kit-provider my-github-org --verbose
+  # prints: Type: my-github-org
+
+=head1 SEE ALSO
+
+L<Genesis::Top>, L<Genesis::Kit::Provider>, L<Genesis::Commands>
+
+=head1 AUTHOR
+
+FiveTwenty, LLC
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Commands/Utility.pod
+++ b/lib/Genesis/Commands/Utility.pod
@@ -416,7 +416,7 @@ connection is available.
 B<Examples:>
 
   my $result = multi_line_prompt_handler("Enter IPs:", min => 1, max => 5);
-  # Returns: "10.0.0.1\010.0.0.2\0" (null-byte-delimited with trailing null)
+  # Returns: "val1\0val2\0" (null-byte-delimited with trailing null)
 
 =head2 multi_block_prompt_handler($prompt, %opts)
 

--- a/lib/Genesis/Commands/Utility.pod
+++ b/lib/Genesis/Commands/Utility.pod
@@ -1,0 +1,652 @@
+=head1 NAME
+
+Genesis::Commands::Utility - Command handlers for Genesis utility operations
+
+=head1 SYNOPSIS
+
+  # Registered in bin/genesis via define_command:
+  genesis ui-prompt-for <type> <path> [prompt text ...]
+
+  # Perl usage (via genesis command dispatch):
+  use Genesis::Commands::Utility;
+  Genesis::Commands::Utility::ui_prompt_for($type, $path, @prompt_lines);
+
+=head1 DESCRIPTION
+
+Provides the implementation for the C<genesis ui-prompt-for> command, which
+allows kit hooks to interactively prompt users for values and write the result
+to a file or vault path.
+
+The module defines a registry of prompt handler functions keyed by prompt type
+(C<$prompt_handlers>).  C<ui_prompt_for> dispatches to the appropriate handler
+based on the C<$type> argument.  Most handlers are thin wrappers around
+functions exported by L<Genesis::UI>.
+
+Supported prompt types:
+
+=over 4
+
+=item C<line>
+
+Single-line text input.  Supports optional label, default value, validation,
+and inline mode.
+
+=item C<boolean>
+
+Yes/no prompt.  Returns the string C<"true"> or C<"false">.
+
+=item C<block>
+
+Multi-line text block entered by the user.
+
+=item C<select>
+
+Single-choice selection from a list of options.
+
+=item C<list>, C<lines>, C<multi-line>
+
+Multiple single-line entries.  All three type names dispatch to the same
+handler.
+
+=item C<blocks>, C<multi-block>
+
+Multiple block entries.  Both type names dispatch to the same handler.
+
+=item C<multi-select>
+
+Multiple selections from a list of options.  Returns an empty string when
+nothing is selected.
+
+=item C<secret-line>
+
+Prompts for a single-line value and stores it directly in Vault rather than
+writing to a file.  Requires a Genesis environment loaded from
+C<$GENESIS_ROOT> / C<$GENESIS_ENVIRONMENT>.
+
+=item C<secret-block>
+
+Prompts for a block value and stores it directly in Vault rather than
+writing to a file.  Requires a Genesis environment loaded from
+C<$GENESIS_ROOT> / C<$GENESIS_ENVIRONMENT>.
+
+=back
+
+=head1 FUNCTIONS
+
+=head2 ui_prompt_for($type, $path, @prompt_lines)
+
+Entry point for the C<genesis ui-prompt-for> command.  Validates arguments,
+dispatches to the registered handler for C<$type>, and writes the result to
+C<$path> (for non-secret types) or stores it directly in Vault (for
+C<secret-line> and C<secret-block> types).
+
+B<Parameters:>
+
+=over 4
+
+=item C<$type>
+
+The prompt type string.  Must be one of the registered keys in
+C<$prompt_handlers>: C<line>, C<boolean>, C<block>, C<select>, C<list>,
+C<lines>, C<multi-line>, C<blocks>, C<multi-block>, C<multi-select>,
+C<secret-line>, or C<secret-block>.
+
+=item C<$path>
+
+For non-secret types, the file path where the prompt result is written via
+C<mkfile_or_fail>.  For secret types, the Vault secret path in the form
+C<path/to/secret:key>.
+
+=item C<@prompt_lines>
+
+Zero or more lines of prompt text.  Lines are joined with newlines and passed
+as a single prompt string to the handler.  The prompt is optional.
+
+=back
+
+B<Returns:>
+
+Does not return.  Calls C<exit 0> on success.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Cannot prompt for secrets outside a kit hook">
+
+Raised when the type is C<secret-line> or C<secret-block> but the Genesis
+environment cannot be loaded from C<$GENESIS_ROOT> / C<$GENESIS_ENVIRONMENT>.
+
+=item C<"#R{ERROR:} cannot prompt for %s: unknown type, expecting one of: %s\n">
+
+Raised when C<$type> is not a recognized prompt type.  C<%s> is replaced with
+the given type and the sorted list of valid type names respectively.
+
+=back
+
+B<Examples:>
+
+  # Prompt for a single line and write the result to a file:
+  genesis ui-prompt-for line /tmp/result "Enter your name"
+  # Returns: exits 0; writes entered text to /tmp/result
+
+  # Prompt for a boolean and write "true" or "false":
+  genesis ui-prompt-for boolean /tmp/answer "Enable TLS?"
+  # Returns: exits 0; writes "true" or "false" to /tmp/answer
+
+  # Prompt for a selection from options (via kit hook, using options passed
+  # through genesis command dispatch):
+  genesis ui-prompt-for select /tmp/choice "Pick a region" \
+    --option us-east-1 --option us-west-2
+  # Returns: exits 0; writes selected value to /tmp/choice
+
+=head1 INTERNAL FUNCTIONS
+
+These functions are internal to the implementation.  They may change without
+notice and should not be called directly.
+
+=head2 validate_prompt_opts($type, $opts, @valid_opts)
+
+Validates that all keys present in the C<$opts> hashref are listed in
+C<@valid_opts>.  Prints an error and calls C<exit 2> if any unsupported
+option keys are found.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$type>
+
+The prompt type name string, used in the error message (e.g., C<"line">,
+C<"boolean">).
+
+=item C<$opts>
+
+Hashref of options to validate.
+
+=item C<@valid_opts>
+
+List of option key names that are permitted for this prompt type.
+
+=back
+
+B<Returns:>
+
+Nothing on success.  Calls C<exit 2> if invalid options are found.
+
+B<Examples:>
+
+  # Validate that only 'label' and 'default' are present in %opts:
+  validate_prompt_opts("line", \%opts, qw(label default validation msg inline));
+  # Returns: nothing (exits with code 2 if unknown keys are present)
+
+=head2 line_prompt_handler($prompt, %opts)
+
+Handler for the C<line> prompt type.  Validates options, resolves inline
+mode if requested, ensures a Vault connection when the validation rule starts
+with C<vault_path>, then delegates to C<prompt_for_line>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$prompt>
+
+The prompt string displayed to the user.  Set to C<undef> in inline mode
+(the prompt text becomes the label instead).
+
+=item C<%opts>
+
+Supported keys: C<label>, C<default>, C<validation>, C<msg>, C<inline>.
+
+=over 4
+
+=item C<label> - Label shown beside the input field
+
+=item C<default> - Default value pre-filled in the prompt
+
+=item C<validation> - Validation rule string or coderef passed to C<prompt_for_line>
+
+=item C<msg> - Message displayed when validation fails
+
+=item C<inline> - When true, the prompt text becomes the inline label and C<$prompt> is cleared
+
+=back
+
+=back
+
+B<Returns:>
+
+The string entered by the user, as returned by C<prompt_for_line>.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Cannot request both label and inline options to prompt_for line">
+
+Raised when both C<inline> and C<label> options are specified simultaneously.
+
+=item C<"No vault selected!">
+
+Raised when the C<validation> value starts with C<vault_path> and no Vault
+connection is available.
+
+=back
+
+B<Examples:>
+
+  # Called by ui_prompt_for for the 'line' type:
+  my $value = line_prompt_handler("Enter your name", label => "Name", default => "Alice");
+  # Returns: the string entered by the user (e.g., "Bob")
+
+=head2 boolean_prompt_handler($prompt, %opts)
+
+Handler for the C<boolean> prompt type.  Appends C<' [y|n]'> to the prompt
+when inline mode is requested, then delegates to C<prompt_for_boolean>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$prompt>
+
+The prompt string displayed to the user.
+
+=item C<%opts>
+
+Supported keys: C<default>, C<invert>, C<inline>.
+
+=over 4
+
+=item C<default> - Default boolean value
+
+=item C<invert> - When true, inverts the boolean sense
+
+=item C<inline> - When true, appends C<' [y|n]'> to the prompt text
+
+=back
+
+=back
+
+B<Returns:>
+
+The string C<"true"> if the user answered yes, C<"false"> if no.
+
+B<Examples:>
+
+  my $answer = boolean_prompt_handler("Enable TLS?", default => 1);
+  # Returns: "true" or "false"
+
+=head2 block_prompt_handler($prompt, %opts)
+
+Handler for the C<block> prompt type.  Accepts no options and delegates
+directly to C<prompt_for_block>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$prompt>
+
+The prompt string displayed to the user.
+
+=item C<%opts>
+
+No supported keys.  Any options passed will cause C<validate_prompt_opts>
+to print an error and exit.
+
+=back
+
+B<Returns:>
+
+The multi-line string entered by the user, as returned by C<prompt_for_block>.
+
+B<Examples:>
+
+  my $text = block_prompt_handler("Paste your certificate:");
+  # Returns: multi-line string entered by the user
+
+=head2 select_prompt_handler($prompt, %opts)
+
+Handler for the C<select> prompt type.  Parses option strings in the form
+C<[value] label> to separate machine values from display labels, then
+delegates to C<prompt_for_choice>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$prompt>
+
+The prompt string displayed to the user.
+
+=item C<%opts>
+
+Supported keys: C<label>, C<default>, C<option>.
+
+=over 4
+
+=item C<label> - Label shown beside the selection prompt
+
+=item C<default> - Default selection value
+
+=item C<option> - Arrayref of option strings.  Each string may optionally begin
+with C<[value]> to specify a separate machine value; if omitted, the display
+text is used as the value.
+
+=back
+
+=back
+
+B<Returns:>
+
+The selected value string (the bracketed portion if present, otherwise the
+full option text), as returned by C<prompt_for_choice>.
+
+B<Errors:>
+
+=over 4
+
+=item C<"No options provided to prompt for select">
+
+Raised when the C<option> key is absent or its arrayref is empty.
+
+=back
+
+B<Examples:>
+
+  my $choice = select_prompt_handler(
+    "Choose a region",
+    option  => ["[us-east-1] US East", "[us-west-2] US West"],
+    default => "us-east-1",
+  );
+  # Returns: "us-east-1" or "us-west-2"
+
+=head2 multi_line_prompt_handler($prompt, %opts)
+
+Handler for the C<list>, C<lines>, and C<multi-line> prompt types.  Collects
+multiple single-line entries from the user via C<prompt_for_list>, then joins
+them with null bytes (C<\0>) for inter-process communication.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$prompt>
+
+The prompt string displayed to the user.
+
+=item C<%opts>
+
+Supported keys: C<label>, C<min>, C<max>, C<validation>, C<msg>.
+
+=over 4
+
+=item C<label> - Label shown beside each input field
+
+=item C<min> - Minimum number of entries required
+
+=item C<max> - Maximum number of entries allowed
+
+=item C<validation> - Validation rule string or coderef for each entry
+
+=item C<msg> - Message displayed when validation fails
+
+=back
+
+=back
+
+B<Returns:>
+
+A null-byte-delimited string of all entered values with a trailing null byte
+(e.g., C<"val1\0val2\0">).
+
+B<Errors:>
+
+=over 4
+
+=item C<"No vault selected!">
+
+Raised when the C<validation> value starts with C<vault_path> and no Vault
+connection is available.
+
+=back
+
+B<Examples:>
+
+  my $result = multi_line_prompt_handler("Enter IPs:", min => 1, max => 5);
+  # Returns: "10.0.0.1\010.0.0.2\0" (null-byte-delimited with trailing null)
+
+=head2 multi_block_prompt_handler($prompt, %opts)
+
+Handler for the C<blocks> and C<multi-block> prompt types.  Collects multiple
+block entries from the user via C<prompt_for_list>, then joins them with null
+bytes for inter-process communication.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$prompt>
+
+The prompt string displayed to the user.
+
+=item C<%opts>
+
+Supported keys: C<label>, C<min>, C<max>, C<msg>.
+
+=over 4
+
+=item C<label> - Label shown beside each input block
+
+=item C<min> - Minimum number of blocks required
+
+=item C<max> - Maximum number of blocks allowed
+
+=item C<msg> - Message displayed when entry requirements are not met
+
+=back
+
+=back
+
+B<Returns:>
+
+A null-byte-delimited string of all entered blocks with a trailing null byte.
+
+B<Examples:>
+
+  my $result = multi_block_prompt_handler("Enter config blocks:", min => 1);
+  # Returns: "block1_text\0block2_text\0" (null-byte-delimited with trailing null)
+
+=head2 multi_select_prompt_handler($prompt, %opts)
+
+Handler for the C<multi-select> prompt type.  Parses option strings in the
+same C<[value] label> format as C<select_prompt_handler>, collects multiple
+user selections via C<prompt_for_choices>, then joins the results with null
+bytes.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$prompt>
+
+The prompt string displayed to the user.
+
+=item C<%opts>
+
+Supported keys: C<label>, C<min>, C<max>, C<option>.
+
+=over 4
+
+=item C<label> - Label shown beside the selection prompt
+
+=item C<min> - Minimum number of selections required
+
+=item C<max> - Maximum number of selections allowed
+
+=item C<option> - Arrayref of option strings in C<[value] label> format
+
+=back
+
+=back
+
+B<Returns:>
+
+An empty string if the user made no selections.  Otherwise, a
+null-byte-delimited string of selected values with a trailing null byte.
+
+B<Errors:>
+
+=over 4
+
+=item C<"No options provided to prompt for select">
+
+Raised when the C<option> key is absent or its arrayref is empty.
+
+=back
+
+B<Examples:>
+
+  my $result = multi_select_prompt_handler(
+    "Choose AZs",
+    option => ["[z1] Zone 1", "[z2] Zone 2", "[z3] Zone 3"],
+    min    => 1,
+  );
+  # Returns: "" if nothing selected, or "z1\0z2\0" if z1 and z2 are selected
+
+=head2 secret_line_prompt_handler($prompt, %opts)
+
+Handler for the C<secret-line> prompt type.  Prompts for a single-line value
+using the C<safe prompt> Vault command and stores the result directly in Vault
+at the path specified by the C<secret> option.
+
+For environments with kit compatibility C<2.7.0-rc4> or later, the Vault path
+is resolved relative to C<< $env->secrets_base >> unless it is already
+absolute.  For older environments, the path is prefixed with C<"secret/">.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$prompt>
+
+The prompt string displayed to the user.
+
+=item C<%opts>
+
+Supported keys: C<echo>.  The C<secret> and C<env> keys are consumed
+before validation.
+
+=over 4
+
+=item C<secret> - Vault secret path in C<path:key> form (required, consumed
+before option validation)
+
+=item C<env> - A Genesis environment object used for path resolution and Vault
+lookup (consumed before option validation)
+
+=item C<echo> - When true, uses C<safe ask> (visible input) instead of
+C<safe set> (hidden input)
+
+=back
+
+=back
+
+B<Returns:>
+
+Nothing.  The value is written directly to Vault.
+
+B<Errors:>
+
+=over 4
+
+=item C<"No vault selected!">
+
+Raised when no Vault connection is available.
+
+=back
+
+B<Examples:>
+
+  # Called by ui_prompt_for for the 'secret-line' type (with vault context):
+  secret_line_prompt_handler(
+    "Enter your API key",
+    secret => "myapp/creds:api_key",
+    env    => $env,
+    echo   => 0,
+  );
+  # Returns: nothing; writes value to Vault at the resolved secret path
+
+=head2 secret_block_prompt_handler($prompt, %opts)
+
+Handler for the C<secret-block> prompt type.  Prompts for a multi-line block
+value, writes it to a temporary file, then stores it in Vault at the path
+specified by the C<secret> option using C<safe set key@file>.
+
+Path resolution follows the same C<2.7.0-rc4> compatibility logic as
+C<secret_line_prompt_handler>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$prompt>
+
+The prompt string displayed to the user.
+
+=item C<%opts>
+
+No supported keys beyond C<secret> and C<env>, which are consumed before
+validation.
+
+=over 4
+
+=item C<secret> - Vault secret path in C<path:key> form (required, consumed
+before option validation)
+
+=item C<env> - A Genesis environment object used for path resolution and Vault
+lookup (consumed before option validation)
+
+=back
+
+=back
+
+B<Returns:>
+
+Nothing.  The value is written directly to Vault.
+
+B<Errors:>
+
+=over 4
+
+=item C<"No vault selected!">
+
+Raised when no Vault connection is available.
+
+=back
+
+B<Examples:>
+
+  # Called by ui_prompt_for for the 'secret-block' type (with vault context):
+  secret_block_prompt_handler(
+    "Paste your certificate",
+    secret => "myapp/certs:ca",
+    env    => $env,
+  );
+  # Returns: nothing; writes block content to Vault at the resolved secret path
+
+=head1 SEE ALSO
+
+L<Genesis::Commands>, L<Genesis::UI>, L<Genesis::Top>, L<Service::Vault::Remote>
+
+=head1 AUTHOR
+
+FiveTwenty, LLC
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut


### PR DESCRIPTION
## Summary

- Add companion `.pod` documentation for all 10 Genesis::Commands modules that lacked POD
- Covers 73 public functions and 29 internal functions across the command dispatch infrastructure
- All 10 new POD files pass mechanical validation (849 checks, 0 failures) and render correctly via `perldoc`

## Modules documented

| Module | Functions | Lines |
|--------|-----------|-------|
| Genesis::Commands | 25 public + 3 internal | 1308 |
| Genesis::Commands::Env | 13 public | 1217 |
| Genesis::Commands::Kit | 6 public + 4 internal | 809 |
| Genesis::Commands::Pipelines | 8 public + 5 internal | 878 |
| Genesis::Commands::Info | 7 public + 1 internal | ~600 |
| Genesis::Commands::Bosh | 5 public + 6 internal | ~580 |
| Genesis::Commands::Utility | 1 public + 10 internal | ~650 |
| Genesis::Commands::Core | 4 public | ~400 |
| Genesis::Commands::Repo | 3 public | 296 |
| Genesis::Commands::Deprecated | 1 public | ~70 |

## Related

- Closes FWT-581
- Code defects found during authoring: FWT-737

## Test plan

- [x] `pod-validate` passes with 0 failures on all 10 modules
- [x] `perldoc` renders correctly for all 10 `.pod` files
- [x] Every `.pm` under `lib/Genesis/Commands/` has a companion `.pod`
- [x] No `.pm` files modified — documentation only