### PR TITLE
Add POD for Env Manifest class hierarchy

### DIFF
--- a/lib/Genesis/Env/Manifest.pod
+++ b/lib/Genesis/Env/Manifest.pod
@@ -303,7 +303,8 @@ B<Parameters for notify:>
 
   my $clean = Genesis::Env::Manifest::dewrap($msg);
 
-Package-level utility function (not an instance method). Strips ANSI terminal
+Package-level utility function (not an instance method). This function is not
+exported; call it with the fully qualified package name. Strips ANSI terminal
 color sequences and log-level labels (e.g., C<[ERROR]>, C<[WARN]>) from a
 message string, and collapses the indent that was used to align continuation
 lines under the label. Returns the original C<$msg> unchanged if no label
@@ -482,13 +483,14 @@ data structure. Calls C<load_yaml_file> from the Genesis utility library.
 
 =head2 _save_data_to_file
 
-  my $path = $manifest->_save_data_to_file($data);
+  my $path = $manifest->_save_data_to_file();
 
-Serializes C<$data> (a parsed YAML hashref) to the canonical manifest file
-path (from C<_generate_file_name>, or the already-recorded file path if set).
-Returns the path of the written file.
+Serializes the object's cached data (C<< $self->{data} >>) to the canonical
+manifest file path (from C<_generate_file_name>, or the already-recorded file
+path if set). Takes no arguments beyond the invocant. Returns the path of the
+written file.
 
-  my $path = $manifest->_save_data_to_file($data);
+  my $path = $manifest->_save_data_to_file();
   print $path; # prints the path of the written YAML file
 
 =head1 AUTHORS

--- a/lib/Genesis/Env/Manifest.pod
+++ b/lib/Genesis/Env/Manifest.pod
@@ -1,0 +1,502 @@
+=head1 NAME
+
+Genesis::Env::Manifest - Base class for all Genesis environment manifest types
+
+=head1 SYNOPSIS
+
+  use Genesis::Env::Manifest;
+
+  # Manifests are created by the builder, not directly
+  my $manifest = $builder->unredacted();
+  my $manifest = $builder->redacted();
+
+  # Access manifest content
+  my $data = $manifest->data();   # returns parsed YAML as hashref
+  my $file = $manifest->file();   # returns path to manifest YAML file
+
+  # Identify the manifest type
+  print $manifest->type();        # prints e.g. 'unredacted'
+  print $manifest->label();       # prints e.g. 'unredacted'
+
+  # Write to a destination
+  $manifest->write_to('/path/to/deploy.yml');
+
+  # Validate the manifest can be built
+  my $ok = $manifest->validate();
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::Manifest> is the abstract base class for all manifest types
+in the Genesis deployment system. It provides the shared interface for
+building, caching, and accessing deployment manifests derived from environment
+files, kit configurations, and cloud configs.
+
+The manifest hierarchy covers every view of a deployment manifest that Genesis
+needs to produce: unredacted (secrets visible), redacted (secrets hidden),
+entombed (Vault operators resolved and embedded), vaultified (Vault references
+substituted), and partial (pre-merged subsets for inspection). Each variant is
+a subclass of this base class.
+
+Manifests are constructed by a builder object and should not be instantiated
+directly. The builder manages caching so each manifest type is built at most
+once per environment.
+
+Results from C<data> and C<file> are memoized on the object. Use C<reset> to
+clear the cache and force a rebuild.
+
+=head1 METHODS
+
+=head2 new
+
+  my $manifest = $class->new($builder, $subset);
+
+Constructs a new manifest object. If a cached YAML file already exists on disk
+(determined by C<_generate_file_name>), the cache is loaded immediately via
+C<set_file>, deferring the actual parse until C<data> is first called.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$builder> - the manifest builder object that provides access to the
+environment, merge sources, and subset retrieval
+
+=item * C<$subset> - an optional subset identifier string; when defined the
+manifest is treated as a subset view built from a parent manifest
+
+=back
+
+B<Returns:> a blessed manifest object of the calling class.
+
+  my $manifest = Genesis::Env::Manifest::Unredacted->new($builder, undef);
+  print ref($manifest); # prints 'Genesis::Env::Manifest::Unredacted'
+
+=head2 builder
+
+  my $builder  = $manifest->builder();
+  my $env      = $manifest->env();
+  my $type_str = $manifest->type();
+
+Three accessors that describe the manifest's identity and context:
+
+B<builder> returns the builder object passed to C<new>. The builder provides
+access to the environment, merge source files, and other manifest variants.
+
+B<env> returns the C<Genesis::Env> object for the deployment environment.
+Delegates to C<< $manifest->builder->env >>.
+
+B<type> derives the manifest type name from the class name. Strips the package
+prefix, lowercases the first letter, and inserts underscores before interior
+uppercase letters to produce a snake_case identifier. For example:
+
+=over 4
+
+=item * C<Genesis::Env::Manifest::Unredacted> returns C<'unredacted'>
+
+=item * C<Genesis::Env::Manifest::VaultifiedEntombed> returns C<'vaultified_entombed'>
+
+=item * C<Genesis::Env::Manifest::PartialEnvironment> returns C<'partial_environment'>
+
+=back
+
+  my $builder = $manifest->builder();
+  print ref($builder);       # prints the builder class name
+
+  my $name = $manifest->env()->name();
+  print $name;               # prints the environment name
+
+  my $type = $manifest->type();
+  print $type;               # prints e.g. 'unredacted'
+
+=head2 label
+
+  my $label = $manifest->label();
+
+Returns the human-readable label for the manifest type. Equivalent to C<type>
+with underscores replaced by spaces.
+
+  my $label = $manifest->label();
+  print $label; # prints e.g. 'unredacted' or 'vaultified entombed'
+
+=head2 subset
+
+  my $subset = $manifest->subset();
+
+Returns the subset identifier string passed to C<new>, or an empty string if
+the manifest was not constructed as a subset.
+
+  my $subset = $manifest->subset();
+  print length($subset) ? $subset : '(none)'; # prints the subset id or '(none)'
+
+=head2 redacted
+
+  my $redacted = $manifest->redacted();
+
+Returns the companion redacted manifest for this manifest type. The base class
+does not implement this method; it exists to define the interface that
+subclasses must fulfill. Subclasses representing deployable manifests that
+contain unredacted secrets must override this to return the appropriate
+redacted variant. Subclasses that already represent a redacted or secret-free
+form should return C<$self>.
+
+Dies with C<"redacted: Not implemented for %s manifest types"> if called on
+the base class or any subclass that has not overridden it, where C<%s> is the
+manifest's label (e.g. for the partial environment type the message would be
+C<"redacted: Not implemented for partial environment manifest types">).
+
+  # Example of a subclass override:
+  my $redacted = $manifest->redacted();
+  # Returns: the companion redacted manifest object for this manifest type
+
+=head2 manifest_lookup_target
+
+  my $target = $manifest->manifest_lookup_target();
+  my $data   = $manifest->data();
+
+B<manifest_lookup_target> returns the manifest object that should be used when
+performing Vault or manifest lookups. The base class returns C<$self>.
+Subclasses that require lookups to be resolved against a different manifest
+variant (such as Entombed and VaultifiedEntombed, which delegate to the
+unredacted manifest) may override this.
+
+B<data> returns the manifest content as a parsed YAML data structure (hashref).
+The result is memoized: the first call builds or loads the manifest; subsequent
+calls return the cached value.
+
+Build strategy for C<data>:
+
+=over 4
+
+=item 1. If a pre-built file is already loaded (C<has_file> is true), loads
+and returns the YAML from that file.
+
+=item 2. If the manifest is a subset (C<is_subset> is true), delegates to
+the builder's subset retrieval.
+
+=item 3. Otherwise calls C<_merge> (which subclasses must implement) to merge
+source files and produce the data.
+
+=back
+
+  my $target = $manifest->manifest_lookup_target();
+  print ref($target); # prints the manifest class name
+
+  my $data = $manifest->data();
+  print $data->{name}; # prints the deployment name
+
+=head2 file
+
+  my $file = $manifest->file();
+
+Returns the path to the manifest YAML file on disk. The result is memoized.
+
+Build strategy:
+
+=over 4
+
+=item 1. If the manifest data is already loaded in memory (C<has_data> is
+true), writes it to a YAML file and returns that path.
+
+=item 2. If the manifest is a subset, delegates to the builder's subset
+retrieval.
+
+=item 3. Otherwise calls C<_merge> (which subclasses must implement).
+
+=back
+
+B<Returns:> a string path to the manifest YAML file.
+
+  my $file = $manifest->file();
+  print $file; # prints e.g. '/path/to/manifest-myenv-abc123-unredacted.yml'
+
+=head2 deployable
+
+  my $bool     = $manifest->deployable();
+  my $has_data = $manifest->has_data();
+  my $has_file = $manifest->has_file();
+  $manifest->set_data($data);
+  $manifest->set_file($path);
+  $manifest->write_to($destination);
+  $manifest->reset();
+
+Several methods that manage the manifest's cached state and deployability:
+
+B<deployable> returns true if this manifest type is suitable for passing to
+C<bosh deploy>. The base class returns C<0> (false). Subclasses representing
+deployment-ready manifests (Unredacted, Vaultified, Entombed,
+VaultifiedEntombed) override this to return C<1>.
+
+B<has_data> returns true if manifest data has been loaded into memory.
+
+B<has_file> returns true if a manifest file path has been recorded on the
+object.
+
+B<set_data> stores C<$data> (a parsed YAML hashref) directly on the manifest
+object, bypassing the normal merge pipeline. Modifies the object in-place.
+
+B<set_file> records C<$path> as the manifest's on-disk YAML file, bypassing
+the normal build pipeline. Modifies the object in-place.
+
+B<write_to> copies the manifest's YAML file to C<$destination>. Calls C<file>
+to trigger a build if the file has not yet been produced. Dies if the copy
+fails.
+
+B<reset> clears all cached state -- in-memory data and recorded file path --
+and deletes any on-disk cache file if it exists. Forces subsequent calls to
+C<data> or C<file> to rebuild from scratch. Modifies the object in-place;
+C<set_data> and C<set_file> also modify the object in-place. Returns the
+manifest object for chaining.
+
+  print $manifest->deployable();   # prints '0' from base class
+  print $manifest->has_data() ? 'loaded' : 'not loaded';
+  # prints 'not loaded' when no data has been fetched yet
+
+  $manifest->set_data({ name => 'myenv', instance_groups => [] });
+  print $manifest->has_data() ? 'yes' : 'no'; # prints 'yes'
+
+  $manifest->set_file('/path/to/prebuilt.yml');
+  print $manifest->has_file() ? 'yes' : 'no'; # prints 'yes'
+
+  $manifest->write_to('/tmp/deploy.yml');
+  # copies the manifest YAML to /tmp/deploy.yml
+
+  $manifest->reset();
+  $manifest->data(); # forces a clean rebuild
+
+=head2 is_subset
+
+  my $bool = $manifest->is_subset();
+  $manifest->notify();
+  $manifest->notify($message);
+
+B<is_subset> returns true if this manifest was created with a defined C<$subset>
+argument (i.e., the subset slot is defined on the object, including as an
+empty string).
+
+B<notify> sets the build notice message for this manifest. When called with no
+argument (or C<undef>), generates a default message of the form
+C<"generating E<lt>labelE<gt> manifest..."> where the label comes from
+C<label>, formatted with terminal color markup. When called with a C<$message>
+string, stores that string as the notice instead.
+
+B<Parameters for notify:>
+
+=over 4
+
+=item * C<$message> - optional custom notice string; defaults to a generated
+"generating..." message when omitted
+
+=back
+
+  print $manifest->is_subset() ? 'subset' : 'full';
+  # prints 'full' when no subset was given to new()
+
+  $manifest->notify();
+  print $manifest->get_build_notice();
+  # prints e.g. 'generating unredacted manifest...'
+
+  $manifest->notify("building deployment manifest...");
+  print $manifest->get_build_notice();
+  # prints 'building deployment manifest...'
+
+=head2 dewrap
+
+  my $clean = Genesis::Env::Manifest::dewrap($msg);
+
+Package-level utility function (not an instance method). Strips ANSI terminal
+color sequences and log-level labels (e.g., C<[ERROR]>, C<[WARN]>) from a
+message string, and collapses the indent that was used to align continuation
+lines under the label. Returns the original C<$msg> unchanged if no label
+decoration is found.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$msg> - the string to clean up, typically an error message captured
+from an C<eval> block
+
+=back
+
+B<Returns:> the cleaned message string, or the original string if no label
+decoration is present.
+
+  my $clean = Genesis::Env::Manifest::dewrap($@);
+  print $clean; # prints the error message without ANSI codes or label prefix
+
+=head2 validate
+
+  my $ok = $manifest->validate();
+
+Attempts to build the manifest by calling C<data> on the corresponding type
+accessor of the builder (e.g., C<< $builder->unredacted->data >>). If the
+build fails, logs an error message.
+
+B<Returns:> C<1> if the manifest was built successfully, C<0> if an error
+occurred.
+
+  if ($manifest->validate()) {
+      print "Manifest is valid\n";
+      # prints 'Manifest is valid' when build succeeds
+  }
+
+=head2 has_notice
+
+  my $bool = $manifest->has_notice();
+  my $msg  = $manifest->get_build_notice();
+
+B<has_notice> returns true if a build notice has been set on this manifest
+(via C<notify>).
+
+B<get_build_notice> returns the build notice string previously set by
+C<notify>, or C<undef> if no notice has been set.
+
+  print $manifest->has_notice() ? 'has notice' : 'no notice';
+  # prints 'no notice' before notify() is called
+
+  $manifest->notify();
+  print $manifest->get_build_notice();
+  # prints e.g. 'generating unredacted manifest...'
+
+=head2 get_vault_paths
+
+  my @paths = $manifest->get_vault_paths();
+
+Returns the Vault paths associated with the environment's manifest. Delegates
+entirely to C<< $manifest->builder->vault_paths() >>.
+
+  my @paths = $manifest->get_vault_paths();
+  print scalar @paths; # prints the number of Vault paths
+
+=head1 ABSTRACT METHODS
+
+Methods that derived classes B<must> implement. The base class dies (via
+C<bug>) if these are not overridden.
+
+=head2 _merge
+
+Must perform the manifest merge operation. Returns a list of C<($data, $file)>
+where C<$data> is the parsed YAML hashref and C<$file> is the path to the
+written YAML file on disk.
+
+This method is also grouped with C<_get_subset>, which handles the C<$req>
+parameter (either C<'data'> or C<'file'>) when the manifest is being retrieved
+as a subset.
+
+B<Parameters for _get_subset:>
+
+=over 4
+
+=item * C<$req> - either C<'data'> or C<'file'>, selecting what to retrieve
+
+=back
+
+Dies with C<"Expected %s to define private _merge method"> if not overridden,
+where C<%s> is the calling class name.
+
+  # In a derived class:
+  sub _merge {
+      my $self = shift;
+      my ($data, $file, $warnings, $errors) = $self->builder->merge(...);
+      return ($data, $file);
+      # Returns: ($data_hashref, '/path/to/manifest.yml')
+  }
+
+=head1 OVERRIDE POINTS
+
+Methods that derived classes B<may> override to customize behavior. The base
+class provides a working default for each.
+
+The following three methods are the primary customization points:
+
+B<deployable> -- override to return C<1> if the manifest type is suitable for
+passing to C<bosh deploy>. The base class returns C<0>.
+
+  # In a derived class that produces a deployable manifest:
+  sub deployable { 1 }
+
+B<redacted> -- override to return the appropriate redacted companion manifest.
+For manifest types that already contain no secrets (e.g., Entombed), return
+C<$self>. For manifest types that expose secrets (e.g., Unredacted), return
+the builder's redacted variant.
+
+  # Manifest type that exposes secrets:
+  sub redacted {
+      my $self = shift;
+      return $self->builder->redacted(subset => $self->{subset});
+  }
+
+  # Manifest type with no secrets:
+  sub redacted { $_[0] }
+
+B<manifest_lookup_target> -- override to return a different manifest object
+for Vault and manifest lookups. The base class returns C<$self>. Entombed-type
+manifests override this to return the unredacted manifest so lookups resolve
+against the manifest that contains the actual values.
+
+  # In a derived class:
+  sub manifest_lookup_target {
+      $_[0]->builder->unredacted(subset => $_[0]->{subset});
+  }
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _generate_file_name
+
+  my $path = $manifest->_generate_file_name($transient_flag);
+
+Constructs the canonical on-disk path for this manifest's YAML file. The path
+is built from the environment's work directory, the environment name, a
+signature hash, the manifest type, and optionally a subset suffix.
+
+When C<$transient_flag> is true, prepends C<"transient-"> to the filename to
+indicate a temporary build artifact.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$transient_flag> - optional boolean; when true, prepends
+C<"transient-"> to the filename
+
+=back
+
+  my $path = $manifest->_generate_file_name();
+  # Returns e.g. '/tmp/genesis/manifest-myenv-abc123-unredacted.yml'
+
+  my $path = $manifest->_generate_file_name(1);
+  # Returns e.g. '/tmp/genesis/transient-manifest-myenv-abc123-unredacted.yml'
+
+=head2 _load_file
+
+  my $data = $manifest->_load_file();
+
+Loads and parses the YAML file at C<< $manifest->file() >>. Returns the parsed
+data structure. Calls C<load_yaml_file> from the Genesis utility library.
+
+  my $data = $manifest->_load_file();
+  print ref($data); # prints 'HASH'
+
+=head2 _save_data_to_file
+
+  my $path = $manifest->_save_data_to_file($data);
+
+Serializes C<$data> (a parsed YAML hashref) to the canonical manifest file
+path (from C<_generate_file_name>, or the already-recorded file path if set).
+Returns the path of the written file.
+
+  my $path = $manifest->_save_data_to_file($data);
+  print $path; # prints the path of the written YAML file
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Manifest/Entombed.pod
+++ b/lib/Genesis/Env/Manifest/Entombed.pod
@@ -1,0 +1,191 @@
+=head1 NAME
+
+Genesis::Env::Manifest::Entombed - Manifest with Vault secrets entombed into BOSH Credhub
+
+=head1 SYNOPSIS
+
+  use Genesis::Env::Manifest::Entombed;
+
+  # Entombed manifests are created by the builder, not directly
+  my $manifest = $builder->entombed();
+
+  # Access manifest content (triggers entombment on first call)
+  my $data = $manifest->data();
+  my $file = $manifest->file();
+
+  # Confirm this manifest type is deployable
+  print $manifest->deployable(); # prints '1'
+
+  # Redaction is a no-op; entombed manifests contain no raw vault secrets
+  my $same = $manifest->redacted();
+  print ref($same); # prints 'Genesis::Env::Manifest::Entombed'
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::Manifest::Entombed> is a concrete subclass of
+L<Genesis::Env::Manifest> that produces deployment manifests suitable for use
+with BOSH environments whose secrets are stored in Credhub rather than
+resolved directly from Vault at deploy time.
+
+During manifest generation this class invokes the entombment workflow
+provided by L<Genesis::Env::Manifest::_entombment_mixin>: every Vault path
+referenced by the rendered manifest is read, each key-value pair is written
+into Credhub as a value-type credential, and the local in-memory Vault is
+populated with the corresponding Credhub variable references
+(C<((path--key--sha))>). The resulting manifest resolves secrets from Credhub
+at deploy time rather than embedding raw Vault values.
+
+This is the default manifest type for regular Genesis kits. The entombed
+manifest is deployable (C<deployable> returns C<1>) and does not need
+redaction because no raw Vault secrets appear in the merged output.
+
+Vault-path lookups are resolved against the unredacted manifest variant so
+that the original secret values are accessible for the entombment copy step.
+
+This class includes entombment behaviour via
+L<Genesis::Env::Manifest::_entombment_mixin>, which provides the
+C<local_vault> and C<_entomb_secrets> methods used during merging.
+
+=head1 METHODS
+
+=head2 description
+
+  my $desc = $manifest->description();
+
+Returns a human-readable string that identifies this manifest variant and
+its purpose.
+
+B<Returns:> C<"Manifest with secrets entombed into BOSH's Credhub from the
+single-source-of-truth Vault (default for regular kits)">
+
+B<Examples:>
+
+  my $manifest = $builder->entombed();
+  print $manifest->description();
+  # prints 'Manifest with secrets entombed into BOSH's Credhub from the single-source-of-truth Vault (default for regular kits)'
+
+=head2 manifest_lookup_target
+
+  my $target = $manifest->manifest_lookup_target();
+
+Returns the unredacted manifest variant that should be used when performing
+Vault or manifest lookups. Because the entombed manifest replaces secrets
+with Credhub references, lookups must be resolved against the unredacted
+variant that still holds the original values.
+
+B<Returns:> C<< $manifest->builder->unredacted(subset => $manifest->{subset}) >>
+
+B<Examples:>
+
+  my $target = $manifest->manifest_lookup_target();
+  print ref($target); # prints 'Genesis::Env::Manifest::Unredacted'
+
+=head2 source_files
+
+  my $files = $manifest->source_files();
+
+Returns an ordered array reference of the source files that are merged to
+produce this manifest. The list is assembled from the builder in the
+standard Genesis merge order:
+
+=over 4
+
+=item 1. Initiation file
+
+=item 2. Kit files
+
+=item 3. Cloud config files (required; C<optional =E<gt> 0>)
+
+=item 4. Environment files
+
+=item 5. Conclusion file
+
+=back
+
+B<Returns:> an array reference of file paths.
+
+B<Examples:>
+
+  my $files = $manifest->source_files();
+  print scalar @{$files}; # prints the number of source files
+
+=head2 merge_options
+
+  my $opts = $manifest->merge_options();
+
+Returns the options hash passed to the builder's C<merge> call. For the
+entombed manifest no extra merge options are required.
+
+B<Returns:> an empty hash reference C<{}>.
+
+B<Examples:>
+
+  my $opts = $manifest->merge_options();
+  print scalar keys %{$opts}; # prints '0'
+
+=head2 remote_vault_merge_environment
+
+  my $env = $manifest->remote_vault_merge_environment();
+
+Returns the environment hash used when merging against the remote
+(production) Vault. Combines the builder's full merge environment with the
+environment's remote Vault environment variables, and explicitly sets
+C<REDACT> to C<undef> to suppress secret redaction.
+
+B<Returns:> a hash reference combining C<< $manifest->builder->full_merge_env >>,
+C<< $manifest->env->vault->env >>, and C<< REDACT =E<gt> undef >>.
+
+B<Examples:>
+
+  my $env = $manifest->remote_vault_merge_environment();
+  print exists $env->{REDACT} ? 'has REDACT key' : 'no REDACT key';
+  # prints 'has REDACT key'
+
+=head2 local_vault_merge_environment
+
+  my $env = $manifest->local_vault_merge_environment();
+
+Returns the environment hash used when merging against the local in-memory
+Vault that holds Credhub variable references. Combines the builder's full
+merge environment with the local Vault's environment variables, and
+explicitly sets C<REDACT> to C<undef>.
+
+B<Returns:> a hash reference combining C<< $manifest->builder->full_merge_env >>,
+C<< $manifest->local_vault->env >>, and C<< REDACT =E<gt> undef >>.
+
+B<Examples:>
+
+  my $env = $manifest->local_vault_merge_environment();
+  print exists $env->{REDACT} ? 'has REDACT key' : 'no REDACT key';
+  # prints 'has REDACT key'
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _merge
+
+  my ($data, $file) = $manifest->_merge();
+
+Performs the full entombed manifest merge. Calls C<_entomb_secrets> (provided
+by the included mixin) to copy Vault secrets into Credhub and populate the
+local in-memory Vault with Credhub variable references. Then merges all
+source files using either the local vault environment (when entombment
+occurred) or the remote vault environment (when there were no Vault paths to
+entomb). If entombment was performed, shuts down the local Vault after the
+merge completes.
+
+B<Returns:> a two-element list C<($data, $file)> where C<$data> is the
+parsed YAML hashref and C<$file> is the path to the written manifest YAML
+file on disk.
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Manifest/Partial.pod
+++ b/lib/Genesis/Env/Manifest/Partial.pod
@@ -1,0 +1,128 @@
+=encoding utf8
+
+=head1 NAME
+
+Genesis::Env::Manifest::Partial - Partially evaluated manifest for debugging spruce operator issues
+
+=head1 SYNOPSIS
+
+  use Genesis::Env::Manifest::Partial;
+
+  # Partial manifests are created by the builder, not directly
+  my $manifest = $builder->partial();
+
+  # Access manifest content -- may contain unevaluated spruce operators
+  my $data = $manifest->data();   # returns parsed YAML as hashref
+  my $file = $manifest->file();   # returns path to manifest YAML file
+
+  # Identify this manifest type
+  print $manifest->type();        # prints 'partial'
+  print $manifest->label();       # prints 'partial'
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::Manifest::Partial> is a subclass of L<Genesis::Env::Manifest>
+that produces a manifest using C<eval=adaptive> mode, allowing spruce to
+merge the manifest even when some spruce operators cannot be fully evaluated.
+The resulting manifest may contain literal spruce operator expressions that
+would normally be resolved.
+
+This manifest type is intended for debugging: it lets developers inspect
+the partially merged YAML structure when spruce operators cannot be resolved
+due to missing Vault values, unavailable cloud-config, or other transient
+conditions. It is not suitable for deployment.
+
+Secrets are not redacted in this manifest type. The merge environment
+explicitly sets C<REDACT> to C<undef> so that Vault operator output
+remains visible in the output.
+
+The source file list includes all standard layers: initiation file, kit
+files, cloud config (treated as optional), environment files, and the
+conclusion file. Cloud config is made optional so the merge proceeds even
+when no cloud config is available, which is common when debugging partial
+manifests.
+
+=head1 METHODS
+
+=head2 description
+
+  my $str = $manifest->description();
+
+Returns the human-readable description of this manifest type.
+
+B<Returns:> the string C<"Partially evaluated manifest for debugging purposes
+- will contain any unevaluateable spruce operators">.
+
+  my $desc = $manifest->description();
+  print $desc;
+  # Returns: 'Partially evaluated manifest for debugging purposes - will contain any unevaluateable spruce operators'
+
+=head2 merge_options
+
+  my $opts = $manifest->merge_options();
+
+Returns the spruce merge options hash reference for this manifest type.
+Sets C<eval> to C<'adaptive'>, which instructs spruce to merge the manifest
+even when some operators cannot be evaluated, leaving them in place rather
+than failing.
+
+B<Returns:> a hash reference of the form C<{ eval => 'adaptive' }>.
+
+  my $opts = $manifest->merge_options();
+  print $opts->{eval};  # Returns: 'adaptive'
+
+=head2 merge_environment
+
+  my $env = $manifest->merge_environment();
+
+Returns the environment variable hash reference used during the spruce
+merge. The returned hash merges three sources:
+
+=over 4
+
+=item * The builder's full merge environment (from
+C<< $manifest->builder->full_merge_env >>)
+
+=item * The Vault environment variables (from
+C<< $manifest->env->vault->env >>)
+
+=item * C<REDACT> set to C<undef>, disabling secret redaction so that
+Vault operator output remains visible in the partial manifest
+
+=back
+
+B<Returns:> a hash reference of environment variable names to values.
+
+  my $env = $manifest->merge_environment();
+  print defined($env->{REDACT}) ? 'redacted' : 'not redacted';
+  # Returns: 'not redacted'
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _merge
+
+  my ($data, $file) = $manifest->_merge();
+
+Performs the manifest merge by delegating to
+C<< $manifest->builder->merge() >> with this manifest object, the source
+files from C<source_files>, the merge options from C<merge_options>, and
+the environment variables from C<merge_environment>.
+
+Returns the merged data and the path to the written YAML file. Warnings
+and errors reported by the merge are currently not acted upon.
+
+B<Returns:> a two-element list of C<($data, $file)>, where C<$data> is the
+parsed YAML hashref and C<$file> is the path to the written YAML file.
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Manifest/Partial.pod
+++ b/lib/Genesis/Env/Manifest/Partial.pod
@@ -97,6 +97,20 @@ B<Returns:> a hash reference of environment variable names to values.
   print defined($env->{REDACT}) ? 'redacted' : 'not redacted';
   # Returns: 'not redacted'
 
+=head2 source_files
+
+  my $files = $manifest->source_files();
+
+Returns an array reference of the ordered merge-source file paths used to
+build this manifest. The merge order is: initiation file, kit files, cloud
+config files (optional, so the merge proceeds even when no cloud config is
+available), environment files, and conclusion file.
+
+B<Returns:> An array reference of absolute file path strings.
+
+  my $files = $manifest->source_files();
+  print ref($files);    # prints 'ARRAY'
+
 =head1 INTERNAL METHODS
 
 These methods are internal to the implementation. They may change without

--- a/lib/Genesis/Env/Manifest/PartialEnvironment.pod
+++ b/lib/Genesis/Env/Manifest/PartialEnvironment.pod
@@ -1,0 +1,103 @@
+=head1 NAME
+
+Genesis::Env::Manifest::PartialEnvironment - Manifest built from environment files only, without kit components.
+
+=head1 SYNOPSIS
+
+  use Genesis::Env::Manifest::PartialEnvironment;
+
+  # Typically instantiated through the manifest builder, not directly.
+  my $manifest = Genesis::Env::Manifest::PartialEnvironment->new($builder, $subset);
+
+  # Access the merged data or file path.
+  my $data = $manifest->data();
+  my $file = $manifest->file();
+
+  # Retrieve the human-readable description of this manifest type.
+  my $desc = $manifest->description();
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::Manifest::PartialEnvironment> is a subclass of
+L<Genesis::Env::Manifest> that builds a manifest from environment-specific
+YAML files only. Kit component files are excluded from the merge, so the
+result represents a partially evaluated view of the environment.
+
+Because kit components are absent, spruce operators that depend on them
+cannot be resolved. The merge uses C<adaptive> evaluation mode so that
+any unevaluatable operators are passed through rather than treated as
+errors. Secret redaction is also disabled for this manifest type.
+
+The list of source files is determined by the builder's C<environment_files>
+method. This manifest is useful for inspecting the raw environment
+configuration before kit-supplied defaults and overrides are applied.
+
+=head1 METHODS
+
+=head2 description
+
+  my $str = $manifest->description();
+
+Returns a human-readable string identifying this manifest type and
+summarising its scope.
+
+  my $desc = $manifest->description();
+  print $desc;
+  # prints 'Partially evaluated environment files only (no kit components)
+  #         - will contain any unevaluateable spruce operators'
+
+=head2 merge_options
+
+  my $opts = $manifest->merge_options();
+
+Returns a hash reference of options to pass to the manifest builder's merge
+operation. For partial environment manifests, evaluation is set to
+C<adaptive> so that spruce operators that cannot be resolved are left in
+place rather than causing the merge to fail.
+
+B<Returns:> A hash reference of the form C<< { eval => 'adaptive' } >>.
+
+  my $opts = $manifest->merge_options();
+  print $opts->{eval};  # prints 'adaptive'
+
+=head2 merge_environment
+
+  my $env = $manifest->merge_environment();
+
+Returns a hash reference of environment variable overrides to apply during
+the merge. For partial environment manifests, the C<REDACT> variable is
+explicitly set to C<undef>, disabling secret redaction so that raw secret
+values are visible in the merged output.
+
+B<Returns:> A hash reference of the form C<< { REDACT => undef } >>.
+
+  my $env = $manifest->merge_environment();
+  print exists($env->{REDACT}) ? 'present' : 'absent';  # prints 'present'
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _merge
+
+  $manifest->_merge()
+
+Performs the actual merge by invoking the builder's C<merge> method with
+the source files, merge options, and merge environment defined by this
+class. Returns the merged data structure and the path to the generated
+manifest file.
+
+B<Returns:> A two-element list C<($data, $file)> where C<$data> is the
+merged YAML data structure and C<$file> is the path to the written manifest
+file.
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Manifest/PartialEnvironment.pod
+++ b/lib/Genesis/Env/Manifest/PartialEnvironment.pod
@@ -7,7 +7,7 @@ Genesis::Env::Manifest::PartialEnvironment - Manifest built from environment fil
   use Genesis::Env::Manifest::PartialEnvironment;
 
   # Typically instantiated through the manifest builder, not directly.
-  my $manifest = Genesis::Env::Manifest::PartialEnvironment->new($builder, $subset);
+  my $manifest = $builder->partial_environment();
 
   # Access the merged data or file path.
   my $data = $manifest->data();

--- a/lib/Genesis/Env/Manifest/PartialEnvironment.pod
+++ b/lib/Genesis/Env/Manifest/PartialEnvironment.pod
@@ -81,7 +81,7 @@ notice and should not be called directly.
 
 =head2 _merge
 
-  $manifest->_merge()
+  my ($data, $file) = $manifest->_merge();
 
 Performs the actual merge by invoking the builder's C<merge> method with
 the source files, merge options, and merge environment defined by this

--- a/lib/Genesis/Env/Manifest/Redacted.pod
+++ b/lib/Genesis/Env/Manifest/Redacted.pod
@@ -1,0 +1,136 @@
+=head1 NAME
+
+Genesis::Env::Manifest::Redacted - Full manifest with secrets redacted for safe viewing
+
+=head1 SYNOPSIS
+
+  use Genesis::Env::Manifest::Redacted;
+
+  # Typically obtained via the manifest builder, not instantiated directly:
+  my $manifest = $builder->redacted;
+
+  # Access the merged YAML data (secrets replaced with REDACTED):
+  my $data = $manifest->data;
+
+  # Get the path to the manifest file on disk:
+  my $file = $manifest->file;
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::Manifest::Redacted> is a subclass of C<Genesis::Env::Manifest>
+that produces a fully merged BOSH manifest with all Vault secrets replaced by
+the string C<"REDACTED">. This makes the manifest safe to display, log, or
+share without exposing credential values.
+
+The redaction is achieved by setting the C<REDACT=yes> environment variable
+during the Spruce merge. Spruce recognizes this variable and substitutes secret
+values with a redacted placeholder instead of resolving them from Vault.
+
+This class overrides C<source_files>, C<merge_options>, C<merge_environment>,
+and C<_merge> from C<Genesis::Env::Manifest> to control exactly which files are
+merged and what environment is passed to the merge process.
+
+=head1 METHODS
+
+=head2 description
+
+  my $label = $manifest->description;
+
+Returns a human-readable string describing this manifest type:
+C<"Full manifest with secrets redacted for safe viewing">.
+
+  # Example
+  my $manifest = $builder->redacted;
+  print $manifest->description;
+  # prints 'Full manifest with secrets redacted for safe viewing'
+
+=head2 source_files
+
+  my $files = $manifest->source_files;
+
+Returns an array reference of source file paths to be merged, in order:
+
+=over 4
+
+=item 1. The builder's initiation file
+
+=item 2. The builder's kit files
+
+=item 3. The builder's cloud config files (required; C<optional =E<gt> 0>)
+
+=item 4. The builder's environment files
+
+=item 5. The builder's conclusion file
+
+=back
+
+B<Returns:> An array reference of file paths.
+
+  # Example
+  my $files = $manifest->source_files;
+  print scalar(@$files), " source files\n";
+
+=head2 merge_options
+
+  my $opts = $manifest->merge_options;
+
+Returns the merge options hash reference for this manifest type. For redacted
+manifests, no special merge options are required, so an empty hash reference is
+returned.
+
+B<Returns:> An empty hash reference (C<{}>).
+
+  # Example
+  my $opts = $manifest->merge_options;
+  print ref($opts);  # prints 'HASH'
+
+=head2 merge_environment
+
+  my $env = $manifest->merge_environment;
+
+Returns a hash reference of environment variables to pass to the Spruce merge
+process. This hash includes:
+
+=over 4
+
+=item * All variables from the builder's full merge environment (via C<full_merge_env>)
+
+=item * All variables from the Vault client environment (via C<env->vault->env>)
+
+=item * C<REDACT =E<gt> "yes">, which instructs Spruce to replace secret values with a redacted placeholder
+
+=back
+
+B<Returns:> A hash reference of environment variable name/value pairs.
+
+  # Example
+  my $env = $manifest->merge_environment;
+  print $env->{REDACT};  # prints 'yes'
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _merge
+
+  my ($data, $file) = $manifest->_merge;
+
+Performs the Spruce merge by delegating to C<< $self->builder->merge >> with
+the results of C<source_files>, C<merge_options>, and C<merge_environment>.
+Returns the merged YAML data structure and the path to the generated manifest
+file on disk.
+
+B<Returns:> A two-element list: C<$data> (the merged YAML data structure) and
+C<$file> (the path to the manifest file). Either may be C<undef> if the merge
+did not produce that output.
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Manifest/Unevaluated.pod
+++ b/lib/Genesis/Env/Manifest/Unevaluated.pod
@@ -1,0 +1,120 @@
+=head1 NAME
+
+Genesis::Env::Manifest::Unevaluated - Manifest subclass producing a raw merged
+template with spruce operators intact
+
+=head1 SYNOPSIS
+
+  use Genesis::Env::Manifest::Unevaluated;
+
+  # Unevaluated manifests are created by the builder, not directly
+  my $manifest = $builder->unevaluated();
+
+  # Access raw merged content (spruce operators still in place)
+  my $data = $manifest->data();
+  my $file = $manifest->file();
+
+  # Inspect the manifest type
+  print $manifest->type();        # prints 'unevaluated'
+  print $manifest->description(); # prints a human-readable summary
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::Manifest::Unevaluated> is a concrete subclass of
+L<Genesis::Env::Manifest> that produces a raw merged manifest template in which
+spruce operators (C<(( ))>) have B<not> been evaluated. The source files are
+merged in the standard order (initiation, kit, cloud config, environment,
+conclusion), but the merge is performed with C<eval =E<gt> 'no'> so that spruce
+interpolation is suppressed.
+
+This variant is useful for inspecting the merged structure of a deployment
+manifest before any spruce evaluation takes place -- for example, to see the
+literal operator expressions that will later be resolved during a full
+unredacted or deployable manifest build.
+
+The merge environment includes the full set of build environment variables plus
+Vault credentials. Redaction is explicitly disabled (C<REDACT =E<gt> undef>),
+so Vault-sourced values appear in plain text in the merged output.
+
+This class is not instantiated directly. Use the builder to obtain an instance.
+
+=head1 METHODS
+
+=head2 description
+
+  my $str = $manifest->description();
+
+Returns a fixed human-readable string describing this manifest variant:
+C<"Raw merged manifest template with no interpolation (merged, but spruce
+operators still in place)">.
+
+B<Returns:> a string.
+
+  print $manifest->description();
+  # prints 'Raw merged manifest template with no interpolation (merged, but spruce operators still in place)'
+
+=head2 merge_options
+
+  my $opts = $manifest->merge_options();
+
+Returns the spruce merge options hash reference used when building this
+manifest. For the Unevaluated variant, evaluation is disabled:
+
+  { eval => 'no' }
+
+This causes spruce to merge the files without evaluating any C<(( ))>
+operator expressions, leaving them intact in the output.
+
+B<Returns:> a hash reference.
+
+  my $opts = $manifest->merge_options();
+  print $opts->{eval}; # prints 'no'
+
+=head2 merge_environment
+
+  my $env = $manifest->merge_environment();
+
+Returns a hash reference of environment variables passed to the spruce merge
+process. Combines C<< $builder->full_merge_env >> (the standard build
+environment) with C<< $manifest->env->vault->env >> (Vault credential
+variables), and then explicitly sets C<REDACT> to C<undef>, disabling any
+redaction of Vault-sourced values in the merged output.
+
+B<Returns:> a hash reference of environment variable names to values.
+
+  my $env = $manifest->merge_environment();
+  print defined($env->{REDACT}) ? 'set' : 'unset'; # prints 'unset'
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _merge
+
+  my ($data, $file) = $manifest->_merge();
+
+Implements the abstract C<_merge> method required by L<Genesis::Env::Manifest>.
+Calls C<< $builder->merge >> with the source files returned by C<source_files>
+(initiation file, kit files, optional cloud config files, environment files,
+and conclusion file), the merge options (C<eval =E<gt> 'no'>), and the merge
+environment assembled by C<merge_environment>. Ignores any warnings or errors
+produced during the merge (see the inline C<FIXME> comment in the source).
+
+B<Returns:> a two-element list C<($data, $file)> where C<$data> is the parsed
+YAML data structure and C<$file> is the path to the written manifest file on
+disk.
+
+  # Called internally by data() and file() from the base class
+  my ($data, $file) = $manifest->_merge();
+  print ref($data); # prints 'HASH'
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Manifest/UnevaluatedEnvironment.pod
+++ b/lib/Genesis/Env/Manifest/UnevaluatedEnvironment.pod
@@ -7,7 +7,7 @@ Genesis::Env::Manifest::UnevaluatedEnvironment - Manifest built from raw environ
   use Genesis::Env::Manifest::UnevaluatedEnvironment;
 
   # Typically constructed via the manifest builder, not directly.
-  my $manifest = Genesis::Env::Manifest::UnevaluatedEnvironment->new($builder);
+  my $manifest = $builder->unevaluated_environment();
 
   # Retrieve the merged (but unevaluated) manifest data.
   my $data = $manifest->data;

--- a/lib/Genesis/Env/Manifest/UnevaluatedEnvironment.pod
+++ b/lib/Genesis/Env/Manifest/UnevaluatedEnvironment.pod
@@ -1,0 +1,112 @@
+=head1 NAME
+
+Genesis::Env::Manifest::UnevaluatedEnvironment - Manifest built from raw environment files only, with spruce operators unevaluated.
+
+=head1 SYNOPSIS
+
+  use Genesis::Env::Manifest::UnevaluatedEnvironment;
+
+  # Typically constructed via the manifest builder, not directly.
+  my $manifest = Genesis::Env::Manifest::UnevaluatedEnvironment->new($builder);
+
+  # Retrieve the merged (but unevaluated) manifest data.
+  my $data = $manifest->data;
+
+  # Get the path to the cached manifest file.
+  my $file = $manifest->file;
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::Manifest::UnevaluatedEnvironment> is a subclass of
+C<Genesis::Env::Manifest> that builds a manifest from the environment's own
+YAML files only, excluding kit components. Spruce operators such as C<(( grab ))>
+and C<(( concat ))> are left in place; evaluation is explicitly disabled.
+
+This type of manifest is useful for inspecting the raw merged structure of an
+environment's configuration before any operator resolution takes place. Secret
+redaction is also disabled so that all values appear as authored.
+
+=head1 METHODS
+
+=head2 description
+
+  my $str = $manifest->description();
+
+Returns a human-readable string describing what this manifest type contains.
+
+B<Returns:> The string C<"Raw merged environment files only (no kit components) - spruce operators still in place">.
+
+  # Example
+  my $manifest = Genesis::Env::Manifest::UnevaluatedEnvironment->new($builder);
+  print $manifest->description();
+  # prints 'Raw merged environment files only (no kit components) - spruce operators still in place'
+
+=head2 source_files
+
+  my $files = $manifest->source_files();
+
+Returns the list of YAML source files to merge for this manifest type. Only
+the environment's own files are included; kit component files are excluded.
+
+B<Returns:> An array reference of file paths returned by the builder's
+C<environment_files> method.
+
+  # Example
+  my $files = $manifest->source_files();
+  print ref($files);   # prints 'ARRAY'
+  print $files->[0];   # prints the path to the first environment file
+
+=head2 merge_options
+
+  my $opts = $manifest->merge_options();
+
+Returns the options hash to pass to the spruce merge engine. For this manifest
+type, evaluation is disabled so that spruce operators remain in the output
+as literal text.
+
+B<Returns:> A hash reference of the form C<{ eval =E<gt> 'no' }>.
+
+  # Example
+  my $opts = $manifest->merge_options();
+  print $opts->{eval};   # prints 'no'
+
+=head2 merge_environment
+
+  my $env = $manifest->merge_environment();
+
+Returns environment variable overrides to apply during the merge. For this
+manifest type, the C<REDACT> variable is explicitly set to C<undef> so that
+secret values are not redacted in the output.
+
+B<Returns:> A hash reference of the form C<{ REDACT =E<gt> undef }>.
+
+  # Example
+  my $env_vars = $manifest->merge_environment();
+  print defined($env_vars->{REDACT}) ? 'defined' : 'undef';   # prints 'undef'
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _merge
+
+  my ($data, $file) = $manifest->_merge();
+
+Performs the actual merge by delegating to the builder's C<merge> method,
+passing the manifest object, the source files, the merge options, and the
+merge environment. Returns the merged data structure and the path to the
+generated manifest file.
+
+B<Returns:> A two-element list: the merged manifest data (hash reference)
+and the path to the written manifest file (string).
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Manifest/UnevaluatedEnvironment.pod
+++ b/lib/Genesis/Env/Manifest/UnevaluatedEnvironment.pod
@@ -26,6 +26,10 @@ This type of manifest is useful for inspecting the raw merged structure of an
 environment's configuration before any operator resolution takes place. Secret
 redaction is also disabled so that all values appear as authored.
 
+Because environment-only files contain no Vault operators (those come from
+the kit), this manifest type does not require Vault credentials or the full
+merge environment -- only the C<REDACT> override is needed.
+
 =head1 METHODS
 
 =head2 description
@@ -77,6 +81,10 @@ B<Returns:> A hash reference of the form C<{ eval =E<gt> 'no' }>.
 Returns environment variable overrides to apply during the merge. For this
 manifest type, the C<REDACT> variable is explicitly set to C<undef> so that
 secret values are not redacted in the output.
+
+Environment-only files contain no Vault operators (those come from the kit),
+so Vault credentials and the full merge environment are unnecessary. Only
+C<REDACT> needs to be set.
 
 B<Returns:> A hash reference of the form C<{ REDACT =E<gt> undef }>.
 

--- a/lib/Genesis/Env/Manifest/Unredacted.pod
+++ b/lib/Genesis/Env/Manifest/Unredacted.pod
@@ -1,0 +1,143 @@
+=head1 NAME
+
+Genesis::Env::Manifest::Unredacted - Complete deployment manifest with embedded clear-text secrets
+
+=head1 SYNOPSIS
+
+  use Genesis::Env::Manifest::Unredacted;
+
+  # Manifests are created via the builder, not directly
+  my $manifest = $builder->unredacted();
+
+  # Access the manifest content with secrets visible
+  my $data = $manifest->data();   # returns parsed YAML with plain-text secrets
+  my $file = $manifest->file();   # returns path to the YAML file on disk
+
+  # Get the companion redacted version
+  my $safe = $manifest->redacted();
+
+  # Write the manifest to a destination path for deployment
+  $manifest->write_to('/path/to/deploy.yml');
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::Manifest::Unredacted> is the concrete manifest subclass that
+produces a complete BOSH deployment manifest with all Vault secrets resolved
+and embedded as clear-text values. This is the manifest form that BOSH
+consumes when performing a deployment.
+
+The unredacted manifest is built by merging all standard source files
+(initiation, kit, cloud config, environment files, and conclusion) using the
+full merge environment extended with Vault credentials, and with the C<REDACT>
+variable explicitly cleared to C<undef>. Clearing C<REDACT> causes any
+Vault-aware YAML operators to emit the actual secret values rather than
+redaction placeholders.
+
+This manifest is I<deployable>: the C<deployable> method returns true, marking
+it as safe to pass directly to BOSH.
+
+The C<source_files> method returns the merge order: initiation file, kit
+files, cloud config files (required, never optional), environment files, and
+conclusion file.
+
+Manifests are constructed by the builder and should not be instantiated
+directly. See L<Genesis::Env::Manifest> for the full interface inherited by
+this class.
+
+=head1 METHODS
+
+=head2 description
+
+  my $str = $manifest->description();
+
+Returns a human-readable string describing this manifest type. Also overrides
+the C<deployable> method (returns C<1>) and the C<source_files> method
+(returns an array reference of the ordered merge-source file paths, with cloud
+config required).
+
+B<Returns:> the string C<"Complete deployment manifest with embedded
+clear-text secrets from Vault">.
+
+  my $manifest = $builder->unredacted();
+  print $manifest->description();
+  # prints 'Complete deployment manifest with embedded clear-text secrets from Vault'
+
+  # This manifest type is deployable
+  print $manifest->deployable();
+  # prints '1'
+
+  # Source files used for the merge
+  my $files = $manifest->source_files();
+  print ref($files);    # prints 'ARRAY'
+
+=head2 redacted
+
+  my $redacted = $manifest->redacted();
+
+Returns the companion redacted manifest for this manifest's subset. Delegates
+to C<< $builder->redacted(subset => $subset) >>, producing a
+C<Genesis::Env::Manifest::Redacted> object scoped to the same subset as this
+manifest.
+
+B<Returns:> a C<Genesis::Env::Manifest::Redacted> object.
+
+  my $unredacted = $builder->unredacted();
+  my $redacted   = $unredacted->redacted();
+  print ref($redacted); # prints 'Genesis::Env::Manifest::Redacted'
+
+=head2 merge_options
+
+  my $opts = $manifest->merge_options();
+
+Returns the merge options hash to be passed to the builder's C<merge> method.
+The unredacted manifest requires no special merge options.
+
+B<Returns:> an empty hash reference C<{}>.
+
+  my $opts = $manifest->merge_options();
+  print ref($opts);         # prints 'HASH'
+  print scalar keys %$opts; # prints '0'
+
+=head2 merge_environment
+
+  my $env = $manifest->merge_environment();
+
+Returns the environment variable hash used during the manifest merge. Combines
+the builder's full merge environment with Vault credentials from the
+environment's Vault instance, then explicitly sets C<REDACT> to C<undef>.
+Setting C<REDACT> to C<undef> causes Vault-aware YAML operators to emit actual
+secret values rather than redaction placeholders.
+
+B<Returns:> a hash reference containing the merged environment variables, with
+C<REDACT> set to C<undef>.
+
+  my $env = $manifest->merge_environment();
+  print defined($env->{REDACT}) ? 'set' : 'unset'; # prints 'unset'
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _merge
+
+  my ($data, $file) = $manifest->_merge();
+
+Invokes the builder's C<merge> method with this manifest, its source files,
+merge options, and merge environment to produce the unredacted manifest
+content. This is the implementation required by the C<Genesis::Env::Manifest>
+base class.
+
+B<Returns:> a two-element list of C<($data, $file)>, where C<$data> is the
+parsed manifest data structure and C<$file> is the path to the written YAML
+file on disk.
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Manifest/Unredacted.pod
+++ b/lib/Genesis/Env/Manifest/Unredacted.pod
@@ -50,10 +50,7 @@ this class.
 
   my $str = $manifest->description();
 
-Returns a human-readable string describing this manifest type. Also overrides
-the C<deployable> method (returns C<1>) and the C<source_files> method
-(returns an array reference of the ordered merge-source file paths, with cloud
-config required).
+Returns a human-readable string describing this manifest type.
 
 B<Returns:> the string C<"Complete deployment manifest with embedded
 clear-text secrets from Vault">.
@@ -62,11 +59,29 @@ clear-text secrets from Vault">.
   print $manifest->description();
   # prints 'Complete deployment manifest with embedded clear-text secrets from Vault'
 
-  # This manifest type is deployable
+=head2 deployable
+
+  my $bool = $manifest->deployable();
+
+Returns C<1>, marking this manifest type as suitable for passing to
+C<bosh deploy>. Overrides the base class default of C<0>.
+
+B<Returns:> C<1>.
+
   print $manifest->deployable();
   # prints '1'
 
-  # Source files used for the merge
+=head2 source_files
+
+  my $files = $manifest->source_files();
+
+Returns an array reference of the ordered merge-source file paths used to
+build this manifest. The merge order is: initiation file, kit files, cloud
+config files (required, never optional), environment files, and conclusion
+file.
+
+B<Returns:> An array reference of absolute file path strings.
+
   my $files = $manifest->source_files();
   print ref($files);    # prints 'ARRAY'
 

--- a/lib/Genesis/Env/Manifest/Vaultified.pod
+++ b/lib/Genesis/Env/Manifest/Vaultified.pod
@@ -1,0 +1,159 @@
+=head1 NAME
+
+Genesis::Env::Manifest::Vaultified - Deployable manifest with Credhub references converted to Vault operators
+
+=head1 SYNOPSIS
+
+  use Genesis::Env::Manifest::Vaultified;
+
+  # Manifests are obtained via the builder, not instantiated directly:
+  my $manifest = $builder->vaultified;
+
+  # Access the merged manifest data with Vault operators resolved:
+  my $data = $manifest->data;
+
+  # Get the path to the manifest file on disk:
+  my $file = $manifest->file;
+
+  # Get the companion redacted view:
+  my $redacted = $manifest->redacted;
+
+  # Confirm this manifest type is deployable:
+  print $manifest->deployable;  # prints '1'
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::Manifest::Vaultified> is a subclass of
+C<Genesis::Env::Manifest> that produces a fully merged BOSH deployment
+manifest suitable for environments that use Vault-based secrets. It is
+the primary deployable manifest type for Vault-based Genesis kits.
+
+The class includes L<Genesis::Env::Manifest::_vaultify_mixin> to gain the
+vaultification methods. The mixin converts Credhub C<((variable))>
+references found in the manifest's C<variables> block into Spruce Vault
+operator calls, then feeds the converted manifest through a final Spruce
+merge to resolve those operators against the live Vault instance. The
+result is a complete, evaluated BOSH manifest with all secrets embedded.
+
+The C<_merge> method defines the two-phase build process:
+
+=over 4
+
+=item 1. I<Vaultification> -- calls C<vaultify> (from the mixin) on a
+deep copy of the unredacted builder data. If the manifest contains a
+C<variables> block, the Credhub references are rewritten and the
+pre-merge file is written to a temporary location.
+
+=item 2. I<Spruce merge> -- calls C<merge_vaultified_manifest> (from the
+mixin) to run Spruce over the vaultified file, resolving Vault operators.
+If the manifest had no C<variables> block, the unredacted builder data and
+file are returned unchanged.
+
+=back
+
+Manifests are built by the manifest builder. Do not instantiate this
+class directly.
+
+See L<Genesis::Env::Manifest> for the full interface inherited by this
+class, and L<Genesis::Env::Manifest::_vaultify_mixin> for the vaultification
+methods that become part of this class's interface.
+
+=head1 METHODS
+
+=head2 description
+
+  my $str = $manifest->description;
+
+Returns a human-readable string describing this manifest type:
+C<"Manifest with Credhub queries converted to Vault operator syntax and
+variable definitions converted to allow for Genesis secrets operations">.
+
+  # Example
+  my $manifest = $builder->vaultified;
+  print $manifest->description;
+  # prints 'Manifest with Credhub queries converted to Vault operator
+  #         syntax and variable definitions converted to allow for
+  #         Genesis secrets operations'
+
+=head2 deployable
+
+  my $bool = $manifest->deployable;
+
+Returns C<1>, indicating that this manifest type is suitable for direct
+submission to BOSH as a deployment manifest.
+
+  # Example
+  my $manifest = $builder->vaultified;
+  print $manifest->deployable;  # prints '1'
+
+=head2 redacted
+
+  my $redacted = $manifest->redacted;
+
+Returns the companion redacted manifest for this manifest's subset.
+Delegates to C<< $self->builder->vaultified_redacted >>, passing the
+current subset, and returns a C<Genesis::Env::Manifest::VaultifiedRedacted>
+object. The redacted form applies the same vaultification step but runs
+the final Spruce merge with C<REDACT=yes> so that secret values appear
+masked.
+
+B<Returns:> a C<Genesis::Env::Manifest::VaultifiedRedacted> object scoped
+to the same subset as this manifest.
+
+  # Example
+  my $manifest = $builder->vaultified;
+  my $redacted = $manifest->redacted;
+  print ref($redacted);  # prints 'Genesis::Env::Manifest::VaultifiedRedacted'
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _merge
+
+  my ($data, $file) = $manifest->_merge;
+
+Implements the two-phase vaultification and merge process required by the
+C<Genesis::Env::Manifest> base class.
+
+First calls C<vaultify> with a deep copy of the builder's unredacted data
+and the path returned by C<pre_merged_vaultified_file>. If vaultification
+succeeds (the manifest contained a C<variables> block), calls
+C<merge_vaultified_manifest> to produce the final merged output and
+returns its C<($data, $file)> pair.
+
+If vaultification finds no C<variables> block, returns the builder's
+cached unredacted data and file unchanged, bypassing the Spruce merge.
+
+B<Returns:> a two-element list:
+
+=over 4
+
+=item * C<$data> - The manifest data structure, either fully merged and
+evaluated or the unredacted builder data if no vaultification was needed.
+
+=item * C<$file> - The path to the manifest file on disk corresponding to
+C<$data>.
+
+=back
+
+  # Called internally by data() and file() via the parent class:
+  my ($data, $file) = $manifest->_merge;
+  # Returns: ($data_hashref, '/path/to/manifest.yml')
+
+=head1 SEE ALSO
+
+L<Genesis::Env::Manifest>,
+L<Genesis::Env::Manifest::_vaultify_mixin>,
+L<Genesis::Env::Manifest::VaultifiedRedacted>
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Manifest/VaultifiedEntombed.pod
+++ b/lib/Genesis/Env/Manifest/VaultifiedEntombed.pod
@@ -194,8 +194,9 @@ The method runs the following steps in order:
 
 =item 1. Calls L<Genesis::Env::Manifest::_vaultify_mixin/vaultify> on a deep
 copy of the unredacted manifest data to populate the pre-merged vaultified
-file. If vaultification finds no C<variables> block it returns the existing
-entombed builder data and file immediately, without performing entombment.
+file. If vaultification finds no C<variables> block, steps 2 through 6 are
+skipped and the method returns the existing entombed builder data and file
+immediately.
 
 =item 2. Calls L<Genesis::Env::Manifest::_entombment_mixin/_entomb_secrets>
 to copy Vault secrets into Credhub and populate the local in-memory Vault
@@ -213,7 +214,8 @@ resolve any remaining Credhub references.
 with the local Vault's merge environment to produce the final manifest data
 and file.
 
-=item 6. Shuts down the local in-memory Vault.
+=item 6. Shuts down the local in-memory Vault. (This step only executes on
+the full-processing path; the early return at step 1 bypasses it.)
 
 =back
 

--- a/lib/Genesis/Env/Manifest/VaultifiedEntombed.pod
+++ b/lib/Genesis/Env/Manifest/VaultifiedEntombed.pod
@@ -1,0 +1,286 @@
+=head1 NAME
+
+Genesis::Env::Manifest::VaultifiedEntombed - Deployable manifest for vaultified kits that entombs Vault secrets into BOSH Credhub
+
+=head1 SYNOPSIS
+
+  use Genesis::Env::Manifest::VaultifiedEntombed;
+
+  # Manifests are created via the builder, not directly
+  my $manifest = $builder->vaultified_entombed();
+
+  # Access the manifest content (triggers full build on first access)
+  my $data = $manifest->data();   # returns parsed YAML with Credhub references
+  my $file = $manifest->file();   # returns path to the YAML file on disk
+
+  # Confirm this manifest type is deployable
+  print $manifest->deployable();  # prints '1'
+
+  # Write the manifest to a destination path for deployment
+  $manifest->write_to('/path/to/deploy.yml');
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::Manifest::VaultifiedEntombed> is the concrete manifest
+subclass used by vaultified kits that entomb Vault secrets into BOSH's
+Credhub. It is the default manifest type for Credhub-based kits.
+
+This class combines two complementary mixins to implement its behaviour:
+
+=over 4
+
+=item * L<Genesis::Env::Manifest::_vaultify_mixin> -- rewrites the
+C<variables> block of a BOSH manifest, converting Credhub C<((variable))>
+references into Spruce Vault operator calls. This makes the manifest's
+Vault dependencies explicit and allows Genesis secrets operations to manage
+them.
+
+=item * L<Genesis::Env::Manifest::_entombment_mixin> -- reads every Vault
+secret that the manifest references, copies each key-value pair into Credhub
+as a value-type credential under the C<genesis-entombed/> prefix, and
+rewrites the local in-memory Vault to hold Credhub variable references in
+place of the original secret values.
+
+=back
+
+The build process implemented by C<_merge> runs in several coordinated
+phases:
+
+=over 4
+
+=item 1. I<Vaultification discovery> -- C<vaultify> is called on a deep copy
+of the unredacted manifest data to discover which Vault paths the manifest
+references, without modifying the cached builder data.
+
+=item 2. I<Entombment> -- C<_entomb_secrets> copies every referenced Vault
+secret into Credhub and populates the local in-memory Vault with the
+resulting Credhub variable references.
+
+=item 3. I<Partial merge> -- a Spruce merge is performed with the vaultified
+intermediate file temporarily installed as the manifest file name, producing a
+partially-entombed data structure.
+
+=item 4. I<Final vaultification and merge> -- the partially-entombed data is
+vaultified again and the result is passed through C<merge_vaultified_manifest>
+using the local Vault's environment to resolve all remaining references.
+
+=item 5. I<Vault shutdown> -- the local in-memory Vault is shut down cleanly
+after the merge completes.
+
+=back
+
+The result is a manifest whose secrets are resolved entirely from Credhub at
+deploy time. Because entombed manifests carry no embedded Vault secrets, the
+C<redacted> method returns the manifest object itself unchanged.
+
+Content-sensitive naming (the SHA-1 suffix on each Credhub credential name)
+means that Credhub detects changes automatically, and Genesis secrets
+operations continue to manage the canonical values in Vault.
+
+Manifests are constructed by the builder and should not be instantiated
+directly. See L<Genesis::Env::Manifest> for the full interface inherited by
+this class.
+
+=head1 METHODS
+
+=head2 description
+
+  my $str = $manifest->description();
+
+Returns a human-readable string describing this manifest type. This class
+also overrides C<deployable> (returns C<1>, marking this manifest as safe to
+pass to BOSH) and C<source_files> (returns the ordered merge-source file
+list: initiation file, kit files, cloud config files (required, never
+optional), environment files, and conclusion file).
+
+B<Returns:> the string C<"Credhub secrets entombed into BOSH's Credhub from
+the single-source-of-truth Vault for a vaultified kit. This allows
+content-sensitive naming of credhub secrets to detect changes,  and use
+Genesis secrets operations for their management (default for credhub-based
+kits)">.
+
+B<Examples:>
+
+  my $manifest = $builder->vaultified_entombed();
+  print $manifest->description();
+  # Returns: 'Credhub secrets entombed into BOSH\'s Credhub from the
+  #           single-source-of-truth Vault for a vaultified kit...'
+
+  print $manifest->deployable();   # Returns: 1
+
+  my @files = $manifest->source_files();
+  # Returns: ('/path/to/init.yml', '/path/to/kit.yml', ...)
+
+=head2 redacted
+
+  my $redacted = $manifest->redacted();
+
+Returns the manifest object itself. Entombed manifests contain no embedded
+Vault secrets (only Credhub variable references), so no separate redacted
+form is required.
+
+B<Returns:> The invocant C<$manifest> object.
+
+B<Examples:>
+
+  my $same = $manifest->redacted();
+  print $same == $manifest ? 'same object' : 'different';  # Returns: 'same object'
+
+=head2 manifest_lookup_target
+
+  my $target = $manifest->manifest_lookup_target();
+
+Returns the vaultified manifest object for this manifest's subset. Used when
+looking up values from the manifest; delegates to
+C<< $self->builder->vaultified(subset => $self->{subset}) >>.
+
+B<Returns:> A C<Genesis::Env::Manifest::Vaultified> object scoped to the
+same subset as this manifest.
+
+B<Examples:>
+
+  my $target = $manifest->manifest_lookup_target();
+  print ref($target);  # Returns: 'Genesis::Env::Manifest::Vaultified'
+
+=head2 merge_options
+
+  my $opts = $manifest->merge_options();
+
+Returns the merge options hash to be passed to the builder's C<merge> method.
+This manifest type requires no special merge options.
+
+B<Returns:> An empty hash reference C<{}>.
+
+B<Examples:>
+
+  my $opts = $manifest->merge_options();
+  print ref($opts);          # Returns: 'HASH'
+  print scalar keys %$opts;  # Returns: 0
+
+=head2 merge_environment
+
+  my $env = $manifest->merge_environment();
+
+Returns the environment variable hash used during the manifest merge. Combines
+the builder's full merge environment with the local in-memory Vault's
+environment variables, and sets C<REDACT> to C<undef>. The local Vault
+contains Credhub variable references written by the entombment process, so
+clearing C<REDACT> allows those references to be resolved rather than masked.
+
+B<Returns:> A hashref of environment variable names to values, with C<REDACT>
+set to C<undef>.
+
+B<Examples:>
+
+  my $env = $manifest->merge_environment();
+  print defined($env->{REDACT}) ? 'set' : 'unset';  # Returns: 'unset'
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _merge
+
+  my ($data, $file) = $manifest->_merge();
+
+Implements the multi-phase build process that produces the fully entombed
+manifest. Called by the base class C<data> and C<file> accessors when no
+cached result exists.
+
+The method runs the following steps in order:
+
+=over 4
+
+=item 1. Calls L<Genesis::Env::Manifest::_vaultify_mixin/vaultify> on a deep
+copy of the unredacted manifest data to populate the pre-merged vaultified
+file. If vaultification finds no C<variables> block it returns the existing
+entombed builder data and file immediately, without performing entombment.
+
+=item 2. Calls L<Genesis::Env::Manifest::_entombment_mixin/_entomb_secrets>
+to copy Vault secrets into Credhub and populate the local in-memory Vault
+with Credhub variable references.
+
+=item 3. Temporarily installs the pre-merged vaultified file as the manifest's
+file name (via C<_set_file_name>), runs the builder's C<merge> with
+C<source_files>, C<merge_options>, and C<merge_environment>, then clears the
+transient file name.
+
+=item 4. Calls C<vaultify> again on the partially-entombed merge result to
+resolve any remaining Credhub references.
+
+=item 5. Calls L<Genesis::Env::Manifest::_vaultify_mixin/merge_vaultified_manifest>
+with the local Vault's merge environment to produce the final manifest data
+and file.
+
+=item 6. Shuts down the local in-memory Vault.
+
+=back
+
+Modifies the object in-place (sets C<entombed>, C<notice>, and
+C<vaultified_data>/C<vaultified_file> internal fields during processing).
+
+B<Returns:> A two-element list C<($data, $file)> where C<$data> is the
+parsed manifest data structure and C<$file> is the path to the written YAML
+file on disk.
+
+=head2 _generate_file_name
+
+  my $path = $manifest->_generate_file_name();
+
+Returns the current manifest file path. Overrides the parent class method to
+return C<$self-E<gt>{transient_filename}> when a transient file name has been
+installed via C<_set_file_name>. Falls back to the parent class implementation
+when no transient name is set.
+
+B<Returns:> The transient file path string if one is set; otherwise the path
+generated by C<< SUPER::_generate_file_name() >>.
+
+=head2 _set_file_name
+
+  $manifest->_set_file_name($filename);
+  $manifest->_set_file_name(undef);
+
+Sets or clears the transient file name used by C<_generate_file_name> during
+intermediate merge phases. When C<$filename> is a defined, true value it is
+stored as C<$self-E<gt>{transient_filename}>. When C<$filename> is false or
+C<undef>, the C<transient_filename> key is deleted from the object.
+
+Modifies the object in-place.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$filename> - A file path string to install as the transient file
+name, or C<undef> (or any false value) to clear the transient name.
+
+=back
+
+B<Returns:> No meaningful return value.
+
+B<Examples:>
+
+  $manifest->_set_file_name('/tmp/transient.yml');
+  # Returns: no meaningful value; sets transient_filename on the object
+
+  $manifest->_set_file_name(undef);
+  # Returns: no meaningful value; clears transient_filename from the object
+
+=head1 SEE ALSO
+
+L<Genesis::Env::Manifest>,
+L<Genesis::Env::Manifest::_entombment_mixin>,
+L<Genesis::Env::Manifest::_vaultify_mixin>,
+L<Genesis::Env::Manifest::Vaultified>,
+L<Genesis::Env::Manifest::Entombed>
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Manifest/VaultifiedRedacted.pod
+++ b/lib/Genesis/Env/Manifest/VaultifiedRedacted.pod
@@ -1,0 +1,157 @@
+=head1 NAME
+
+Genesis::Env::Manifest::VaultifiedRedacted - Redacted view of a vaultified BOSH manifest
+
+=head1 SYNOPSIS
+
+  use Genesis::Env::Manifest::VaultifiedRedacted;
+
+  # Typically obtained via the manifest builder, not instantiated directly:
+  my $manifest = $builder->vaultified_redacted;
+
+  # Access the merged YAML data (Vault secrets replaced with REDACTED):
+  my $data = $manifest->data;
+
+  # Get the path to the manifest file on disk:
+  my $file = $manifest->file;
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::Manifest::VaultifiedRedacted> is a subclass of
+C<Genesis::Env::Manifest> that produces a fully merged BOSH manifest for
+Vault-based kits, with all secret values replaced by a redacted placeholder.
+This makes the manifest safe to display, log, or share without exposing
+credential values.
+
+The class combines the vaultification step (converting Credhub C<((var))>
+references to Spruce Vault operators) with redaction (setting C<REDACT=yes>
+during the final Spruce merge so that secrets are masked rather than
+resolved). The result is a manifest that shows the full structure of a
+vaultified deployment without revealing any secret values.
+
+This class overrides C<description>, C<redacted>, C<merge_environment>,
+C<merge_options>, and C<_merge> from C<Genesis::Env::Manifest>.
+
+Vaultification behavior is provided by
+L<Genesis::Env::Manifest::_vaultify_mixin>, which is included into this
+class at load time and supplies C<vaultify>, C<get_vault_paths>,
+C<vaultify_merge_environment>, C<vaultify_merge_options>,
+C<pre_merged_vaultified_file>, C<merge_vaultified_manifest>, and
+C<_get_decoupled_data>.
+
+=head1 METHODS
+
+=head2 description
+
+  my $label = $manifest->description;
+
+Returns a human-readable string describing this manifest type:
+C<"Redacted manifest for an environment that has been vaultified, with secrets redacted for safe viewing">.
+
+  # Example
+  my $manifest = $builder->vaultified_redacted;
+  print $manifest->description;
+  # prints 'Redacted manifest for an environment that has been vaultified, with secrets redacted for safe viewing'
+
+=head2 redacted
+
+  my $redacted = $manifest->redacted;
+
+Returns the manifest object itself. This override of the parent abstract
+method signals that this manifest type is already a redacted view, so it
+is its own redacted form.
+
+B<Returns:> The invocant (C<$self>).
+
+  # Example
+  my $manifest = $builder->vaultified_redacted;
+  my $redacted = $manifest->redacted;
+  print ref($redacted);  # prints 'Genesis::Env::Manifest::VaultifiedRedacted'
+
+=head2 merge_environment
+
+  my $env = $manifest->merge_environment;
+
+Returns a hash reference of environment variables to pass to the Spruce
+merge process. This hash includes:
+
+=over 4
+
+=item * All variables from the builder's full merge environment (via C<builder->full_merge_env>)
+
+=item * All variables from the Vault client environment (via C<env->vault->env>)
+
+=item * C<REDACT =E<gt> "yes">, which instructs Spruce to replace secret values with a redacted placeholder
+
+=back
+
+B<Returns:> A hash reference of environment variable name/value pairs.
+
+  # Example
+  my $env = $manifest->merge_environment;
+  print $env->{REDACT};  # prints 'yes'
+
+=head2 merge_options
+
+  my $opts = $manifest->merge_options;
+
+Returns the merge options hash reference controlling the Spruce merge
+behavior for this manifest type. The returned options always specify:
+
+=over 4
+
+=item * C<eval =E<gt> 'full'> -- full operator evaluation
+
+=item * C<multidoc =E<gt> 0> -- single-document YAML output
+
+=item * C<gopatch =E<gt> 0> -- Go-patch processing disabled
+
+=back
+
+B<Returns:> A hash reference of merge option keys to values.
+
+  # Example
+  my $opts = $manifest->merge_options;
+  print $opts->{eval};  # prints 'full'
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _merge
+
+  my ($data, $file) = $manifest->_merge;
+
+Performs the two-phase build for this manifest type. First, vaultifies the
+builder's unredacted data (converting Credhub C<((var))> references to Vault
+operators) and writes the result to a transient temporary file. If
+vaultification succeeds (i.e., a C<variables> block was present), delegates
+to C<< $self->builder->merge >> using the transient file, the merge options
+from C<merge_options>, and the merge environment from C<merge_environment>
+(which sets C<REDACT=yes>). The transient file is deleted after the merge.
+
+If vaultification produces no changes (no C<variables> block), falls back to
+returning the data and file from the builder's existing redacted manifest
+(C<< $self->builder->redacted >>).
+
+B<Returns:> A two-element list: C<$data> (the merged YAML data structure)
+and C<$file> (the path to the manifest file on disk). Either may be C<undef>
+if the merge did not produce that output.
+
+=head1 SEE ALSO
+
+L<Genesis::Env::Manifest>,
+L<Genesis::Env::Manifest::_vaultify_mixin>,
+L<Genesis::Env::Manifest::Vaultified>,
+L<Genesis::Env::Manifest::VaultifiedEntombed>
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Manifest/_entombment_mixin.pod
+++ b/lib/Genesis/Env/Manifest/_entombment_mixin.pod
@@ -198,14 +198,15 @@ immediately to L<"_entomb_secret_for_vault"> using all passed arguments.
 Otherwise it performs the same SHA-based naming and Credhub write logic as
 C<_entomb_secret_for_vault> using the parameters listed below.
 
-B<Note: This method contains a known defect (FWT-736).> The implementation
+B<WARNING:> This method contains a known defect (FWT-736). The implementation
 references the variable C<$cred_path> in the SHA computation and credential
 name construction (lines 160-161), but the parameter actually received is
 named C<$path>. Because C<$cred_path> is not declared in this scope it
 evaluates to C<undef>, producing an incorrect credential name and SHA digest.
 Additionally, the return variable C<$color> is assigned without C<my>,
 creating an implicit package global. These issues do not affect calls that
-are redirected to C<_entomb_secret_for_vault> via the arity guard.
+are redirected to C<_entomb_secret_for_vault> via the arity guard. Callers
+should use C<_entomb_secret_for_vault> instead until FWT-736 is resolved.
 
 B<Parameters:>
 

--- a/lib/Genesis/Env/Manifest/_entombment_mixin.pod
+++ b/lib/Genesis/Env/Manifest/_entombment_mixin.pod
@@ -1,0 +1,241 @@
+=head1 NAME
+
+Genesis::Env::Manifest::_entombment_mixin - Mixin providing Credhub entombment of Vault secrets for manifest classes
+
+=head1 DESCRIPTION
+
+This is a mixin module. It has no C<package> declaration and is included into
+consuming classes via C<require>. The methods it defines become available in
+the consuming class's namespace after inclusion.
+
+This mixin extends manifest classes with the ability to I<entomb> secrets: it
+reads every Vault path that a rendered manifest references, copies each
+key-value pair into a Credhub instance as a value-type credential, and
+rewrites the consuming object's local Vault to hold Credhub variable
+references (C<((path--key--sha))>) in place of the original secret values.
+The result is a manifest that resolves secrets from Credhub at deploy time
+rather than embedding them directly from Vault.
+
+The entombment process is idempotent within a single object lifetime: once
+C<_entomb_secrets> has run successfully it sets an C<entombed> flag on the
+consuming object and returns immediately on any subsequent call.
+
+=head1 USAGE
+
+Include this mixin in your manifest class before calling any of its methods:
+
+    # Typical inclusion pattern inside a consuming manifest class:
+    use parent qw/Genesis::Env::Manifest/;
+    require File::Basename;
+    do((File::Basename::dirname(__FILE__) =~ s#^lib/##r) . "/_entombment_mixin.pm");
+
+After the C<do>, all methods defined in this file become available as
+methods on the consuming class.
+
+=head1 METHODS
+
+=head2 local_vault
+
+    my $vault = $obj->local_vault;
+
+Creates and returns a new C<Service::Vault::Local> instance scoped to the
+current environment's name. The local vault is used as an in-memory store to
+hold Credhub variable references during the entombment process.
+
+B<Parameters:> None beyond the implicit invocant.
+
+B<Returns:> A C<Service::Vault::Local> object created via
+C<< Service::Vault::Local->create($env_name) >>.
+
+B<Examples:>
+
+    my $local_vault = $manifest->local_vault;
+    # Returns: a Service::Vault::Local instance for the current environment
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _entomb_secrets
+
+    $obj->_entomb_secrets($data);
+
+Orchestrates the full entombment workflow for the consuming manifest object.
+Determines every Vault path referenced by the rendered manifest, retrieves
+the corresponding secret values from the environment's Vault, writes each
+value into Credhub as a value-type credential under the prefix
+C<genesis-entombed/>, and stores the resulting Credhub variable reference
+back into the local in-memory Vault. Progress is printed to STDERR as each
+secret is processed.
+
+The method is guarded by an C<entombed> flag on the consuming object: if
+C<_entomb_secrets> has already completed successfully for this object it
+returns C<1> immediately without repeating any work.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$data> - Accepted but unused in the current implementation. Present
+for forward-compatibility.
+
+=back
+
+B<Returns:> C<1> if secrets were entombed (or entombment had already been
+performed), C<0> if the manifest references no Vault paths and there was
+nothing to entomb.
+
+B<Errors:>
+
+Calls C<bail> with the message C<"Failed to entomb one or more secrets into
+Credhub.  This may be due to a bug in Genesis, communication or
+authentication error with Credhub, or a value that Credhub can't
+support.\n\nPlease try again without the --entomb option if used, or if
+deploying, use the --no-entomb option, if this persists.\n\nPlease contact
+the Genesis team, or open a issue on #Bu{%s/issues/new}"> (where C<%s> is
+C<$Genesis::GITHUB>) if any individual secret fails to round-trip through
+Credhub correctly.
+
+B<Examples:>
+
+    # Entomb all manifest secrets; returns 1 when vault paths are found.
+    my $entombed = $manifest->_entomb_secrets(undef);
+    # Returns: 1 if secrets were copied to Credhub, 0 if no vault paths found
+
+=head2 _setup_local_vault
+
+    my $local_vault = $obj->_setup_local_vault;
+
+Creates the local in-memory Vault by delegating to L<"local_vault">, printing
+a progress message to STDERR before and after. This is a thin wrapper that
+separates the I/O notification from the construction logic.
+
+B<Parameters:> None beyond the implicit invocant.
+
+B<Returns:> A C<Service::Vault::Local> instance as returned by
+C<< $obj->local_vault >>.
+
+=head2 _entomb_secret_for_vault
+
+    my ($credhub_var, $secret_sha, $action, $action_color, $existing) =
+        $obj->_entomb_secret_for_vault(
+            $local_vault, $vault_path, $key, $value,
+            $credhub, $cred_path, $entombment_prefix
+        );
+    # Returns: ('((genesis-entombed/_myenv--password--a3f1c2b4))',
+    #           'a3f1c2b4', 'new', 'gi', undef)
+
+Entombs a single Vault key-value pair into Credhub and records the resulting
+Credhub variable reference in the local Vault. The credential name is derived
+from C<$entombment_prefix>, C<$cred_path>, C<$key>, and the first eight
+hexadecimal characters of the SHA-1 digest of C<"$cred_path--$key--$value">.
+
+If the credential already exists in Credhub with the same value the method
+skips the write and reports the action as C<"exists">. If the value differs
+it overwrites the credential and reports C<"altered">. If the value is new it
+reports C<"new">. If Credhub does not return the expected value after a write
+the action is C<"failed">.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$local_vault> - A C<Service::Vault::Local> instance. If defined,
+the Credhub variable reference is written back to this vault under
+C<$vault_path> / C<$key>. May be C<undef> to skip the local-vault write.
+
+=item * C<$vault_path> - The Vault path (e.g. C</secret/dev/myenv/cf/uaa>)
+from which the secret originates. Used as the target path in the local Vault.
+
+=item * C<$key> - The key within C<$vault_path> (e.g. C<password>).
+
+=item * C<$value> - The plaintext secret value to store in Credhub.
+
+=item * C<$credhub> - A connected C<Service::Credhub> instance used for
+C<get> and C<set> operations.
+
+=item * C<$cred_path> - The environment-relative credential path segment
+used to construct the Credhub credential name.
+
+=item * C<$entombment_prefix> - Optional string prepended to the Credhub
+credential name. Defaults to C<"genesis-entombed/">.
+
+=back
+
+B<Returns:> A five-element list:
+
+=over 4
+
+=item * C<$credhub_var> - The Credhub CredHub variable reference string in
+the form C<((credential-name))>.
+
+=item * C<$secret_sha> - An eight-character hex string (first 8 chars of the
+SHA-1 of C<"$cred_path--$key--$value">) used as a uniqueness suffix.
+
+=item * C<$action> - One of C<"new">, C<"exists">, C<"altered">, or
+C<"failed">, describing the outcome of the Credhub write.
+
+=item * C<$action_color> - A Genesis terminal color code corresponding to
+C<$action>: C<"gi"> (new), C<"yi"> (exists), C<"ri"> (altered), or
+C<"Yr"> (failed).
+
+=item * C<$existing> - The value previously stored in Credhub under this
+credential name, or C<undef> if no prior value existed.
+
+=back
+
+=head2 _entomb_secret
+
+    my ($credhub_var, $secret_sha, $action, $color, $existing) =
+        $obj->_entomb_secret($credhub, $path, $key, $value, $prefix);
+    # Returns: ('((genesis-entombed/path--key--deadbeef))',
+    #           'deadbeef', 'new', 'gi', undef)
+
+Single-secret entombment method retained for backwards compatibility. When
+called with more than six arguments (counting C<$self>) it delegates
+immediately to L<"_entomb_secret_for_vault"> using all passed arguments.
+Otherwise it performs the same SHA-based naming and Credhub write logic as
+C<_entomb_secret_for_vault> using the parameters listed below.
+
+B<Note: This method contains a known defect (FWT-736).> The implementation
+references the variable C<$cred_path> in the SHA computation and credential
+name construction (lines 160-161), but the parameter actually received is
+named C<$path>. Because C<$cred_path> is not declared in this scope it
+evaluates to C<undef>, producing an incorrect credential name and SHA digest.
+Additionally, the return variable C<$color> is assigned without C<my>,
+creating an implicit package global. These issues do not affect calls that
+are redirected to C<_entomb_secret_for_vault> via the arity guard.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$credhub> - A connected C<Service::Credhub> instance.
+
+=item * C<$path> - The credential path segment. B<Note:> due to FWT-736 this
+parameter is not used in the implementation body; C<$cred_path> (undef) is
+used instead.
+
+=item * C<$key> - The key name within the credential path.
+
+=item * C<$value> - The plaintext secret value to store.
+
+=item * C<$prefix> - Optional prefix string for the Credhub credential name.
+Defaults to C<"genesis-entombed/">.
+
+=back
+
+B<Returns:> A five-element list identical in structure to the return of
+L<"_entomb_secret_for_vault">: C<($credhub_var, $secret_sha, $action,
+$color, $existing)>.
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Manifest/_entombment_mixin.pod
+++ b/lib/Genesis/Env/Manifest/_entombment_mixin.pod
@@ -5,7 +5,7 @@ Genesis::Env::Manifest::_entombment_mixin - Mixin providing Credhub entombment o
 =head1 DESCRIPTION
 
 This is a mixin module. It has no C<package> declaration and is included into
-consuming classes via C<require>. The methods it defines become available in
+consuming classes via C<do>. The methods it defines become available in
 the consuming class's namespace after inclusion.
 
 This mixin extends manifest classes with the ability to I<entomb> secrets: it

--- a/lib/Genesis/Env/Manifest/_vaultify_mixin.pod
+++ b/lib/Genesis/Env/Manifest/_vaultify_mixin.pod
@@ -1,0 +1,358 @@
+=head1 NAME
+
+Genesis::Env::Manifest::_vaultify_mixin - Mixin providing Credhub-to-Vault operator conversion for vaultified manifest classes
+
+=head1 DESCRIPTION
+
+This is a mixin module. It has no C<package> declaration and is included into
+consuming classes via C<do>. The methods it defines become part of the
+consuming class's namespace after inclusion.
+
+This mixin is the core of the I<vaultification> process: it rewrites a BOSH
+manifest's C<variables>-block Credhub references (C<((var))> syntax) into
+Spruce Vault operator calls so that Genesis Vault-based secrets can be
+resolved during manifest rendering. The converted manifest is cached in the
+consuming object for reuse by subsequent merge operations.
+
+Three manifest classes include this mixin:
+
+=over 4
+
+=item * C<Genesis::Env::Manifest::Vaultified> -- the primary deployable
+manifest for Vault-based kits: vaultifies the unredacted data and merges
+back through Spruce for secret interpolation.
+
+=item * C<Genesis::Env::Manifest::VaultifiedRedacted> -- the redacted view of
+a vaultified manifest: same vaultification step, but the final merge uses
+C<REDACT=yes> so secrets appear masked.
+
+=item * C<Genesis::Env::Manifest::VaultifiedEntombed> -- for kits that
+entomb secrets into BOSH Credhub: vaultification is used both to discover
+which Vault paths appear in the manifest (via C<get_vault_paths>) and to
+prepare the final merged output after entombment.
+
+=back
+
+=head1 USAGE
+
+Include this mixin in a manifest class with C<do>, using an absolute path
+derived from the consuming file's own location:
+
+    # Path-relative inclusion (used by all three consuming classes):
+    use File::Basename;
+    my $base_path = dirname(__FILE__) =~ s#^lib/##r;
+    do "$base_path/_vaultify_mixin.pm";
+
+    # Or inline (as used by Vaultified.pm):
+    do((File::Basename::dirname(__FILE__) =~ s#^lib/##r) . "/_vaultify_mixin.pm");
+
+After the C<do>, all methods defined by this mixin are available as methods
+on the consuming class.
+
+=head1 METHODS
+
+=head2 get_vault_paths
+
+    my $paths = $obj->get_vault_paths(%opts);
+
+Returns a merged hash of all Vault secret paths referenced by the manifest.
+This method overrides the parent class's C<get_vault_paths> to include
+paths that only become visible after vaultification (i.e., Credhub variable
+references that map to Vault secrets).
+
+The override calls the parent class C<get_vault_paths> first to obtain the
+baseline set of paths, then determines the vaultified form of the manifest
+data using the following priority:
+
+=over 4
+
+=item 1. Uses C<$self-E<gt>{vaultified_file}> if a vaultified file already
+exists from a prior call.
+
+=item 2. Uses C<$self-E<gt>{vaultified_data}> if in-memory vaultified data
+already exists from a prior call.
+
+=item 3. Otherwise, calls L<vaultify> on a shallow copy of the builder's
+partial manifest data. If vaultification succeeds, uses the resulting data to
+discover additional paths.
+
+=back
+
+If no vaultification path arguments can be constructed (vaultification
+produced nothing), returns the baseline C<SUPER> result unchanged.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<%opts> - Options passed through to the parent class's
+C<get_vault_paths> method. Recognised options include C<notify>.
+
+=back
+
+B<Returns:> A hashref whose keys are C<"path:key"> strings identifying every
+Vault secret referenced by the manifest, combining the parent class's paths
+with any additional paths discovered through vaultification. Returns only the
+parent result if no vaultified data can be produced.
+
+B<Examples:>
+
+    my $paths = $manifest->get_vault_paths(notify => 0);
+    # Returns: { 'secret/env/deployment:value' => 1, ... }
+
+=head2 vaultify
+
+    my $changed = $obj->vaultify($data, $file);
+
+Rewrites a manifest data structure in place, replacing Credhub
+C<((variable))> references with equivalent Spruce Vault operator calls.
+The C<variables> block is consumed from C<$data> during processing.
+
+For each value in the flattened manifest that matches the C<((var))> pattern,
+the method looks up the corresponding secret in the environment's secrets plan
+(via C<$self-E<gt>env-E<gt>secrets_plan-E<gt>secrets>). Variables that
+originated from the BOSH manifest (C<from_manifest> secrets) are eligible for
+replacement.
+
+Two cases are handled:
+
+=over 4
+
+=item B<Single variable reference> -- a value that is entirely one
+C<((variable))> reference. The variable is resolved to a Vault operator
+(e.g., C<(( vault "secret/env:key" ))>) and the manifest value is replaced
+directly.
+
+=item B<Compound / embedded reference> -- a value that interpolates one or
+more C<((variable))> references inside a larger string. Each recognisable
+variable is replaced with a Spruce C<concat> operator that assembles the
+final string at render time. Literal newline substrings are extracted into
+C<meta> keys to avoid YAML quoting problems.
+
+=back
+
+Variables in the C<bosh-variables> block and paths beginning with
+C<genesis-entombed/> are left unchanged (they are managed by BOSH or by
+the entombment process respectively). Unrecognised variables produce a
+warning and are left as-is.
+
+After processing, the converted data structure is stored in
+C<$self-E<gt>{vaultified_data}> and, if C<$file> was given, written to disk
+via C<save_to_yaml_file>.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$data> - A hashref containing the manifest data to transform.
+Modified in place: the C<variables> key is deleted and affected leaf values
+are replaced with Vault operator strings or Spruce C<concat> expressions.
+
+=item * C<$file> - Optional. A file path. When provided, the vaultified data
+structure is written to this YAML file in addition to being stored in
+C<$self-E<gt>{vaultified_file}>.
+
+=back
+
+B<Returns:> C<1> if the manifest contained a C<variables> block (vaultification
+was performed); C<0> if no C<variables> block was present and no changes
+were made.
+
+B<Errors:>
+
+=over 4
+
+=item * C<"Could not find vault lookup operator"> -- a secret was found in the
+secrets plan for a single C<((variable))> reference but the secret object
+could not produce a Vault operator expression. Raised via C<bail>.
+
+=item * C<"Cannot use a compound credhub reference inside a string in %s"> --
+a Credhub variable that maps to a compound Vault object (rather than a
+scalar) appears inside an interpolated string expression. The placeholder
+C<%s> is replaced with the dotted manifest key path of the offending value.
+Raised via C<bail>.
+
+=back
+
+B<Examples:>
+
+    my $data = decode_yaml($manifest_yaml);
+
+    if ($manifest->vaultify($data)) {
+        # $data now has Vault operators in place of ((...)) references
+        # Returns: 1
+    } else {
+        # No variables block was present; $data is unchanged
+        # Returns: 0
+    }
+
+    # With file output:
+    my $tmpfile = $manifest->pre_merged_vaultified_file;
+    $manifest->vaultify($data, $tmpfile);
+    # Returns: 1 (if variables block existed), vaultified YAML written to $tmpfile
+
+=head2 vaultify_merge_environment
+
+    my $env = $obj->vaultify_merge_environment;
+
+Returns the environment variable hash used when running the Spruce merge
+during L<merge_vaultified_manifest>. The hash combines the builder's full
+merge environment with the current environment's Vault environment variables,
+and sets C<REDACT> to C<undef> (disabled) so that secret values are
+interpolated rather than redacted.
+
+Consuming classes may override this method to alter the merge environment
+(for example, C<VaultifiedRedacted> overrides the merge environment in its
+own C<_merge> to set C<REDACT=yes>).
+
+B<Returns:> A hashref of environment variable names to values suitable for
+passing to the Spruce merge process.
+
+B<Examples:>
+
+    my $env = $manifest->vaultify_merge_environment;
+    # Returns: { 'VAULT_ADDR' => '...', 'VAULT_TOKEN' => '...', REDACT => undef, ... }
+
+=head2 vaultify_merge_options
+
+    my $opts = $obj->vaultify_merge_options;
+
+Returns the option hash controlling the Spruce merge behaviour used during
+L<merge_vaultified_manifest>. The returned options always specify:
+
+=over 4
+
+=item * C<eval =E<gt> 'full'> -- full operator evaluation
+
+=item * C<multidoc =E<gt> 0> -- single-document YAML output
+
+=item * C<gopatch =E<gt> 0> -- Go-patch processing disabled
+
+=back
+
+B<Returns:> A hashref of merge option keys to values.
+
+B<Examples:>
+
+    my $opts = $manifest->vaultify_merge_options;
+    # Returns: { eval => 'full', multidoc => 0, gopatch => 0 }
+
+=head2 pre_merged_vaultified_file
+
+    my $path = $obj->pre_merged_vaultified_file;
+
+Returns the path to a temporary file used to hold the vaultified manifest
+data before it is passed to the Spruce merge step. The file is created in
+the environment's work directory on the first call and cached on the object
+for reuse on subsequent calls. The filename follows the pattern
+C<pre-merged-vaultified-manifest-XXXXXXXXXXXX.yml>.
+
+B<Returns:> The absolute path string of the temporary YAML file.
+
+B<Examples:>
+
+    my $tmpfile = $manifest->pre_merged_vaultified_file;
+    # Returns: '/path/to/env/workdir/pre-merged-vaultified-manifest-aB3xK9zQ1m.yml'
+
+=head2 merge_vaultified_manifest
+
+    my ($data, $file, $errors, $warnings) = $obj->merge_vaultified_manifest(%opts);
+
+Performs the Spruce merge that resolves Vault operators in the vaultified
+manifest. Merges the consuming object together with the file produced by
+L<pre_merged_vaultified_file>, using the merge options and environment
+returned by L<vaultify_merge_options> and L<vaultify_merge_environment>
+unless overridden via C<%opts>.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<merge_ops> - Optional hashref of merge options. Defaults to the
+result of C<$self-E<gt>vaultify_merge_options>.
+
+=item * C<merge_env> - Optional hashref of environment variables for the
+merge process. Defaults to the result of C<$self-E<gt>vaultify_merge_environment>.
+
+=back
+
+B<Returns:> A four-element list:
+
+=over 4
+
+=item * C<$data> - The merged manifest data as a Perl data structure.
+
+=item * C<$file> - The path to the file containing the merged output.
+
+=item * C<$errors> - An arrayref of error strings from the merge, or C<undef>.
+
+=item * C<$warnings> - An arrayref of warning strings from the merge, or C<undef>.
+
+=back
+
+B<Examples:>
+
+    my ($data, $file, $errors, $warnings) = $manifest->merge_vaultified_manifest;
+    # Returns: ($data_hashref, '/tmp/merged.yml', undef, undef)
+
+    # With a custom merge environment (as used by VaultifiedEntombed):
+    my ($data, $file, $errors, $warnings) = $manifest->merge_vaultified_manifest(
+        merge_env => {
+            %{$self->builder->full_merge_env},
+            %{$self->local_vault->env},
+            REDACT => undef,
+        }
+    );
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _get_decoupled_data
+
+    my $copy = $obj->_get_decoupled_data;
+    my $copy = $obj->_get_decoupled_data($source);
+
+Returns a deep copy of manifest data from the builder, serialised through
+JSON to break all object references. This ensures that in-place modifications
+during L<vaultify> do not affect the builder's cached data.
+
+B<Parameters:>
+
+=over 4
+
+=item * C<$source> - Optional string naming the builder method to call for
+the data source. Defaults to C<'unredacted'>. Must name a method on
+C<$self-E<gt>builder> that returns an object responding to C<data>.
+
+=back
+
+B<Returns:> A fully independent (deep-copied) Perl hashref of the manifest
+data.
+
+B<Examples:>
+
+    my $copy = $manifest->_get_decoupled_data;
+    # Returns: a deep copy of $manifest->builder->unredacted->data as a hashref
+
+    my $copy = $manifest->_get_decoupled_data('redacted');
+    # Returns: a deep copy of $manifest->builder->redacted->data as a hashref
+
+=head1 SEE ALSO
+
+L<Genesis::Env::Manifest>,
+L<Genesis::Env::Manifest::Vaultified>,
+L<Genesis::Env::Manifest::VaultifiedRedacted>,
+L<Genesis::Env::Manifest::VaultifiedEntombed>,
+L<Genesis::Env::Manifest::_entombment_mixin>
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/Manifest/_vaultify_mixin.pod
+++ b/lib/Genesis/Env/Manifest/_vaultify_mixin.pod
@@ -91,14 +91,16 @@ C<get_vault_paths> method. Recognised options include C<notify>.
 =back
 
 B<Returns:> A hashref whose keys are C<"path:key"> strings identifying every
-Vault secret referenced by the manifest, combining the parent class's paths
-with any additional paths discovered through vaultification. Returns only the
-parent result if no vaultified data can be produced.
+Vault secret referenced by the manifest, with values being arrayrefs of
+reference-location strings describing where each path is used. Combines the
+parent class's paths with any additional paths discovered through
+vaultification. Returns only the parent result if no vaultified data can be
+produced.
 
 B<Examples:>
 
     my $paths = $manifest->get_vault_paths(notify => 0);
-    # Returns: { 'secret/env/deployment:value' => 1, ... }
+    # Returns: { 'secret/env/deployment:value' => ['instance_groups.cell.jobs...'], ... }
 
 =head2 vaultify
 
@@ -256,7 +258,7 @@ B<Examples:>
 
 =head2 merge_vaultified_manifest
 
-    my ($data, $file, $errors, $warnings) = $obj->merge_vaultified_manifest(%opts);
+    my ($data, $file, $warnings, $errors) = $obj->merge_vaultified_manifest(%opts);
 
 Performs the Spruce merge that resolves Vault operators in the vaultified
 manifest. Merges the consuming object together with the file produced by
@@ -284,19 +286,19 @@ B<Returns:> A four-element list:
 
 =item * C<$file> - The path to the file containing the merged output.
 
-=item * C<$errors> - An arrayref of error strings from the merge, or C<undef>.
+=item * C<$warnings> - A string of warning messages from the merge, or C<undef>.
 
-=item * C<$warnings> - An arrayref of warning strings from the merge, or C<undef>.
+=item * C<$errors> - A string of error messages from the merge, or C<undef>.
 
 =back
 
 B<Examples:>
 
-    my ($data, $file, $errors, $warnings) = $manifest->merge_vaultified_manifest;
+    my ($data, $file, $warnings, $errors) = $manifest->merge_vaultified_manifest;
     # Returns: ($data_hashref, '/tmp/merged.yml', undef, undef)
 
     # With a custom merge environment (as used by VaultifiedEntombed):
-    my ($data, $file, $errors, $warnings) = $manifest->merge_vaultified_manifest(
+    my ($data, $file, $warnings, $errors) = $manifest->merge_vaultified_manifest(
         merge_env => {
             %{$self->builder->full_merge_env},
             %{$self->local_vault->env},

--- a/lib/Genesis/Env/ManifestProvider.pod
+++ b/lib/Genesis/Env/ManifestProvider.pod
@@ -1,0 +1,717 @@
+=encoding utf8
+
+=head1 NAME
+
+Genesis::Env::ManifestProvider - Manifest builder and cache coordinator for a Genesis environment
+
+=head1 SYNOPSIS
+
+  use Genesis::Env::ManifestProvider;
+
+  # Typically obtained via a Genesis::Env object, not constructed directly
+  my $provider = Genesis::Env::ManifestProvider->new($env);
+
+  # Access a typed manifest
+  my $manifest = $provider->unredacted();
+  my $data     = $manifest->data();
+
+  # Access the deployment manifest
+  my $deploy   = $provider->deployment();
+
+  # Access a manifest subset
+  my $pruned   = $provider->unredacted(subset => 'pruned');
+
+  # List known types and subsets
+  my %types   = $provider->known_types();
+  my %subsets = $provider->known_subsets();
+
+  # Find all vault secret paths referenced in the manifest
+  my $paths = $provider->vault_paths();
+
+  # Reset all cached manifests and work files
+  $provider->reset();
+
+=head1 DESCRIPTION
+
+C<Genesis::Env::ManifestProvider> is the central coordinator for building,
+caching, and accessing manifests for a Genesis deployment environment. It is
+owned by a C<Genesis::Env> instance and provides a uniform interface to every
+manifest variant the environment supports.
+
+At load time, the provider dynamically discovers all C<Genesis::Env::Manifest::*>
+subclasses present on disk and installs one accessor method per type. Each
+accessor returns a cached C<Genesis::Env::Manifest> object (or builds one on
+first access). Passing a C<subset> option to an accessor returns a narrowed
+view of that manifest type.
+
+The provider also manages the set of recognized subset names (C<credhub_vars>,
+C<bosh_vars>, C<pruned>, C<releases>) and the low-level merge operations
+(via C<spruce>) that all manifest subclasses delegate back to it.
+
+The following manifest type accessors are installed automatically at class
+load time:
+
+=over 4
+
+=item C<entombed>
+
+Manifest with secrets entombed into BOSH's Credhub from the
+single-source-of-truth Vault (default for regular kits). Deployable.
+
+=item C<partial>
+
+Partially evaluated manifest for debugging purposes -- will contain any
+unevaluatable spruce operators.
+
+=item C<partial_environment>
+
+Partially evaluated environment files only (no kit components) -- will
+contain any unevaluatable spruce operators.
+
+=item C<redacted>
+
+Full manifest with secrets redacted for safe viewing.
+
+=item C<unevaluated>
+
+Raw merged manifest template with no interpolation (merged, but spruce
+operators still in place).
+
+=item C<unevaluated_environment>
+
+Raw merged environment files only (no kit components) -- spruce operators
+still in place.
+
+=item C<unredacted>
+
+Complete deployment manifest with embedded clear-text secrets from Vault.
+Deployable.
+
+=item C<vaultified>
+
+Manifest with Credhub queries converted to Vault operator syntax and variable
+definitions converted to allow for Genesis secrets operations. Deployable.
+
+=item C<vaultified_entombed>
+
+Credhub secrets entombed into BOSH's Credhub from the single-source-of-truth
+Vault for a vaultified kit. Allows content-sensitive naming of Credhub
+secrets and use of Genesis secrets operations for their management (default
+for Credhub-based kits). Deployable.
+
+=item C<vaultified_redacted>
+
+Redacted manifest for an environment that has been vaultified, with secrets
+redacted for safe viewing.
+
+=back
+
+All type accessors share the same calling convention:
+
+  my $manifest = $provider->$type();
+  my $manifest = $provider->$type(subset => $subset_name);
+  my $manifest = $provider->$type(notify => 1);
+  my $manifest = $provider->$type(notification => $notice);
+
+The C<subset> option names a known subset (see L</known_subsets>). The
+C<notify> and C<notification> options trigger a notification on the manifest
+before it is returned. Results are cached in the provider keyed by type and
+subset name.
+
+=head1 METHODS
+
+=head2 new
+
+  my $provider = Genesis::Env::ManifestProvider->new($env);
+
+Constructs a new, empty provider bound to the given C<$env> object. No
+manifests are built at construction time; they are created lazily on first
+access.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env>
+
+A C<Genesis::Env> instance that owns this provider.
+
+=back
+
+B<Returns:> A new C<Genesis::Env::ManifestProvider> object.
+
+B<Examples:>
+
+  my $provider = Genesis::Env::ManifestProvider->new($env);
+  # Returns: a Genesis::Env::ManifestProvider object
+
+=head2 known_types
+
+  my %types = $provider->known_types();
+
+Returns a hash mapping each known manifest type name to its human-readable
+description. Types that are irrelevant for the current environment are
+excluded automatically:
+
+=over 4
+
+=item *
+
+Types matching C<entombed> are excluded when the environment uses
+C<create-env> mode.
+
+=item *
+
+Types matching C<vaultif> are excluded when the environment's kit does not
+use Credhub.
+
+=back
+
+B<Returns:> A flat list suitable for assignment to a hash, where keys are
+type name strings (e.g., C<"unredacted">) and values are description strings.
+
+B<Examples:>
+
+  my %types = $provider->known_types();
+  for my $type (sort keys %types) {
+      printf "%s: %s\n", $type, $types{$type};
+  }
+  # prints each available type and its description
+
+=head2 known_subsets
+
+  my %subsets = $provider->known_subsets();
+
+Returns a hash mapping each known subset name to its human-readable
+description. The built-in subsets are:
+
+=over 4
+
+=item C<credhub_vars>
+
+The list of variable and Credhub lookups used in the manifest.
+
+=item C<bosh_vars>
+
+BOSH variables in a format suitable for the C<bosh deploy> C<--vars-file>
+(C<-l>) option.
+
+=item C<pruned>
+
+Manifest with Genesis-specific keys pruned -- suitable for use with
+C<bosh deploy>.
+
+=item C<releases>
+
+YAML file containing the array of BOSH releases used in the deployment.
+
+=back
+
+B<Returns:> A flat list suitable for assignment to a hash, where keys are
+subset name strings and values are description strings.
+
+B<Examples:>
+
+  my %subsets = $provider->known_subsets();
+  print join(', ', sort keys %subsets);
+  # prints: bosh_vars, credhub_vars, pruned, releases
+
+=head2 env
+
+  my $env = $provider->env($type);
+
+C<env> returns the C<Genesis::Env> object that owns this provider (the
+C<$type> argument is not used by C<env> itself; it is the parameter for the
+companion C<set_deployment> method documented below).
+
+C<set_deployment($type)> sets the default deployment manifest type.
+Subsequent calls to C<deployment> will return a manifest of this type.
+C<$type> must be a known deployable manifest type name (e.g.,
+C<"entombed">, C<"unredacted">); otherwise the method aborts with an
+internal error.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$type>
+
+A manifest type name string passed to C<set_deployment>. The type must exist
+and must be flagged as deployable.
+
+=back
+
+B<Returns:> C<env> returns a C<Genesis::Env> object. C<set_deployment>
+returns the provider object itself, for method chaining.
+
+B<Errors:>
+
+Dies with C<"Manifest type $type is not deployable"> if C<$type> is not a
+known manifest type or is not marked as deployable. C<$type> in the message
+is the literal name string that was passed.
+
+B<Examples:>
+
+  my $env = $provider->env();
+  # Returns: the Genesis::Env object bound to this provider
+
+  $provider->set_deployment('entombed');
+  my $manifest = $provider->deployment();
+  # Returns: a Genesis::Env::Manifest::Entombed object
+
+=head2 deployment
+
+  my $manifest = $provider->deployment();
+
+Returns the manifest object for the current default deployment type. If no
+default has been set via C<set_deployment>, the type is determined by calling
+C<< $env->deployment_manifest_type >>. Any additional arguments are forwarded
+to the type accessor.
+
+B<Returns:> A C<Genesis::Env::Manifest> subclass object for the deployment
+manifest type.
+
+B<Examples:>
+
+  my $manifest = $provider->deployment();
+  # Returns: a Genesis::Env::Manifest object of the deployment type
+
+=head2 base_manifest
+
+  my $manifest = $provider->base_manifest(@args);
+
+Returns the manifest most suitable for looking up data -- the non-entombed,
+non-redacted view. Selects C<vaultified> when the environment has been
+vaultified; otherwise selects C<unredacted>. Any additional arguments are
+forwarded to the selected type accessor.
+
+B<Returns:> A C<Genesis::Env::Manifest::Vaultified> or
+C<Genesis::Env::Manifest::Unredacted> object, depending on the environment's
+vaultification state. The type decision is memoized after the first call.
+
+B<Examples:>
+
+  my $manifest = $provider->base_manifest();
+  # Returns: vaultified or unredacted manifest depending on env state
+
+=head2 reset
+
+  $provider->reset();
+
+Resets all cached manifest objects and work files for this provider. Each
+cached manifest object has its own reset called before being discarded.
+All memoized provider-level values (keys beginning with C<__>) are cleared,
+the deployment type is set back to undef, and all C<manifest-E<lt>nameE<gt>-*>
+work files in the environment work directory are deleted.
+
+B<Returns:> The provider object itself, for method chaining.
+
+B<Examples:>
+
+  $provider->reset();
+  my $fresh = $provider->unredacted();
+  # Returns: a freshly built manifest, ignoring any prior cache
+
+=head2 merge
+
+  my ($data, $file, $warnings, $errors) = $provider->merge($manifest, $sources, $options, $env_vars);
+
+Merges a set of YAML source files using C<spruce merge> and saves the result
+to the manifest's work file. This is the low-level build operation used by
+all C<Genesis::Env::Manifest> subclasses; it is not normally called
+directly by application code.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$manifest>
+
+A C<Genesis::Env::Manifest> object for which the merge is being performed.
+Used to determine the output file name, type label, and whether to emit a
+build notification.
+
+=item C<$sources>
+
+An array reference of absolute file paths to merge in order.
+
+=item C<$options>
+
+A hash reference of merge options. The C<eval> key controls spruce evaluation
+mode: C<"full"> (default) for full evaluation, C<"no"> to pass
+C<--skip-eval>, or C<"adaptive"> to defer unresolvable operators rather than
+failing. The C<multidoc> key (default 1) passes C<--multi-doc> to spruce
+when true. The C<gopatch> key (default 1) passes C<--go-patch> to spruce
+when true.
+
+=item C<$env_vars>
+
+An optional hash reference of environment variables to set when invoking
+spruce. Defaults to an empty hash.
+
+=back
+
+B<Returns:> A four-element list C<($data, $file, $warnings, $errors)> where
+C<$data> is a hash reference of the parsed merged YAML (or C<undef> on error),
+C<$file> is the absolute path to the saved manifest file (or C<undef> on
+error), C<$warnings> is a string of warnings from spruce in adaptive mode
+(or C<undef>), and C<$errors> is a string of error output if the merge failed
+(or C<undef> on success).
+
+B<Examples:>
+
+  my ($data, $file, $warnings, $errors) = $provider->merge(
+      $manifest,
+      [$init_file, @kit_files, @env_files, $cap_file],
+      {eval => 'full', multidoc => 1, gopatch => 1},
+      {GENESIS_ENV => 'prod'}
+  );
+  # Returns: ($data_hashref, '/path/to/manifest.yml', undef, undef)
+
+=head2 get_subset
+
+  my ($data, $file) = $provider->get_subset($manifest, $subset, $req);
+
+Derives a subset manifest from its parent manifest type using include,
+exclude, or fetch operations defined in the subset plan. Used internally by
+manifest subclasses; not normally called by application code.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$manifest>
+
+The C<Genesis::Env::Manifest> subset object being built. Its type determines
+the parent manifest to derive from.
+
+=item C<$subset>
+
+The subset name (e.g., C<"pruned">, C<"releases">). Must match a key in the
+subset plans.
+
+=item C<$req>
+
+Either C<"data"> to return the subset as a Perl data structure, or any other
+value to write the subset to a file and return its path.
+
+=back
+
+B<Returns:> A two-element list C<($data, $file)>. When C<$req> is C<"data">,
+C<$data> is a hash (or scalar) and C<$file> is C<undef>. Otherwise, C<$data>
+is C<undef> and C<$file> is the path to the written subset file.
+
+B<Errors:>
+
+Dies with C<"Unknown subset '%s' requested for manifest %s"> if C<$subset>
+does not match any known subset plan. C<%s> is the subset name and C<%s> is
+the manifest type.
+
+Dies with C<"Invalid subset '%s' requested for manifest %s: valid operators are %s">
+if the subset plan exists but contains none of the recognized operators
+(C<include>, C<exclude>, C<fetch>).
+
+Dies with C<"Too many selections specified for subset '%s' in manifest %s">
+if the subset plan specifies more than one operator.
+
+Dies with C<"Could not get subset %s from %s manifest: %s"> if the
+file-mode subset extraction command fails. The placeholders are the subset
+name, the source manifest type, and the error output.
+
+B<Examples:>
+
+  my ($data, undef) = $provider->get_subset($manifest, 'releases', 'data');
+  # Returns: (hashref containing 'releases' key, undef)
+
+  my (undef, $file) = $provider->get_subset($manifest, 'pruned', 'file');
+  # Returns: (undef, '/path/to/pruned-manifest-file.yml')
+
+=head2 initiation_file
+
+  my $path = $provider->initiation_file();
+
+Returns the path to the initiation YAML file used as the first source in a
+manifest merge. The result is memoized after the first call.
+
+B<Returns:> An absolute file path string.
+
+B<Examples:>
+
+  my $path = $provider->initiation_file();
+  # Returns: '/path/to/env/.genesis/manifests/initiation.yml'
+
+=head2 kit_files
+
+  my @paths = $provider->kit_files();
+
+Returns the list of absolute file paths contributed by the kit's blueprint for
+this environment. Results are memoized. On first call, emits a pending
+notification while the kit is queried.
+
+B<Returns:> A list of absolute file path strings.
+
+B<Examples:>
+
+  my @files = $provider->kit_files();
+  # Returns: ('/path/to/kit/base.yml', '/path/to/kit/addons/db.yml', ...)
+
+=head2 cloud_config_files
+
+  my @paths = $provider->cloud_config_files(%options);
+
+Returns the list of cloud config YAML files needed for the manifest build.
+Results are memoized separately for the required and optional cases.
+
+B<Parameters:>
+
+=over 4
+
+=item C<optional>
+
+Boolean. When true, optional cloud config files are included; when false or
+absent, only required files are returned.
+
+=back
+
+B<Returns:> A list of absolute file path strings.
+
+B<Examples:>
+
+  my @files = $provider->cloud_config_files();
+  # Returns: required cloud config file paths
+
+  my @all = $provider->cloud_config_files(optional => 1);
+  # Returns: required and optional cloud config file paths
+
+=head2 environment_files
+
+  my @paths = $provider->environment_files();
+
+Returns the list of local environment YAML files used in the manifest build.
+Results are memoized after the first call.
+
+B<Returns:> A list of absolute file path strings.
+
+B<Examples:>
+
+  my @files = $provider->environment_files();
+  # Returns: ('/path/to/env/us-east-1-prod.yml', ...)
+
+=head2 conclusion_file
+
+  my $path = $provider->conclusion_file();
+
+Returns the path to the conclusion (cap) YAML file appended as the final
+source in a manifest merge. The result is memoized after the first call.
+
+B<Returns:> An absolute file path string.
+
+B<Examples:>
+
+  my $path = $provider->conclusion_file();
+  # Returns: '/path/to/env/.genesis/manifests/conclusion.yml'
+
+=head2 full_merge_env
+
+  my $env_vars = $provider->full_merge_env();
+
+Returns a hash reference of all environment variables required when running a
+full manifest merge. Variables are retrieved from the associated
+C<Genesis::Env> object using the C<manifest> context. The result is memoized
+after the first call.
+
+B<Returns:> A hash reference of environment variable name-to-value pairs.
+
+B<Examples:>
+
+  my $vars = $provider->full_merge_env();
+  # Returns: { GENESIS_ENV => 'prod', BOSH_ENVIRONMENT => 'bosh', ... }
+
+=head2 valid_subset
+
+  my $bool = $provider->valid_subset($subset);
+
+Returns true if C<$subset> is a known subset name, false (C<undef>) if
+C<$subset> is C<undef>, and aborts with an internal error if C<$subset> is a
+defined but unrecognized name.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$subset>
+
+The subset name to validate, or C<undef>.
+
+=back
+
+B<Returns:> C<1> if the subset is valid, C<undef> if C<$subset> is C<undef>.
+
+B<Errors:>
+
+Dies with C<"Invalid subset '$subset' requested for manifest"> if C<$subset>
+is defined but is not a recognized subset name. C<$subset> is the literal
+name string that was passed.
+
+B<Examples:>
+
+  my $ok = $provider->valid_subset('pruned');
+  # Returns: 1
+
+  my $ok = $provider->valid_subset(undef);
+  # Returns: undef
+
+=head2 vault_paths
+
+  my $paths = $provider->vault_paths(%opts);
+
+Extracts and returns a map of all Vault secret paths referenced in a
+manifest. Uses C<spruce vaultinfo> to enumerate the secrets and their
+referencing locations within the manifest.
+
+The manifest to inspect is determined by the options provided:
+
+=over 4
+
+=item If C<data> is given -- writes the data to a temporary YAML file and inspects it.
+
+=item If C<file> is given -- inspects the named file directly.
+
+=item If C<manifest> is given -- inspects the manifest's associated file.
+
+=item Otherwise -- builds and inspects the C<unevaluated> manifest for this environment.
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item C<data>
+
+Optional. A Perl data structure (hash reference) to serialize to YAML and
+inspect.
+
+=item C<file>
+
+Optional. An absolute path to an existing YAML manifest file to inspect.
+
+=item C<manifest>
+
+Optional. A C<Genesis::Env::Manifest> object whose associated file is
+inspected.
+
+=item C<notify>
+
+Optional boolean. Controls whether a notification is emitted when the
+C<unevaluated> manifest must be built. Defaults to C<1> (notify).
+
+=back
+
+B<Returns:> A hash reference where each key is a vault path string (always
+beginning with C</>) and each value is an array reference of the locations
+within the manifest that reference that path.
+
+B<Errors:>
+
+Dies with C<"Expecting spruce vaultinfo to return an array of secrets, got this instead:\n\n">
+followed by a Data::Dumper dump of the unexpected value, if the
+C<spruce vaultinfo> output is not a hash containing a C<secrets> array.
+
+B<Examples:>
+
+  my $paths = $provider->vault_paths();
+  for my $path (sort keys %$paths) {
+      printf "%s referenced at: %s\n", $path, join(', ', @{$paths->{$path}});
+  }
+  # prints each vault path and where it appears in the manifest
+
+  my $paths = $provider->vault_paths(file => '/tmp/my-manifest.yml');
+  # Returns: hashref of vault paths from the given file
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _subset_plans
+
+  my $plans = $provider->_subset_plans();
+
+Returns a hash reference defining the available manifest subsets and their
+extraction rules. Each key is a subset name; each value is a hash with a
+C<description> and exactly one of:
+
+=over 4
+
+=item C<include>
+
+An array reference of top-level YAML keys to cherry-pick from the source
+manifest.
+
+=item C<exclude>
+
+An array reference of top-level YAML keys to prune from the source manifest.
+
+=item C<fetch>
+
+A hash reference with a C<key> to extract and a C<default> to use when the
+key is absent.
+
+=back
+
+The result is memoized after the first call.
+
+B<Returns:> A hash reference of subset plan definitions.
+
+=head2 _adaptive_merge
+
+  my ($out, $warnings) = $provider->_adaptive_merge();
+
+Attempts to merge source files with C<spruce merge>. When the initial merge
+fails due to unresolvable operators (e.g., missing Vault secrets or
+unevaluatable references), it inspects the error output, locates the
+problematic spruce operators in the source content, rewrites them as
+C<(( defer ... ))> expressions, and retries. Up to five retry attempts are
+made before giving up.
+
+Accepts an optional leading hash reference of options (e.g., C<env> for
+environment variables to pass to the merge command). If the first positional
+argument after C<$self> is not a hash reference, no options hash is consumed.
+The remaining arguments are a list of absolute file paths to merge.
+
+In list context, returns C<($merged_yaml, $warnings_string)>. In scalar
+context, returns only C<$merged_yaml>. The C<$warnings_string> contains spruce
+stderr output: on the early-success path it is the stderr from the successful
+merge (which may be empty or contain warnings); on the retry path it contains
+the original error output collected before retry attempts began.
+
+B<Errors:>
+
+Dies with C<"Internal error: Could not find line causing error '$err_msg' during adaptive merge.">
+if a failing spruce error path cannot be traced back to a source location
+in the merged content. C<$err_msg> is the spruce error message text.
+
+Dies with C<"Could not merge %s environment files:\n\n%s\n\n..."> if all
+retry attempts are exhausted and the merge still fails. C<%s> is the
+environment name and C<%s> is the original or final error output. The
+message also suggests C<export GENESIS_UNEVALED_PARAMS=1> as a partial
+workaround.
+
+B<Examples:>
+
+  my ($yaml, $warnings) = $provider->_adaptive_merge(
+      {env => {GENESIS_ENV => 'prod'}},
+      $init_file, $kit_file, $env_file
+  );
+  # Returns: ($merged_yaml_string, $warnings_string_or_undef)
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Env/ManifestProvider.pod
+++ b/lib/Genesis/Env/ManifestProvider.pod
@@ -218,17 +218,25 @@ B<Examples:>
 
 =head2 env
 
-  my $env = $provider->env($type);
+  my $env = $provider->env();
 
-C<env> returns the C<Genesis::Env> object that owns this provider (the
-C<$type> argument is not used by C<env> itself; it is the parameter for the
-companion C<set_deployment> method documented below).
+Returns the C<Genesis::Env> object that owns this provider.
 
-C<set_deployment($type)> sets the default deployment manifest type.
-Subsequent calls to C<deployment> will return a manifest of this type.
-C<$type> must be a known deployable manifest type name (e.g.,
-C<"entombed">, C<"unredacted">); otherwise the method aborts with an
-internal error.
+B<Returns:> A C<Genesis::Env> object.
+
+B<Examples:>
+
+  my $env = $provider->env();
+  # Returns: the Genesis::Env object bound to this provider
+
+=head2 set_deployment
+
+  $provider->set_deployment($type);
+
+Sets the default deployment manifest type. Subsequent calls to C<deployment>
+will return a manifest of this type. C<$type> must be a known deployable
+manifest type name (e.g., C<"entombed">, C<"unredacted">); otherwise the
+method aborts with an internal error.
 
 B<Parameters:>
 
@@ -236,13 +244,12 @@ B<Parameters:>
 
 =item C<$type>
 
-A manifest type name string passed to C<set_deployment>. The type must exist
-and must be flagged as deployable.
+A manifest type name string. The type must exist and must be flagged as
+deployable.
 
 =back
 
-B<Returns:> C<env> returns a C<Genesis::Env> object. C<set_deployment>
-returns the provider object itself, for method chaining.
+B<Returns:> The provider object itself, for method chaining.
 
 B<Errors:>
 
@@ -251,9 +258,6 @@ known manifest type or is not marked as deployable. C<$type> in the message
 is the literal name string that was passed.
 
 B<Examples:>
-
-  my $env = $provider->env();
-  # Returns: the Genesis::Env object bound to this provider
 
   $provider->set_deployment('entombed');
   my $manifest = $provider->deployment();
@@ -666,7 +670,7 @@ B<Returns:> A hash reference of subset plan definitions.
 
 =head2 _adaptive_merge
 
-  my ($out, $warnings) = $provider->_adaptive_merge();
+  my ($out, $warnings) = $provider->_adaptive_merge(\%opts, @files);
 
 Attempts to merge source files with C<spruce merge>. When the initial merge
 fails due to unresolvable operators (e.g., missing Vault secrets or


### PR DESCRIPTION
## Summary

- Add companion `.pod` documentation for all 14 Genesis::Env Manifest classes (base, provider, 2 mixins, 10 subclasses)
- Document the full inheritance contract, mixin composition pattern, and override points
- File FWT-736 for `_entomb_secret` variable scope defect found during documentation

## Details

**Foundation**: Manifest base class (inheritance contract, abstract methods, override points) and ManifestProvider (builder, merge orchestration, memoization)

**Mixins**: `_entombment_mixin` (Vault-to-Credhub secret migration) and `_vaultify_mixin` (Credhub variable-to-Vault operator conversion), both using USAGE/no SYNOPSIS per mixin convention

**Simple subclasses**: Unredacted, Redacted, Partial, Unevaluated, UnevaluatedEnvironment, PartialEnvironment

**Mixin consumers**: Entombed, Vaultified, VaultifiedRedacted, VaultifiedEntombed — each with `L<>` cross-references to consumed mixins

**Validation**: 781 mechanical checks (775 pass, 6 extractor false positives), all files pass `podchecker` and `perldoc` rendering

## Test plan

- [ ] Verify all 14 `.pod` files render with `perldoc`
- [ ] Verify `podchecker` reports 0 errors on all files
- [ ] Confirm mixin PODs have USAGE (not SYNOPSIS)
- [ ] Confirm mixin consumers include `L<>` refs to their mixins
- [ ] Run `skill.py validate` on all 14 modules

Related: FWT-582