### PR TITLE
POD: Genesis::Kit classes

### DIFF
--- a/lib/Genesis/Kit.pod
+++ b/lib/Genesis/Kit.pod
@@ -1,100 +1,1337 @@
 =head1 NAME
 
-Genesis::Kit
+Genesis::Kit - Abstract base class for all Genesis kit types.
+
+=head1 SYNOPSIS
+
+  # Genesis::Kit is abstract; use a concrete subclass:
+  use Genesis::Kit::Compiled;
+  use Genesis::Kit::Dev;
+
+  # Typical access through a provider:
+  my $kit = $provider->kit('cf', '2.8.0');
+
+  # Inspect kit identity and metadata
+  print $kit->id();             # prints 'cf/2.8.0'
+  print $kit->name();           # prints 'cf'
+  print $kit->version();        # prints '2.8.0'
+
+  # Check for and run hooks
+  if ($kit->has_hook('check')) {
+      $kit->run_hook('check', env => $env);
+  }
+
+  # Access kit files
+  my $hook_path = $kit->path('hooks/new');
+  my @yamls      = $kit->glob('base/*.yml');
 
 =head1 DESCRIPTION
 
-This module encapsulates all of the logic for dealing with Genesis Kits in
-the abstract.  It does not handle the concrete problems of dealing with
-tarballs (Genesis::Kit::Compiled) or dev/ directories (Genesis::Kit::Dev).
+C<Genesis::Kit> encapsulates all of the logic for dealing with Genesis kits
+in the abstract. It does not handle the concrete problems of dealing with
+tarballs (L<Genesis::Kit::Compiled>) or C<dev/> directories
+(L<Genesis::Kit::Dev>).
 
-=head1 CLASS METHODS
+A Genesis kit is a self-contained bundle of BOSH deployment configuration
+and hook scripts that know how to provision, configure, and manage a
+specific type of BOSH deployment. Kits define hooks for lifecycle events
+(C<new>, C<blueprint>, C<check>, C<pre-deploy>, C<post-deploy>, etc.) and
+carry metadata in a C<kit.yml> file.
 
-=head2 new()
+This class is abstract and cannot be instantiated directly. All usable kit
+objects are instances of one of its concrete subclasses. Subclasses must
+implement C<new>, C<id>, C<name>, C<version>, and C<extract>.
 
-This is an abstract method, placeholder for derived classes to provide their
-own constructors.
-
-=head1 INSTANCE METHODS
-
-=head2 path([$relative])
-
-Returns a fully-qualified, absolute path to a file inside the kit workspace.
-If C<$relative> is omitted, the workspace root is returned.
-
-=head2 glob($pattern)
-
-Returns the absolute paths to all files inside the kit workspace that match
-the given C<$pattern> file glob.
-
-=head2 metadata()
-
-Returns the parsed metadata from this kit's C<kit.yml> file.  This call is
-moemoized, so it only actually touches the disk once.
-
-=head2 check_prereqs()
-
-Checks the prerequisites of the kit, notably the C<genesis_version_min>
-assertion, against the executing environment.
-
-=head2 has_hook($name)
-
-Returns true if the kit has defined the given hook.
-
-=head2 run_hook($name, %opts)
-
-Executes the named hook and returns something useful to the caller.  It is
-an error if the kit does not define the kit; use C<has_hook> to avoid that.
-
-The specific composition of C<%opts>, as well as the return value / side
-effects of running a hook are wholly hook-dependent.  Refer to the section
-B<GENESIS KIT HOOKS>, later, for more detail.
-
-=head2 source_yaml_files(\@features, $absolute)
-
-Determines, by way of either C<hooks/blueprint> which kit YAML files need to be
-merged together, and returns there paths.
-
-If you pass C<$absolute> as a true value, the paths returned by this
-function will be absolutely qualified to the Kit's Top object root.  This is
-necessary for merging from a different directory (i.e. the deployment root,
-when blueprint is going to return paths relative to the kit working space).
-
-If C<\@features> is omitted, it defaults to the empty arrayref, C<[]>.
-
-=head1 GENESIS KIT HOOKS
-
-Genesis defines the following hooks:
+=head1 METHODS
 
 =head2 new
 
-Provisions a new environment, by interrogating the environment or asking the
-operator for information.
+  my $kit = SubClass->new($provider);
 
-=head2 blueprint
+Abstract constructor. Raises an internal error if called directly on
+C<Genesis::Kit>. Concrete subclasses provide their own constructors.
 
-Maps feature flags in an environment onto manifest fragment YAML files in
-the kit, prescribing order and augmenting feature selection with additional
-logic as needed.
+B<Parameters:>
 
-=head2 secrets
+=over 4
 
-Manages automatic generation of non-Credhub secrets that are stored in the
-shared Genesis Vault.  This hook is repoonsible for determining if secrets
-are missing (i.e. after an upgrade), adding them if they are, and rotating
-what is safe to rotate.
+=item C<$provider>
 
-=head2 info
+The kit provider object (e.g., a local cache or remote registry) that
+produced this kit. Stored for reference by subclasses.
 
-Prints out a kit-specific summary of a single environment.  This could
-include IP addresses, certificates, passwords, and URLs.
+=back
 
-=head2 addon
+B<Returns:>
 
-Executes arbitrary actions.  This allows kit authors to enrich the Genesis
-expierience in highly kit-specific ways by giving operators new commands to
-run.  For example, the BOSH kit defines a C<login> addon that sets up a BOSH
-CLI alias and authenticates to the BOSH director, transparently pulling
-secrets from the Vault.
+A blessed object of the concrete subclass. Does not return when called
+directly on C<Genesis::Kit>.
+
+B<Errors:>
+
+Dies with C<"Attempt to initialize abstract class Genesis::Kit"> if called
+directly on C<Genesis::Kit> rather than on a concrete subclass.
+
+B<Examples:>
+
+  # Incorrect - will die:
+  # my $kit = Genesis::Kit->new($provider);
+
+  # Correct - use a concrete subclass:
+  my $kit = Genesis::Kit::Compiled->new(
+      name     => 'cf',
+      version  => '2.8.0',
+      archive  => '/path/to/cf-2.8.0.tar.gz',
+      provider => $provider,
+  );
+  # Returns: a Genesis::Kit::Compiled object
+
+=head2 known_hooks
+
+  my @hooks = Genesis::Kit::known_hooks();
+  my @hooks = $kit->known_hooks();
+
+Returns the list of all hook names that Genesis recognizes. This is a
+class-level method and may be called on either the class or an instance.
+
+B<Returns:>
+
+A list of strings naming every valid Genesis hook:
+C<new>, C<feature>, C<blueprint>, C<info>, C<check>, C<pre-deploy>,
+C<post-deploy>, C<terminate>, C<edit>, C<shell>, C<addon>,
+C<cloud-config>, C<cpi-config>, C<features>, and C<runtime-config>.
+
+B<Examples:>
+
+  my @hooks = Genesis::Kit::known_hooks();
+  print join(', ', @hooks);
+  # Returns: new, feature, blueprint, info, check, pre-deploy, ...
+
+=head2 path
+
+  my $file = $kit->path($path);
+  my $root = $kit->path();
+
+Returns a fully-qualified, absolute path to a file inside the kit's
+extracted workspace. Calling C<extract> is triggered automatically if it
+has not already been called.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$relative>
+
+Optional. A relative path within the kit workspace (e.g., C<"hooks/new">).
+Leading slashes are stripped before joining. When omitted, the workspace
+root directory is returned.
+
+=back
+
+B<Returns:>
+
+When C<$relative> is omitted: the absolute path to the kit workspace root.
+
+When C<$relative> is provided: the absolute path formed by joining the
+workspace root with the relative path.
+
+B<Errors:>
+
+Dies with C<"self->extract did not set self->{root}!!"> if extraction
+succeeded but failed to record the workspace root on the object.
+
+B<Examples:>
+
+  my $root = $kit->path();
+  # Returns: '/tmp/genesis-kit-work-XXXXX'
+
+  my $hook = $kit->path('hooks/new');
+  # Returns: '/tmp/genesis-kit-work-XXXXX/hooks/new'
+
+=head2 glob
+
+  my @paths = $kit->glob($glob, $absolute);
+  my @paths = $kit->glob($glob);
+
+Returns the paths to all files inside the kit workspace that match the
+given file glob pattern. Calls C<extract> automatically if needed.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$pattern>
+
+A shell glob pattern relative to the kit workspace root (e.g.,
+C<"base/*.yml">). Leading slashes are stripped before matching.
+
+=item C<$absolute>
+
+Optional. When true, the glob is expanded with the workspace root
+prepended so that all returned paths are absolute. When false or omitted,
+paths are relative to the workspace root.
+
+=back
+
+B<Returns:>
+
+A list of matching file paths. When C<$absolute> is true the paths are
+absolute; otherwise they are relative to the kit workspace root.
+
+B<Errors:>
+
+Dies with C<"self->extract did not set self->{root}!!"> if the workspace
+root is not set after extraction.
+
+B<Examples:>
+
+  my @yamls = $kit->glob('base/*.yml');
+  # Returns: ('base/base.yml', 'base/params.yml', ...)
+
+  my @yamls = $kit->glob('base/*.yml', 1);
+  # Returns: ('/tmp/genesis-kit-work-XXXXX/base/base.yml', ...)
+
+=head2 has_hook
+
+  my $path = $kit->has_hook($hook, %opts);
+
+Returns the path to the hook script if the kit defines the named hook, or
+a false value if it does not. Results are cached on the object after the
+first check.
+
+For the C<cloud-config> hook, an optional C<purpose> key in C<%opts>
+selects a purpose-specific subtype (e.g., C<cloud-config-aws>). For the
+C<addon> hook, an optional C<script> key selects a named addon script.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$hook>
+
+The name of the hook to check (e.g., C<"check">, C<"blueprint">,
+C<"addon">).
+
+=item C<%opts>
+
+Optional key-value pairs:
+
+=over 4
+
+=item C<purpose>
+
+Used when C<$hook> is C<"cloud-config">. Selects the
+purpose-specific hook file, e.g., C<"hooks/cloud-config-aws">.
+
+=item C<script>
+
+Used when C<$hook> is C<"addon">. Identifies which addon script
+file to locate.
+
+=back
+
+=back
+
+B<Returns:>
+
+The absolute path to the hook script file if found, or C<undef> if the
+hook is not defined. For Perl-based hooks, C<.pm> files are included in
+the search unless C<GENESIS_NO_MODULE_HOOKS> is set in the environment.
+
+B<Examples:>
+
+  if ($kit->has_hook('check')) {
+      print "Kit defines a check hook\n";
+  }
+
+  my $path = $kit->has_hook('cloud-config', purpose => 'aws');
+  # Returns: '/tmp/.../hooks/cloud-config-aws' or undef
+
+=head2 get_addon_hook_file
+
+  my $file = $kit->get_addon_hook_file($script);
+
+Locates the addon hook file for the given script name. Returns a cached
+result on repeat calls. This method is used internally by C<has_hook> and
+C<run_hook> for addon dispatch.
+
+For the special names C<list>, C<help>, and the empty string, returns
+C<'@Genesis::Hook::Addon'> (a module reference marker) when Perl module
+hooks are enabled.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$script>
+
+The name of the addon script to find (e.g., C<"login">, C<"list">, or
+an empty string for the default addon).
+
+=back
+
+B<Returns:>
+
+The path to the matching addon hook file, the string
+C<'@Genesis::Hook::Addon'> for the built-in help/list handler, or
+C<undef> if no matching file is found.
+
+B<Examples:>
+
+  my $file = $kit->get_addon_hook_file('login');
+  # Returns: '/tmp/.../hooks/addon-login.pm' or undef
+
+  my $file = $kit->get_addon_hook_file('list');
+  # Returns: '@Genesis::Hook::Addon' (when module hooks are enabled)
+
+=head2 get_hook_module
+
+  my $module = $kit->get_hook_module($hook_file);
+
+Reads the first non-blank, non-comment line from a hook file and returns
+the package name if it is a C<Genesis::Hook::*> Perl module. Returns
+C<undef> for shell scripts or files without a recognized C<package>
+declaration.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$hook_file>
+
+Path to the hook file to inspect. If not absolute, the path is resolved
+relative to the kit workspace root via C<path()>.
+
+=back
+
+B<Returns:>
+
+The package name (e.g., C<"Genesis::Hook::Blueprint">) if the first
+substantive line of the file is a C<Genesis::Hook::*> package declaration,
+or C<undef> otherwise.
+
+B<Examples:>
+
+  my $mod = $kit->get_hook_module('hooks/blueprint.pm');
+  # Returns: 'Genesis::Hook::Blueprint' or undef
+
+=head2 run_hook
+
+  my $result = $kit->run_hook($hook, %opts);
+
+Executes the named kit hook and returns its result. This is the central
+dispatch method for all hook execution. The hook may be implemented as a
+Perl module (C<Genesis::Hook::*>) or as a shell script.
+
+The method sets a standard set of C<GENESIS_KIT_*> environment variables
+before running the hook. For most hooks the C<env> option is required to
+populate additional deployment-specific environment variables.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$hook>
+
+The name of the hook to run. Must be one of the names returned by
+C<known_hooks()>.
+
+=item C<%opts>
+
+Key-value options. The available keys depend on which hook is being run:
+
+=over 4
+
+=item C<env>
+
+A C<Genesis::Env> object. Required for the C<new>, C<secrets>, C<info>,
+C<addon>, C<check>, C<blueprint>, C<pre-deploy>, C<post-deploy>,
+C<cloud-config>, C<cpi-config>, C<features>, and C<terminate> hooks.
+
+=item C<extra_vars>
+
+Optional hashref of additional environment variables to set when running
+the hook, in addition to those from C<env-E<gt>get_environment_variables>.
+
+=item C<eval_var_args>
+
+Optional. Passed through to the underlying shell runner for bash hooks.
+
+=item C<shell>
+
+Used with the C<shell> hook. The shell executable to invoke; defaults to
+C<"/bin/bash">.
+
+=item C<editor>
+
+Used with the C<edit> hook. The editor to open; defaults to C<$EDITOR>
+or C<vim>.
+
+=item C<script>
+
+Used with the C<addon> hook. The name of the addon script to execute.
+
+=item C<args>
+
+Used with the C<addon> and C<runtime-config> hooks. An arrayref of
+arguments to pass to the hook.
+
+=item C<action>
+
+Used with the C<secrets> hook. The secrets action to perform (e.g.,
+C<"check">, C<"add">, C<"rotate">).
+
+=item C<purpose>
+
+Used with the C<cloud-config> hook. The cloud-config subtype to generate
+(e.g., C<"aws">).
+
+=item C<credhub_prefix>
+
+Used with the C<cpi-config> hook. The CredHub prefix for CPI config
+generation.
+
+=item C<manifest>
+
+Used with the C<pre-deploy> hook. Path to the generated manifest file.
+
+=item C<vars_file>
+
+Used with the C<pre-deploy> hook. Path to the BOSH variables file.
+
+=item C<rc>
+
+Used with the C<post-deploy> hook. The BOSH deploy exit code.
+
+=item C<data>
+
+Used with the C<post-deploy> hook. Optional pre-deploy data to make
+available to the hook.
+
+=item C<interactive>
+
+Used with the C<post-deploy> and C<runtime-config> hooks.
+
+=item C<flags>
+
+Used with the C<post-deploy> hook.
+
+=item C<features>
+
+Used with the C<features> hook. An arrayref of requested feature flags.
+Required for the C<features> hook.
+
+=item C<mode>
+
+Used with the C<terminate> hook.
+
+=item C<dryrun>
+
+Used with the C<terminate> and C<runtime-config> hooks. Defaults to C<0>.
+
+=item C<force>
+
+Used with the C<terminate> hook. Defaults to C<0>.
+
+=item C<noprompt>
+
+Used with the C<terminate> hook. Defaults to C<0>.
+
+=item C<remove>
+
+Used with the C<runtime-config> hook. Defaults to C<0>.
+
+=item C<print>
+
+Used with the C<runtime-config> hook. Defaults to C<0>.
+
+=back
+
+=back
+
+B<Returns:>
+
+The return value is hook-dependent:
+
+=over 4
+
+=item C<new>
+
+Returns C<1> on success.
+
+=item C<blueprint>
+
+Returns an arrayref of YAML file paths to merge.
+
+=item C<features>
+
+Returns an arrayref of feature flag strings.
+
+=item C<pre-deploy>
+
+Returns a two-element list: a boolean success flag and the pre-deploy data
+contents (or C<undef> if no data file was produced).
+
+=item C<addon>, C<check>, C<secrets check>
+
+Returns a boolean: C<1> on success, C<0> on failure.
+
+=item C<shell>
+
+Does not return; exits the process with the shell's exit code.
+
+=item All other hooks (Perl module-based)
+
+Returns the result of C<$hook_obj-E<gt>results()>.
+
+=item All other hooks (bash-based)
+
+Returns C<1> on success.
+
+=back
+
+B<Errors:>
+
+=over 4
+
+=item C<"No '$hook' hook script found">
+
+The named hook is not defined by this kit (and it is not the C<addon>
+hook, which is allowed to be absent).
+
+=item C<"Unrecognized hook '$hook'\n">
+
+The hook name is not in the list returned by C<known_hooks()>.
+
+=item C<"The 'env' option to run_hook is required for the '$hook' hook!!">
+
+The C<env> key was not supplied in C<%opts> for a hook that requires it.
+
+=item C<"The 'features' option to run_hook is required for the '$hook' hook!!">
+
+The C<features> key was not supplied for the C<features> hook.
+
+=item C<"Could not find addon hook for '%s' script in kit %s">
+
+The C<addon> hook file could not be located. C<%s> is the script name and
+the kit identity string.
+
+=item C<"Could not load Perl module %s to run hook %s in kit %s: %s">
+
+The Perl hook module file could not be loaded via C<require>. The four
+C<%s> placeholders are: module file path, hook name, kit identity, and
+the Perl error from C<$@>.
+
+=item C<"Could not run '%s' hook successfully!">
+
+A Perl module hook's C<perform> method returned a false value. C<%s>
+is the hook name.
+
+=item C<"Could not create new env #C{%s} (in %s): 'new' hook exited %d">
+
+The C<new> hook exited with a non-zero exit code. The placeholders are the
+environment name, the deployment root path, and the exit code.
+
+=item C<"Could not create new env #C{%s} (in %s): 'new' hook did not create #M{%1$s}">
+
+The C<new> hook exited successfully but did not create the expected
+C<E<lt>env-nameE<gt>.yml> file. The placeholders are the environment name
+and the deployment root path.
+
+=item C<"Could not determine which YAML files to merge: 'blueprint' hook exited with %d:">
+
+The C<blueprint> hook exited with a non-zero exit code. C<%d> is the exit
+code, followed by the hook's stdout output.
+
+=item C<"Could not determine which YAML files to merge: 'blueprint' specified no files">
+
+The C<blueprint> hook succeeded but produced no output.
+
+=item C<"Could not run feature hook in kit %s:">
+
+The C<features> hook exited non-zero. C<%s> is the kit identity.
+
+=item C<"Cannot continue with deployment: 'pre-deploy' hook for #C{%s} environment exited %d.">
+
+The C<pre-deploy> hook failed. The placeholders are the environment name
+and the exit code.
+
+=item C<"Could not run '%s' hook successfully - exited with %d:">
+
+A bash hook exited non-zero and produced stdout output. C<%s> is the hook
+name and C<%d> is the exit code, followed by stdout.
+
+=item C<"Could not run '%s' hook successfully - exited with %d">
+
+A bash hook exited non-zero without stdout. C<%s> is the hook name and
+C<%d> is the exit code.
+
+=back
+
+B<Examples:>
+
+  # Run the 'check' hook
+  $kit->run_hook('check', env => $env);
+
+  # Run the 'blueprint' hook and get YAML file list
+  my $files = $kit->run_hook('blueprint', env => $env);
+  # Returns: ['base/base.yml', 'base/networking.yml']
+
+  # Run the 'pre-deploy' hook
+  my ($ok, $data) = $kit->run_hook('pre-deploy',
+      env      => $env,
+      manifest => '/tmp/manifest.yml',
+      vars_file => '/tmp/vars.yml',
+  );
+  # Returns: (1, undef) on success with no pre-deploy data
+
+=head2 metadata
+
+  my $meta     = $kit->metadata(@keys);
+  my $value    = $kit->metadata($key);
+  my $all      = $kit->metadata();
+
+Returns the parsed metadata from this kit's C<kit.yml> file. The result is
+memoized so the file is only read and merged once per kit object.
+
+If environment-specific override files have been registered via
+C<apply_env_overrides()>, those files are merged on top of C<kit.yml> using
+C<spruce merge>. If the environment variable C<PREVIOUS_ENV> is set and a
+cached override file exists, that file is also merged.
+
+The C<use_create_env> field is normalized after loading: JSON booleans are
+converted to C<'yes'> or C<'no'>; string values of C<yes>, C<no>, C<allow>,
+C<true>, C<false>, C<1>, and C<0> are normalized; for kits with a
+C<genesis_version_min> of 2.8.0 or later the field defaults to C<'allow'>
+if absent.
+
+Modifies the object in-place by caching the parsed metadata on first call.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@keys>
+
+Optional. When omitted, the entire metadata hashref is returned. When one
+key is given, the value for that key is returned. When multiple keys are
+given, a subset of the metadata hash selected by those keys is returned via
+C<get_opts>.
+
+=back
+
+B<Returns:>
+
+With no arguments: a hashref of all metadata.
+
+With one argument: the value of the named key, or C<undef> if absent.
+
+With multiple arguments: a hash of the selected key-value pairs.
+
+Returns an empty hashref (C<{}>) if C<kit.yml> does not exist.
+
+B<Examples:>
+
+  my $meta = $kit->metadata();
+  # Returns: { name => 'cf', version => '2.8.0', genesis_version_min => '2.7.0', ... }
+
+  my $store = $kit->metadata('secrets_store');
+  # Returns: 'vault'
+
+=head2 apply_env_overrides
+
+  $kit->apply_env_overrides(@override_files);
+
+Registers one or more YAML override files to be merged on top of
+C<kit.yml> when metadata is next loaded. Clears any previously cached
+metadata so the next call to C<metadata()> re-reads from disk.
+
+Modifies the object in-place.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@override_files>
+
+One or more absolute file paths to YAML files that will be merged on top
+of C<kit.yml> using C<spruce merge>.
+
+=back
+
+B<Returns:>
+
+Nothing.
+
+B<Examples:>
+
+  $kit->apply_env_overrides('/path/to/kit-overrides.yml');
+  my $meta = $kit->metadata();
+  # Returns: merged metadata including override values
+
+=head2 env_override_files
+
+  my @files = $kit->env_override_files();
+
+Returns the list of environment-specific override files currently registered
+on this kit object via C<apply_env_overrides>.
+
+B<Returns:>
+
+A list of file paths, or an empty list if no overrides have been registered.
+
+B<Examples:>
+
+  my @files = $kit->env_override_files();
+  # Returns: ('/path/to/kit-overrides.yml') or ()
+
+=head2 secrets_store
+
+  my $store = $kit->secrets_store();
+
+Returns the name of the secrets store used by this kit, as declared in
+its C<kit.yml> metadata. Defaults to C<'vault'> when the C<secrets_store>
+field is absent or empty.
+
+B<Returns:>
+
+A string: C<'vault'>, C<'credhub'>, or whatever value the kit declares.
+Returns C<'vault'> when not specified.
+
+B<Examples:>
+
+  my $store = $kit->secrets_store();
+  # Returns: 'vault' or 'credhub'
+
+=head2 uses_credhub
+
+  my $bool = $kit->uses_credhub();
+
+Returns a true value if this kit uses CredHub as its secrets store instead
+of Vault. This is a convenience wrapper around C<secrets_store()>.
+
+B<Returns:>
+
+C<1> if C<secrets_store()> returns C<"credhub">, otherwise a false value.
+
+B<Examples:>
+
+  if ($kit->uses_credhub()) {
+      print "Kit uses CredHub\n";
+  }
+
+=head2 required_configs
+
+  my @configs = $kit->required_configs(@hooks);
+
+Returns the list of BOSH config types (e.g., C<'cloud'>) that must be
+present for the given hook operations to succeed.
+
+If no C<required_configs> key is present in C<kit.yml>, the method applies
+built-in defaults: C<'cloud'> is required for the C<blueprint>, C<manifest>,
+and C<check> (unless C<GENESIS_CONFIG_NO_CHECK> is set) hooks. The C<cloud-config>
+hook itself never requires any config.
+
+When C<required_configs> in C<kit.yml> is an arrayref, it is returned
+directly. When it is a hashref mapping config type to hook arrays, only
+the config types relevant to the given hooks are returned.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@hooks>
+
+The hook names for which required configs should be determined (e.g.,
+C<'blueprint'>, C<'check'>).
+
+=back
+
+B<Returns:>
+
+A list of config type strings. May be empty.
+
+B<Examples:>
+
+  my @required = $kit->required_configs('blueprint');
+  # Returns: ('cloud')
+
+  my @required = $kit->required_configs('cloud-config');
+  # Returns: ()
+
+=head2 required_connectivity
+
+  my @conns = $kit->required_connectivity(@hooks);
+
+Returns the list of connectivity requirements that this kit declares in its
+C<kit.yml> metadata under the C<required_connectivity> key.
+
+If C<required_connectivity> is an arrayref, it is returned directly. If it
+is a hashref mapping connectivity type to hook arrays, only the types
+relevant to the given hooks are returned.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@hooks>
+
+The hook names for which connectivity requirements should be evaluated. When
+omitted, all declared connectivity requirements are returned.
+
+=back
+
+B<Returns:>
+
+A list of connectivity type strings, or an empty list if no connectivity
+requirements are declared.
+
+B<Examples:>
+
+  my @conns = $kit->required_connectivity('blueprint');
+  # Returns: ('bosh', 'vault') or ()
+
+=head2 feature_compatibility
+
+  my $bool = $kit->feature_compatibility($version);
+
+Returns true if the kit's minimum required Genesis version is at least
+C<$version>. This is used to determine whether a Genesis feature that was
+introduced in a specific version is available to kits targeting that version
+or later.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$version>
+
+A semantic version string (e.g., C<"2.6.13">) representing the minimum
+Genesis version at which a feature was introduced.
+
+=back
+
+B<Returns:>
+
+A true value if the kit's C<genesis_version_min> is greater than or equal to
+C<$version>; false otherwise.
+
+B<Errors:>
+
+Dies with C<"Invalid base version provided to Genesis::Kit::feature_compatibility">
+if C<$version> is not a valid semantic version string.
+
+B<Examples:>
+
+  my $ok = $kit->feature_compatibility('2.6.13');
+  # Returns: 1 if kit targets Genesis 2.6.13+, 0 otherwise
+
+  if ($kit->feature_compatibility('2.6.13')) {
+      print "Kit supports 2.6.13+ features\n";
+  }
+
+=head2 genesis_version_min
+
+  my $ver = $kit->genesis_version_min();
+
+Returns the minimum Genesis version required to use this kit, as declared
+in its C<kit.yml> metadata under the C<genesis_version_min> key. The result
+is memoized after the first call.
+
+B<Returns:>
+
+A semantic version string (e.g., C<"2.7.0">). Returns C<"0.0.0"> when the
+kit does not declare a minimum version or the declared value is not a valid
+semantic version string.
+
+B<Examples:>
+
+  my $min = $kit->genesis_version_min();
+  # Returns: '2.7.0' or '0.0.0'
+
+=head2 check_prereqs
+
+  my $ok = $kit->check_prereqs($env);
+
+Checks that the runtime environment satisfies the kit's prerequisites.
+Verifies that the running Genesis version meets the kit's
+C<genesis_version_min> requirement and, if the kit defines a C<prereqs>
+hook, runs that hook.
+
+Emits a warning (but does not fail) when running a development version of
+Genesis that cannot be compared against the minimum version requirement.
+Emits an error message and returns false when the running Genesis version
+is too old.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env>
+
+The C<Genesis::Env> object for the deployment environment. Passed to the
+C<prereqs> hook if one exists.
+
+=back
+
+B<Returns:>
+
+C<1> if all prerequisite checks pass, C<0> if any fail.
+
+B<Examples:>
+
+  my $ok = $kit->check_prereqs($env);
+  if (!$ok) {
+      die "Kit prerequisites not met\n";
+  }
+  # Returns: 1 on success, 0 on failure
+
+=head2 source_yaml_files
+
+  my @files = $kit->source_yaml_files($env, $absolute);
+
+Determines, by running the C<blueprint> hook, which kit YAML files need to
+be merged to produce the deployment manifest.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env>
+
+The C<Genesis::Env> object for the deployment. Passed to the C<blueprint>
+hook.
+
+=item C<$absolute>
+
+Optional. When true, paths that are not already under the environment's
+root are converted to absolute paths under the kit workspace root. When
+false or omitted, paths are returned as the C<blueprint> hook produced them.
+
+=back
+
+B<Returns:>
+
+A list of file path strings representing the YAML files to be merged.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Kit %s is not supported by Genesis %s (no hooks/blueprint script).  ">
+
+The kit does not define a C<blueprint> hook. C<%s> is the kit identity
+and the running Genesis version.
+
+=item C<"Kit %s blueprint hook did not return a list of files to merge">
+
+The C<blueprint> hook ran successfully but the return value was not a
+valid arrayref. C<%s> is the kit identity.
+
+=back
+
+B<Examples:>
+
+  my @files = $kit->source_yaml_files($env);
+  # Returns: ('base/base.yml', 'base/networking.yml', 'addons/tls.yml')
+
+  my @files = $kit->source_yaml_files($env, 1);
+  # Returns: ('/tmp/kit-work-XXX/base/base.yml', ...)
+
+=head2 dereferenced_metadata
+
+  my $meta = $kit->dereferenced_metadata($lookup, $fatal);
+
+Returns a copy of the kit metadata with all C<${key}> parameter references
+expanded using the supplied lookup callback. The result is memoized: the
+callback is only invoked during the first call; subsequent calls return the
+cached result.
+
+Modifies the object in-place by caching the dereferenced metadata and a
+deref-miss list on first call.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$lookup>
+
+A code reference that accepts a parameter key and an optional default value
+and returns the resolved value. For example:
+C<sub { my ($key, $default) = @_; return $env->params->{$key} // $default }>.
+
+=item C<$fatal>
+
+Optional boolean. When true, the method dies if any C<${key}> references
+could not be resolved. When false or omitted, unresolved references are
+left as literal C<"${key}"> strings in the returned structure.
+
+=back
+
+B<Returns:>
+
+A hashref containing a deep copy of the kit metadata with all C<${key}>
+placeholders replaced by their resolved values. Individual values within
+the hashref may be scalars, arrayrefs, or nested hashrefs depending on
+the metadata structure.
+
+B<Errors:>
+
+Dies with C<"Could not dereference the following values specified in the metadata:\n  - ">
+followed by a newline-separated list of unresolved keys when C<$fatal>
+is true and any references could not be resolved.
+
+B<Examples:>
+
+  my $meta = $kit->dereferenced_metadata(sub {
+      my ($key, $default) = @_;
+      return $env->params->{$key} // $default;
+  });
+  # Returns: metadata hashref with all ${key} references expanded
+
+=head2 requires_iaas
+
+  my $iaas = $kit->requires_iaas($env);
+
+Returns the IaaS type that this kit requires, as declared in its C<kit.yml>
+metadata under the C<requires_iaas> key.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env>
+
+The C<Genesis::Env> object. Currently unused; accepted for API consistency.
+
+=back
+
+B<Returns:>
+
+The value of the C<requires_iaas> metadata field (e.g., C<"aws">,
+C<"vsphere">), or C<undef> if not declared.
+
+B<Examples:>
+
+  my $iaas = $kit->requires_iaas($env);
+  # Returns: 'vsphere' or undef
+
+=head2 requires_scale
+
+  my $scale = $kit->requires_scale($env);
+
+Returns the scale identifier that this kit requires, as declared in its
+C<kit.yml> metadata under the C<requires_scale> key.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env>
+
+The C<Genesis::Env> object. Currently unused; accepted for API consistency.
+
+=back
+
+B<Returns:>
+
+The value of the C<requires_scale> metadata field (e.g., C<"small">,
+C<"production">), or C<undef> if not declared.
+
+B<Examples:>
+
+  my $scale = $kit->requires_scale($env);
+  # Returns: 'production' or undef
+
+=head2 services
+
+  my @services = $kit->services();
+
+Returns the list of services this kit provides, as declared in its
+C<kit.yml> metadata under the C<services> key.
+
+B<Returns:>
+
+A list of service name strings. When the C<services> field is an arrayref,
+its contents are returned as a flat list. When it is a scalar string, a
+single-element list is returned. Returns an empty list if the field is
+absent.
+
+B<Examples:>
+
+  my @services = $kit->services();
+  # Returns: ('vault') or ('director') or ()
+
+=head2 provides_service
+
+  my $bool = $kit->provides_service($service);
+
+Returns a true value if this kit provides the named service.
+
+First checks explicit declarations in the C<services> field of C<kit.yml>.
+If no explicit declarations exist, falls back to backward-compatible
+heuristics: for C<'vault'>, checks whether the kit name equals C<'vault'>;
+for C<'director'>, checks whether the kit id starts with C<'bosh/'> or the
+C<is_bosh_director> metadata flag is set.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$service>
+
+The service name to check (e.g., C<'vault'>, C<'director'>).
+
+=back
+
+B<Returns:>
+
+A true value (count of matching declarations, or C<1>) if the kit provides
+the service, or C<0> if it does not.
+
+B<Examples:>
+
+  if ($kit->provides_service('vault')) {
+      print "Kit provides a Vault service\n";
+  }
+  # Returns: 1 or 0
+
+=head2 is_dev
+
+  my $bool = $kit->is_dev();
+
+Returns false. This base-class implementation always returns C<0>.
+Subclasses representing dev kits (C<Genesis::Kit::Dev>) override this
+method to return a true value.
+
+B<Returns:>
+
+C<0>.
+
+B<Examples:>
+
+  print $kit->is_dev();
+  # prints '0' for compiled kits; '1' for dev kits
+
+=head1 ABSTRACT METHODS
+
+Concrete subclasses must implement the following methods. Calling them on a
+C<Genesis::Kit> instance directly will raise an error or produce undefined
+behavior.
+
+=head2 id
+
+  my $id = $kit->id();
+
+Returns the identity string for this kit in the form C<"name/version">.
+
+=head2 name
+
+  my $name = $kit->name();
+
+Returns the kit name (e.g., C<"cf">).
+
+=head2 version
+
+  my $version = $kit->version();
+
+Returns the kit version string (e.g., C<"2.8.0">).
+
+=head2 extract
+
+  $kit->extract();
+
+Extracts the kit's contents to a temporary working directory. After this
+method runs, C<path()>, C<glob()>, C<has_hook()>, and related methods
+become operational. Implementations are expected to memoize this operation
+so that the extraction is performed only once.
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _deref_metadata
+
+  my $copy = $self->_deref_metadata($metadata, $lookup);
+
+Recursively walks a metadata structure (arrayref, hashref, or scalar) and
+expands all C<${key}> and C<${key||default}> placeholders by calling
+C<_dereference_param>. Returns a new deep copy with all placeholders
+replaced. Elements tagged as C<maybe:key> that resolve to a missing value
+are silently dropped from the result.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$metadata>
+
+The metadata structure to dereference. May be a hashref, arrayref, or
+scalar string.
+
+=item C<$lookup>
+
+A code reference used to resolve parameter keys. Passed through to
+C<_dereference_param>.
+
+=back
+
+B<Returns:>
+
+A new arrayref, hashref, or scalar with all C<${key}> references expanded.
+
+B<Examples:>
+
+  # Called internally by dereferenced_metadata(); not typically invoked directly.
+  my $expanded = $kit->_deref_metadata($kit->metadata, $lookup);
+  # Returns: a deep copy with all ${key} placeholders replaced
+
+=head2 _dereference_param
+
+  my $val = $self->_dereference_param($lookup, $key, $default);
+
+Resolves a single parameter key by calling C<$lookup>. Follows Spruce
+C<(( grab ... ))> indirection chains until a concrete value is found.
+Results are cached on the object to avoid redundant lookups.
+
+If the resolved value contains an unresolved C<(( vault ... ))> operator,
+the method dies with a detailed error that includes an OCFP-specific hint
+when the vault path contains C<ocfp>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$lookup>
+
+A code reference that maps a key to its value.
+
+=item C<$key>
+
+The parameter key to resolve. A C<maybe:> prefix is stripped and causes
+missing keys to be silently ignored rather than recorded as unresolved.
+
+=item C<$default>
+
+Optional default value used when the key is not found.
+
+=back
+
+B<Returns:>
+
+The resolved string value, or C<"${key}"> if the key could not be resolved
+(and C<maybe:> was not set).
+
+B<Errors:>
+
+=over 4
+
+=item C<"metadata not found\n">
+
+Raised internally when a C<maybe:key> reference cannot be resolved.
+Caught by C<_deref_metadata> and silently suppressed.
+
+=item C<"Cannot dereference kit parameter '%s' to a value because it has an unresolved\n">
+
+The resolved value contains a Vault operator that has not been interpolated.
+C<%s> is the parameter key.
+
+=back
+
+B<Examples:>
+
+  # Called internally; not typically invoked directly.
+  my $lookup = sub { my ($k,$d) = @_; return $env->params->{$k} // $d };
+  my $val = $kit->_dereference_param($lookup, 'iaas', 'vsphere');
+  # Returns: the resolved value for 'iaas', or 'vsphere' if not found
+
+=head1 GENESIS KIT HOOKS
+
+Genesis kits communicate with the Genesis CLI through hook scripts located
+in the kit's C<hooks/> directory. Hooks may be Perl modules
+(C<Genesis::Hook::*>) or shell scripts. The following hooks are defined:
+
+=head3 new
+
+Provisions a new environment by interrogating the operator for required
+configuration values and creating the initial environment YAML file.
+
+=head3 feature
+
+Declares which feature flags this kit supports.
+
+=head3 blueprint
+
+Maps feature flags onto YAML fragment files within the kit, defining which
+files are merged and in what order to produce the deployment manifest.
+
+=head3 info
+
+Prints a kit-specific summary of a deployed environment, including IP
+addresses, certificates, passwords, and service URLs.
+
+=head3 check
+
+Performs pre-deployment validation of the environment configuration.
+
+=head3 pre-deploy
+
+Runs immediately before a BOSH deployment. May produce a data file that
+is later consumed by the C<post-deploy> hook.
+
+=head3 post-deploy
+
+Runs immediately after a BOSH deployment completes, regardless of whether
+the deployment succeeded. Receives the deployment exit code and any data
+produced by C<pre-deploy>.
+
+=head3 terminate
+
+Handles cleanup and teardown of a deployed environment.
+
+=head3 addon
+
+Executes arbitrary kit-specific operator commands. Kit authors use this
+hook to provide operators with additional tools, such as C<login> commands,
+health-check scripts, and rotation utilities.
+
+=head3 cloud-config
+
+Generates a BOSH cloud config for the deployment environment. A
+purpose-specific variant (e.g., C<cloud-config-aws>) may be used when
+the kit supports multiple IaaS types.
+
+=head3 cpi-config
+
+Generates a BOSH CPI config.
+
+=head3 features
+
+Determines and returns the list of active feature flags for an environment.
+
+=head3 runtime-config
+
+Generates or manages BOSH runtime configs for the deployment.
+
+=head3 edit
+
+Opens an editor for an environment file.
+
+=head3 shell
+
+Launches an interactive shell within the kit workspace environment.
+
+=head1 SEE ALSO
+
+L<Genesis::Kit::Compiled>, L<Genesis::Kit::Dev>, L<Genesis::Base>
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
 
 =cut

--- a/lib/Genesis/Kit.pod
+++ b/lib/Genesis/Kit.pod
@@ -8,8 +8,14 @@ Genesis::Kit - Abstract base class for all Genesis kit types.
   use Genesis::Kit::Compiled;
   use Genesis::Kit::Dev;
 
-  # Typical access through a provider:
-  my $kit = $provider->kit('cf', '2.8.0');
+  # Typical access through a provider and constructor:
+  my ($name, $ver, $file) = $provider->fetch_kit_version('cf', 'latest', '/tmp');
+  my $kit = Genesis::Kit::Compiled->new(
+      name     => $name,
+      version  => $ver,
+      archive  => $file,
+      provider => $provider,
+  );
 
   # Inspect kit identity and metadata
   print $kit->id();             # prints 'cf/2.8.0'
@@ -344,7 +350,7 @@ Key-value options. The available keys depend on which hook is being run:
 
 =item C<env>
 
-A C<Genesis::Env> object. Required for the C<new>, C<secrets>, C<info>,
+A C<Genesis::Env> object. Required for the C<new>, C<info>,
 C<addon>, C<check>, C<blueprint>, C<pre-deploy>, C<post-deploy>,
 C<cloud-config>, C<cpi-config>, C<features>, and C<terminate> hooks.
 
@@ -375,11 +381,6 @@ Used with the C<addon> hook. The name of the addon script to execute.
 
 Used with the C<addon> and C<runtime-config> hooks. An arrayref of
 arguments to pass to the hook.
-
-=item C<action>
-
-Used with the C<secrets> hook. The secrets action to perform (e.g.,
-C<"check">, C<"add">, C<"rotate">).
 
 =item C<purpose>
 
@@ -472,7 +473,7 @@ Returns an arrayref of feature flag strings.
 Returns a two-element list: a boolean success flag and the pre-deploy data
 contents (or C<undef> if no data file was produced).
 
-=item C<addon>, C<check>, C<secrets check>
+=item C<addon>, C<check>
 
 Returns a boolean: C<1> on success, C<0> on failure.
 

--- a/lib/Genesis/Kit/Compiler.pod
+++ b/lib/Genesis/Kit/Compiler.pod
@@ -646,7 +646,7 @@ The version string used in the commit message template.
 
 B<Returns:>
 
-Nothing. Exits after the interactive git commit editor closes.
+Nothing. Returns after the interactive git commit editor closes.
 
 B<Examples:>
 

--- a/lib/Genesis/Kit/Compiler.pod
+++ b/lib/Genesis/Kit/Compiler.pod
@@ -1,92 +1,676 @@
 =head1 NAME
 
-Genesis::Kit::Compiler
+Genesis::Kit::Compiler - Compile and scaffold Genesis kit source directories.
 
-=head1 DESCRIPTION
-
-The Compiler class encapsulates all of the rules and logic that go into
-compiling a kit source directory into a distributable Genesis Kit tarball.
-It includes facilities for validating the kit source, expunging files we
-don't wish to distribute (other tarballs, ci/ directories, etc.), and
-handles the naming and composition of the Kit archive.
-
-This module is fully object-oriented, and does not export any procedural
-functions or package variables.
+=head1 SYNOPSIS
 
     use Genesis::Kit::Compiler;
 
     my $cc = Genesis::Kit::Compiler->new("path/to/kit/src");
-    if (!$cc->validate) {
-      error "#R{Problems were found with your Kit source.}";
-      exit 2;
+
+    # Validate the kit source before compiling
+    if (!$cc->validate("my-kit", "1.0.0")) {
+        error "#R{Problems were found with your Kit source.}";
+        exit 2;
     }
 
-    my $v = '1.0.9';
-    $cc->compile("my-kit", , ".");
-    # file will be ./my-kit-1.0.9.tar.gz
+    # Compile to a distributable tarball
+    my $filename = $cc->compile("my-kit", "1.0.0", ".");
+    # Returns: 'my-kit-1.0.0.tar.gz'
+    # File written to: ./my-kit-1.0.0.tar.gz
+
+    # Or scaffold a new kit source directory from scratch
+    my $scaffolder = Genesis::Kit::Compiler->new("path/to/new-kit");
+    $scaffolder->scaffold("new-kit");
+
+=head1 DESCRIPTION
+
+C<Genesis::Kit::Compiler> encapsulates all of the rules and logic that go
+into compiling a kit source directory into a distributable Genesis Kit
+tarball. It includes facilities for validating the kit source, excluding
+files that should not be distributed (C<ci/> directories, C<.git/>,
+untracked files, etc.), and handles the naming and composition of the kit
+archive.
+
+It also provides a C<scaffold> method for generating a new kit source
+directory from a built-in template, giving kit authors a correct starting
+point.
+
+This module is a standalone utility. It is not a subclass of
+C<Genesis::Kit>. It does not export any procedural functions or package
+variables.
+
+B<Note:> A single C<Genesis::Kit::Compiler> instance should not be
+reused across different source directories. Several internal methods cache
+state that is only valid for the C<$root> path provided to C<new>. In
+practice this is not an issue, since Genesis uses this for the
+C<compile-kit> sub-command, which processes only one kit at a time.
 
 =head1 METHODS
 
-=head2 new($root)
+=head2 new
 
-Instantiate a new Kit Compiler, for compiling the source found in C<$root>.
+    my $cc = Genesis::Kit::Compiler->new($root);
 
-=head2 validate()
+Constructs a new kit compiler for the source directory at C<$root>. No
+filesystem operations are performed at construction time.
 
-Validate a Kit by inspecting its source code and defined metadata.
+B<Parameters:>
 
-The following validations are performed:
+=over 4
 
-=over
+=item C<$root>
 
-=item 1.
-
-All kits must have a kit.yml with valid YAML in it.
-
-=item 2.
-
-The kit.yml file must provide values for the top-level C<name>, C<author>,
-C<homepage>, and C<github> keys.
-
-=item 3.
-
-The C<hooks/> directory must exist.
-
-=item 4.
-
-Any present hooks must be executable files.
-
-=item 5.
-
-If defined, the C<genesis_min_version> value must be a valid semantic
-version.
+The path to the kit source directory to compile or scaffold.
 
 =back
 
-=head2 compile($name, $version, $outdir)
+B<Returns:>
 
-Compiles a kit source directory into a distributable tarball, of the given
-version.  Version is specified here, vs. in the kit.yml metadata, to enable
-automation of release engineering via tools like Concourse.  Compilation
-implciitly calls C<validate()> for you, so you don't need to do so
-out-of-band.
+A blessed C<Genesis::Kit::Compiler> object.
 
-The output tarball will be written to C<$outdir/$name-$version.tar.gz>, and
-will bundle all files in the archive under the relative path
-C<$name-$version/>.
+B<Examples:>
 
-=head2 scaffold($name)
+    my $cc = Genesis::Kit::Compiler->new("/home/user/cf-genesis-kit");
+    # Returns: a Genesis::Kit::Compiler object
 
-Generates a new kit source directory, populating it with (hopefully!)
-helpful scaffolding files for things like kit.yml, hooks, and manifest
-fragments.
+=head2 validate
 
-=head2 CAVEATS
+    my $ok = $cc->validate($name, $version);
 
-You cannot easily re-use one Kit Compiler to compile a different directory.
-Several internal functions cache state that is only valid for a single root
-source directory.  In practice this is not an issue, since for the most
-part Genesis just uses this for the C<compile-kit> sub-command, which only
-deals with a single Kit.
+Validates a kit source directory by inspecting its metadata, secret
+specifications, hook scripts, and Git working tree state. Prints
+descriptive error output for each problem found.
+
+As a side effect, sets an internal C<git_clean> flag on the object
+reflecting whether the working tree has uncommitted changes. The C<compile>
+method reads this flag to decide whether to update version strings in Perl
+hook files.
+
+The following checks are performed:
+
+=over 4
+
+=item 1. Root directory existence
+
+The C<$root> directory passed to C<new> must exist. If it does not, an
+error is printed and C<0> is returned immediately without further checks.
+
+=item 2. kit.yml presence and structure
+
+C<kit.yml> must exist and contain valid YAML with a map at the root. It
+must define the top-level keys C<name>, C<version>, and C<code>.
+
+=item 3. Kit name match
+
+If C<kit.yml> defines a C<name>, it must equal the C<$name> argument.
+
+=item 4. Authorship
+
+Exactly one of C<author> (scalar) or C<authors> (array) must be present.
+Both together, or neither, are errors.
+
+=item 5. Structural field types
+
+C<authors> must be an array. C<exclude_paths> must be an array when
+present. C<services> must be an array when present.
+
+=item 6. Minimum Genesis version
+
+If C<genesis_version_min> is set, it must be a valid semantic version
+(C<x.y.z>). The currently running Genesis must satisfy the minimum. An RC
+minimum version cannot be specified when compiling a non-RC kit version.
+
+=item 7. Valid top-level keys
+
+C<kit.yml> may only contain known top-level keys. The valid set depends on
+the C<secrets_store> and C<genesis_version_min> values.
+
+=item 8. Secrets specification
+
+For kits using the C<vault> secrets store (or no explicit store), all
+C<credentials>, C<certificates>, and C<provided> blocks are parsed and
+validated. Errors in the secrets plan are reported. If any error contains
+unresolved parameter references, a hint about C<ci/test_params.yml> is
+appended.
+
+=item 9. Hook scripts
+
+The C<new> and C<blueprint> hooks are required and must be present. All
+known hooks that are present must be regular files. Bash hooks must be
+executable. Perl (C<.pm>) hooks must compile without errors (checked via
+C<perl -c>).
+
+=item 10. Git working tree
+
+The Git working tree must be clean (no staged or unstaged changes).
+If uncommitted changes are found, they are listed and validation fails
+(returns C<0>). Clean the working tree via C<git stash> or C<git commit>
+before compiling.
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The expected kit name. Must match the C<name> field in C<kit.yml>.
+
+=item C<$version>
+
+The version being compiled. Used to cross-check RC constraints in
+C<genesis_version_min>.
+
+=back
+
+B<Returns:>
+
+C<1> if all checks pass, C<0> if any check fails.
+
+B<Examples:>
+
+    if ($cc->validate("cf", "2.8.0")) {
+        print "Kit source is valid\n";
+        # Returns: 1
+    } else {
+        print "Validation failed\n";
+        # Returns: 0
+    }
+
+=head2 compile
+
+    my $filename = $cc->compile($name, $version, $outdir, %opts);
+    my $filename = $cc->compile($name, $version, $outdir, force => 1);
+
+Compiles the kit source directory into a gzip-compressed tar archive and
+writes it to C<$outdir>. Validation is run implicitly before compilation.
+
+When the Git working tree is clean and C<skip-version-updates> is not set,
+the following preparatory steps are performed before archiving:
+
+=over 4
+
+=item *
+
+The C<version:> field in C<kit.yml> is updated to C<$version>.
+
+=item *
+
+The C<package> declaration line in each C<hooks/*.pm> Perl file is rewritten
+to use the correct versioned package name (e.g.,
+C<"Genesis::Hook::New::CF v2.8.0">).
+
+=item *
+
+The modified files are staged and an interactive C<git commit> editor is
+opened, pre-populated with a commit message template.
+
+=back
+
+If the working tree has uncommitted changes, or if C<skip-version-updates>
+is set, these updates are skipped with a warning.
+
+All files are collected from the source tree (see L</_select_files>) and
+bundled under a top-level directory named C<$name-$version/> inside the
+archive. Ownership metadata is normalized to a placeholder value.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The kit name (e.g., C<"cf">). Used to name the output file and the
+archive's internal base directory.
+
+=item C<$version>
+
+The version string (e.g., C<"2.8.0">). Must be a valid semantic version.
+Used in the output filename, the archive's base directory, and for updating
+version strings in Perl hooks.
+
+=item C<$outdir>
+
+The directory in which to write the output tarball.
+
+=item C<%opts>
+
+Optional key-value pairs:
+
+=over 8
+
+=item C<force>
+
+If set to a true value, compilation proceeds even when C<validate> returns
+C<0>. Defaults to false.
+
+=item C<skip-version-updates>
+
+If set to a true value, skip rewriting the version string in C<kit.yml>
+and the C<package> lines in C<hooks/*.pm>, even when the working tree is
+clean. Defaults to false.
+
+=back
+
+=back
+
+B<Returns:>
+
+The filename of the produced tarball (e.g., C<"cf-2.8.0.tar.gz">) on
+success. Returns C<undef> if C<validate> fails and C<force> is not set.
+
+B<Errors:>
+
+Dies with C<"Version %s is not semantic-compliant"> if C<$version> is not
+a valid semantic version. C<%s> is the version string provided.
+
+B<Examples:>
+
+    my $filename = $cc->compile("cf", "2.8.0", "/tmp/kits");
+    # Returns: 'cf-2.8.0.tar.gz'
+    # File written to: /tmp/kits/cf-2.8.0.tar.gz
+
+    # Force compilation even if validation finds issues
+    my $filename = $cc->compile("cf", "2.8.0", ".", force => 1);
+
+    # Skip version update commits (e.g., in CI)
+    my $filename = $cc->compile("cf", "2.8.0", ".",
+        'skip-version-updates' => 1);
+
+=head2 scaffold
+
+    $cc->scaffold($name);
+
+Generates a new kit source directory at C<$root> (the path given to
+C<new>), populating it with template files so a kit author has a working
+starting point.
+
+The following files and directories are created:
+
+=over 4
+
+=item C<.gitignore>
+
+Excludes C<*.tar.gz> from version control.
+
+=item C<kit.yml>
+
+Populated with the C<$name>, version C<0.0.1>, the Git user name and email
+from C<git config>, placeholder C<docs> and C<code> URLs, and
+C<genesis_version_min: 2.7.0>.
+
+=item C<README.md>
+
+A template README with FIXME placeholders for the kit description,
+features, params, and cloud config documentation.
+
+=item C<manifests/$name.yml>
+
+A minimal BOSH deployment manifest template with one instance group,
+standard stemcell and update blocks, and placeholder release entries.
+
+=item C<hooks/new>
+
+A Bash C<new> hook that generates an environment YAML file from
+C<genesis_config_block>.
+
+=item C<hooks/blueprint>
+
+A Bash C<blueprint> hook that assembles manifests from the C<manifests/>
+directory and optional C<features/> subdirectories.
+
+=back
+
+Both generated hook scripts are made executable (mode C<0755>).
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The kit name (e.g., C<"my-kit">). Used to name files and populate template
+content.
+
+=back
+
+B<Returns:>
+
+Nothing (returns C<undef> implicitly).
+
+B<Errors:>
+
+Dies with C<"Found a kit.yml in $self-E<gt>{root}; cowardly refusing to
+overwrite an existing kit."> if C<kit.yml> already exists in C<$root>.
+
+B<Examples:>
+
+    my $cc = Genesis::Kit::Compiler->new("/home/user/my-kit");
+    $cc->scaffold("my-kit");
+    # Creates: /home/user/my-kit/kit.yml
+    # Creates: /home/user/my-kit/README.md
+    # Creates: /home/user/my-kit/manifests/my-kit.yml
+    # Creates: /home/user/my-kit/hooks/new
+    # Creates: /home/user/my-kit/hooks/blueprint
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _lookup_test_params
+
+    $cc->_lookup_test_params($key, $default)
+
+Looks up a parameter value from C<ci/test_params.yml> in the kit source
+directory. Used as a callback by C<validate> when dereferencing kit
+metadata parameter substitutions during secrets plan validation.
+
+The file is loaded once and cached on the object. If the file does not
+exist, an empty hash is used and parameter lookups return the provided
+C<$default>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$key>
+
+The dotted-path key to look up in the test params structure.
+
+=item C<$default>
+
+The default value to return if the key is not found.
+
+=back
+
+B<Returns:>
+
+The value found in C<ci/test_params.yml> for C<$key>, or C<$default> if
+the key is absent or the file does not exist.
+
+B<Examples:>
+
+    # Called internally by validate() as a dereference callback.
+    # Given ci/test_params.yml containing:
+    #   network: 10.0.0.0/24
+    my $val = $cc->_lookup_test_params("network", "10.0.0.1/32");
+    # Returns: '10.0.0.0/24'
+
+    my $val = $cc->_lookup_test_params("missing_key", "default_value");
+    # Returns: 'default_value'
+
+=head2 _select_files
+
+    my @files = $cc->_select_files();
+
+Builds the list of files to include in the compiled tarball. Operates
+within the C<$root> directory.
+
+Always excludes: C<ci/>, C<.git/>, C<.gitignore>, C<spec/>, C<devtools/>,
+and any additional paths listed in C<kit.yml>'s C<exclude_paths> array.
+Also excludes any files that Git would remove via C<git clean -xdn>
+(untracked and ignored files). Paths that escape the kit root via C<../> in
+C<exclude_paths> are silently skipped.
+
+B<Returns:>
+
+A list of relative file paths (without leading C<./>) to include in the
+archive.
+
+=head2 _update_hook_packages
+
+    $cc->_update_hook_packages($name, $version)
+
+Rewrites the C<package> declaration line in each C<*.pm> file under
+C<hooks/> to use the correct versioned package name for the kit.
+
+Package names are generated by L</_generate_package_name>. The version
+component is extracted as a bare semantic version (without pre-release
+suffix) for the C<vX.Y.Z> version declaration; any pre-release suffix is
+appended as a comment.
+
+Does nothing if the C<hooks/> directory does not exist or contains no
+C<.pm> files.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The kit name. Used by C<_to_camel_case> to derive the kit type identifier.
+
+=item C<$version>
+
+The version string. Used to construct the versioned C<package> line.
+
+=back
+
+B<Returns:>
+
+Nothing.
+
+B<Examples:>
+
+    # Called internally by compile() when the working tree is clean.
+    # Rewrites package lines in hooks/*.pm for kit 'cf' version '2.8.0'.
+    $cc->_update_hook_packages("cf", "2.8.0");
+    # Returns: nothing (void method, rewrites hooks/*.pm in-place)
+
+=head2 _to_camel_case
+
+    my $camel = $cc->_to_camel_case($name)
+
+Converts a hyphen-separated kit name into a CamelCase identifier for use
+in Perl package names. Applies special-case mappings for known acronyms:
+C<cf> becomes C<CF>, C<bosh> becomes C<BOSH>. All other parts are
+capitalized with C<ucfirst(lc(...))>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+A hyphen-separated name string (e.g., C<"cf-rabbitmq">).
+
+=back
+
+B<Returns:>
+
+A CamelCase string (e.g., C<"CFRabbitmq">).
+
+B<Examples:>
+
+    $cc->_to_camel_case("cf");          # Returns: 'CF'
+    $cc->_to_camel_case("bosh");        # Returns: 'BOSH'
+    $cc->_to_camel_case("rabbitmq");    # Returns: 'Rabbitmq'
+    $cc->_to_camel_case("cf-rabbitmq"); # Returns: 'CFRabbitmq'
+
+=head2 _generate_package_name
+
+    my $pkg = $cc->_generate_package_name($filename, $kit_type)
+
+Generates the Perl package name for a given hook file. The naming
+convention depends on whether the hook is a regular hook or an addon hook:
+
+=over 4
+
+=item Regular hooks
+
+Package follows the pattern C<"Genesis::Hook::HookName::KitType">
+(e.g., C<"Genesis::Hook::New::CF">).
+
+=item Addon hooks
+
+Files matching C<addon-NAME.pm> produce a package following
+C<"Genesis::Hook::Addon::KitType::AddonName">
+(e.g., C<"Genesis::Hook::Addon::CF::BindAutoscaler">).
+
+=back
+
+Any tilde shortcut suffix in the filename (e.g., C<addon-bind-autoscaler~ba>)
+is stripped before processing.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$filename>
+
+The hook filename without the C<.pm> extension.
+
+=item C<$kit_type>
+
+The CamelCase kit type identifier, as produced by L</_to_camel_case>.
+
+=back
+
+B<Returns:>
+
+A fully qualified Perl package name string.
+
+B<Examples:>
+
+    $cc->_generate_package_name("new",   "CF");
+    # Returns: 'Genesis::Hook::New::CF'
+
+    $cc->_generate_package_name("blueprint", "BOSH");
+    # Returns: 'Genesis::Hook::Blueprint::BOSH'
+
+    $cc->_generate_package_name("addon-rabbitmq", "CF");
+    # Returns: 'Genesis::Hook::Addon::CF::Rabbitmq'
+
+    # Tilde shortcut suffix is stripped before processing
+    $cc->_generate_package_name("addon-bind-autoscaler~ba", "CF");
+    # Returns: 'Genesis::Hook::Addon::CF::BindAutoscaler'
+
+=head2 _update_package_line
+
+    my $changed = $cc->_update_package_line($hook_file, $new_package_line)
+
+Reads the file at C<$hook_file>, finds the first line matching
+C</^package\s+/>, and replaces it with C<$new_package_line> if the line
+has changed. Writes the file back only when a change is made.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$hook_file>
+
+The absolute path to the Perl hook file to update.
+
+=item C<$new_package_line>
+
+The replacement C<package> declaration line (without trailing newline).
+
+=back
+
+B<Returns:>
+
+C<1> if the file was updated, C<0> if no change was needed or the file
+could not be opened.
+
+B<Examples:>
+
+    my $changed = $cc->_update_package_line(
+        "/path/to/hooks/new.pm",
+        "package Genesis::Hook::New::CF v2.8.0",
+    );
+    # Returns: 1  (file was updated)
+
+    # No-op when the package line already matches
+    my $changed = $cc->_update_package_line(
+        "/path/to/hooks/new.pm",
+        "package Genesis::Hook::New::CF v2.8.0",
+    );
+    # Returns: 0  (no change needed)
+
+=head2 _update_version
+
+    $cc->_update_version($version)
+
+Reads C<kit.yml> from C<$root> and rewrites the C<version:> line to
+C<$version>. The updated content is written back to the same file.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$version>
+
+The version string to write into C<kit.yml>.
+
+=back
+
+B<Returns:>
+
+Nothing.
+
+B<Examples:>
+
+    # Updates 'version: 0.0.1' to 'version: 2.8.0' in kit.yml
+    $cc->_update_version("2.8.0");
+    # kit.yml now contains: version: 2.8.0
+
+=head2 _prepare_hook_commit
+
+    $cc->_prepare_hook_commit($version)
+
+Stages C<kit.yml> and all C<hooks/*.pm> files via C<git add>, then opens
+an interactive C<git commit> editor pre-populated with a commit message
+template. The template reads:
+
+    Update for release v$version
+
+    Updated kit version and perl hook packages
+
+The commit editor is opened using C<git commit --edit --file>, allowing
+the developer to review and adjust the message before committing. A
+temporary file holding the message template is cleaned up after the editor
+exits.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$version>
+
+The version string used in the commit message template.
+
+=back
+
+B<Returns:>
+
+Nothing. Exits after the interactive git commit editor closes.
+
+B<Examples:>
+
+    # Called internally by compile() after _update_version and
+    # _update_hook_packages have staged their changes.
+    $cc->_prepare_hook_commit("2.8.0");
+    # prints: Updated version and package versions in perl hook files to v2.8.0.
+    # prints: Changes have been staged. Opening git commit editor...
+    # Opens: interactive git commit editor with pre-populated message
+
+=head1 CAVEATS
+
+A single C<Genesis::Kit::Compiler> object should not be reused to compile
+multiple source directories. The C<_lookup_test_params> method caches the
+loaded C<ci/test_params.yml> content on the object. Similarly, C<validate>
+sets C<git_clean> state that is consumed by C<compile>. Create a new
+instance for each distinct kit source directory.
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
 
 =cut

--- a/lib/Genesis/Kit/Dev.pod
+++ b/lib/Genesis/Kit/Dev.pod
@@ -1,50 +1,242 @@
 =head1 NAME
 
-Genesis::Kit::Dev
+Genesis::Kit::Dev - A Genesis kit loaded directly from a C<dev/> directory on disk.
+
+=head1 SYNOPSIS
+
+  use Genesis::Kit::Dev;
+
+  # Construct from a dev kit directory
+  my $kit = Genesis::Kit::Dev->new('/path/to/deployment/dev');
+
+  print $kit->id();      # prints 'my-kit/1.0.0 (dev)'
+  print $kit->name();    # prints 'dev'
+  print $kit->version(); # prints 'latest'
+  print $kit->is_dev();  # prints '1'
+
+  # Extract to a temporary workspace before accessing kit contents
+  $kit->extract();
+  my $hook_path = $kit->path('hooks/blueprint');
 
 =head1 DESCRIPTION
 
-This class represents a "dev" kit, one that exist as a directory on-disk,
-and not as a compiled tarball archive.  Kit authors use dev kits whenever
-they are updating or modifying kits, and operators may opt to use dev kits
-if they are experimenting, or working outside the capabilities of existing
-kits.
+C<Genesis::Kit::Dev> represents a Genesis kit that lives as a directory on
+disk rather than as a compiled tarball archive. Kit authors use dev kits
+when iterating on kit code: the kit is loaded directly from the C<dev/>
+directory in the deployment root, so changes take effect immediately without
+a compile step.
 
-=head1 CONSTRUCTORS
+Operators may also use dev kits when experimenting with kit modifications or
+working outside the capabilities of published kit releases.
 
-=head2 new($path)
-
-Instantiates a new dev kit, using source files in C<$path>.
-
+This class inherits from L<Genesis::Kit>, which provides methods such as
+C<path>, C<glob>, C<has_hook>, C<metadata>, and C<known_hooks>.
+Inherited methods are not re-documented here; see L<Genesis::Kit> for
+details.
 
 =head1 METHODS
 
-=head2 id()
+=head2 new
 
-Returns the identity of the dev kit, which is always C<(dev kit)>.  This is
-useful for error messages and reporting.
+  my $kit = Genesis::Kit::Dev->new($path);
 
-=head2 name()
+Creates a new C<Genesis::Kit::Dev> object backed by the kit sources at
+C<$path>. No validation of the directory contents is performed at
+construction time; the directory is read when C<extract> is first called.
 
-Returns the name of the dev kit, which is always C<dev>.
+B<Parameters:>
 
-=head2 version()
+=over 4
 
-Returns the version of the dev kit, which is always C<latest>.
+=item C<$path>
 
-=head2 kit_bug($fmt, ...)
+The path to the C<dev/> kit directory. This is typically an absolute path
+to the C<dev/> subdirectory inside a Genesis deployment repository (e.g.,
+C<"/path/to/my-deployment/dev">).
 
-Prints an error to the screen, complete with details about how the problem
-at hand is a problem with the (local) development kit.
+=back
 
-=head2 extract()
+B<Returns:>
 
-Copies the contents of the dev/ working directory to a temporary workspace,
-and installs the Genesis hooks helper script.  The copy is done to avoid
-accidental modifications to pristine dev kit sources, and to ensure that we
-can safely write the hooks helper.
+A blessed C<Genesis::Kit::Dev> object.
 
-This method is memoized; subsequent calls to C<extract> will not re-copy the
-dev/ working directory to the temporary workspace.
+B<Examples:>
+
+  my $kit = Genesis::Kit::Dev->new('/home/user/deployments/cf/dev');
+  print $kit->name();    # prints 'dev'
+  print $kit->version(); # prints 'latest'
+
+=head2 id
+
+  my $id = $kit->id();
+
+Returns the identity string for this dev kit. The string is formed from
+the C<name> and C<version> fields in C<kit.yml>, with C<(dev)> appended
+to distinguish it from compiled kits. If the metadata fields are missing
+they default to C<unknown> and C<in-development> respectively.
+
+B<Returns:>
+
+A string of the form C<"$name/$version (dev)">, for example
+C<"cf/2.8.0 (dev)">. When metadata is unavailable, returns
+C<"unknown/in-development (dev)">.
+
+B<Examples:>
+
+  my $kit = Genesis::Kit::Dev->new('/path/to/dev');
+  print $kit->id();
+  # Returns: 'cf/2.8.0 (dev)'
+
+=head2 name
+
+  my $name = $kit->name();
+
+Returns the name of this dev kit. Always returns the string C<"dev">,
+regardless of the kit's actual name in C<kit.yml>.
+
+B<Returns:>
+
+The string C<"dev">.
+
+B<Examples:>
+
+  print $kit->name();
+  # Returns: 'dev'
+
+=head2 version
+
+  my $version = $kit->version();
+
+Returns the version of this dev kit. Always returns the string C<"latest">,
+regardless of the version declared in C<kit.yml>.
+
+B<Returns:>
+
+The string C<"latest">.
+
+B<Examples:>
+
+  print $kit->version();
+  # Returns: 'latest'
+
+=head2 is_dev
+
+  my $bool = $kit->is_dev();
+
+Returns a true value indicating that this is a dev kit. This overrides
+the C<is_dev> method from L<Genesis::Kit>, which returns C<0>.
+
+B<Returns:>
+
+C<1>.
+
+B<Examples:>
+
+  print $kit->is_dev();
+  # Returns: 1
+
+  # Distinguish dev kits from compiled kits:
+  if ($kit->is_dev()) {
+      print "Running from dev/ directory\n";
+  }
+
+=head2 kit_bug
+
+  $kit->kit_bug(@msg);
+
+Reports a bug in the dev kit and terminates the process. This method is
+intended to be called when the kit behaves in a way that indicates a defect
+in the kit author's code rather than an operator configuration error.
+
+C<@msg> is passed to C<csprintf>, which treats the first element as a
+format string and the remaining elements as arguments. C<csprintf> supports
+ANSI color markup and standard C<sprintf> conversion specifiers.
+
+After the formatted message, the output always includes:
+
+  This is a bug in your dev/ kit.
+  Please contact the author(s):
+    - you
+
+The method always dies (throws an exception via C<die>). Before dying,
+C<$!> is set to 2 (C<ENOENT>). Callers that wrap this in an C<eval> block
+can inspect C<$!> to distinguish kit bugs from other fatal errors.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@msg>
+
+A list whose first element is a C<csprintf>-compatible format string and
+whose remaining elements are arguments interpolated into that string. May
+contain ANSI color markup and standard C<sprintf> conversion specifiers.
+
+=back
+
+B<Returns:>
+
+Does not return. Always dies. Sets C<$!> to 2 before dying.
+
+B<Examples:>
+
+  # In a hook, signal an unexpected state in the dev kit
+  $kit->kit_bug("Unexpected feature flag '%s' encountered", $flag);
+  # prints and dies with:
+  #   Unexpected feature flag 'unknown-feature' encountered
+  #   This is a bug in your dev/ kit.
+  #   Please contact the author(s):
+  #     - you
+
+=head2 extract
+
+  $kit->extract();
+
+Copies the contents of the C<dev/> working directory to a temporary
+workspace and installs the Genesis hooks helper script. The copy is
+performed so that hook execution cannot accidentally modify the developer's
+source files, and to ensure a safe location for writing the helper.
+
+After extraction, the inherited methods C<path>, C<glob>, C<has_hook>, and
+all hook execution methods become operational.
+
+This method is memoized: the first call performs the copy and records the
+workspace path on the object. Subsequent calls return immediately without
+re-copying.
+
+Modifies the object in-place by setting the internal C<root> field on
+first call.
+
+B<Returns:>
+
+Returns C<1> on the first call (copy performed). Returns nothing (an empty
+return) on subsequent calls when the kit has already been extracted.
+
+B<Errors:>
+
+Dies with C<"Could not copy dev/ kit directory"> if the C<cp> command fails
+to copy the directory contents to the temporary workspace.
+
+B<Examples:>
+
+  $kit->extract();
+  my $hook = $kit->path('hooks/blueprint');
+  # $hook is now a valid filesystem path inside the temporary workspace
+
+  # Subsequent calls are safe and do nothing:
+  $kit->extract();
+  $kit->extract();
+
+=head1 SEE ALSO
+
+L<Genesis::Kit>, L<Genesis::Kit::Compiled>
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
 
 =cut

--- a/lib/Genesis/Kit/Provider.pod
+++ b/lib/Genesis/Kit/Provider.pod
@@ -7,9 +7,9 @@ Genesis::Kit::Provider - Abstract base class and factory for Genesis kit provide
   use Genesis::Kit::Provider;
 
   # Create a provider via the factory (dispatches to the appropriate subclass)
-  my $provider = Genesis::Kit::Provider->new(type => 'genesis-community');
+  my $provider = Genesis::Kit::Provider->new(type => 'genesis_community');
   my $provider = Genesis::Kit::Provider->new(type => 'github',
-      owner => 'myorg',
+      organization => 'myorg',
   );
 
   # Create a provider from CLI options parsed by parse_opts
@@ -100,7 +100,7 @@ B<Examples:>
   print ref($p); # prints 'Genesis::Kit::Provider::GenesisCommunity'
 
   # GitHub provider
-  my $p = Genesis::Kit::Provider->new(type => 'github', owner => 'myorg');
+  my $p = Genesis::Kit::Provider->new(type => 'github', organization => 'myorg');
   print ref($p); # prints 'Genesis::Kit::Provider::Github'
 
 =head2 init
@@ -129,7 +129,7 @@ immediately.
 
 Optional. The provider type string. Recognised values are C<"genesis-community">
 (the default when this key is absent) and C<"github">. Additional keys required
-by the specific provider (e.g., C<kit-provider-github-owner>) must also be
+by the specific provider (e.g., C<kit-provider-org>) must also be
 present in C<%opts>; they are forwarded to the subclass's C<init()>.
 
 =back
@@ -302,11 +302,11 @@ provider.
 
 B<Examples:>
 
-  my @args = ('--kit-provider', 'github', '--kit-provider-github-owner', 'myorg', 'deploy');
+  my @args = ('--kit-provider', 'github', '--kit-provider-org', 'myorg', 'deploy');
   my %kit_opts;
   Genesis::Kit::Provider->parse_opts(\@args, \%kit_opts);
   # @args is now ('deploy')
-  # %kit_opts is ('kit-provider' => 'github', 'kit-provider-github-owner' => 'myorg')
+  # %kit_opts is ('kit-provider' => 'github', 'kit-provider-org' => 'myorg')
   # Returns: 1
 
 =head2 label

--- a/lib/Genesis/Kit/Provider.pod
+++ b/lib/Genesis/Kit/Provider.pod
@@ -1,88 +1,789 @@
 =head1 NAME
 
-Genesis::Kit::Provider
+Genesis::Kit::Provider - Abstract base class and factory for Genesis kit providers
+
+=head1 SYNOPSIS
+
+  use Genesis::Kit::Provider;
+
+  # Create a provider via the factory (dispatches to the appropriate subclass)
+  my $provider = Genesis::Kit::Provider->new(type => 'genesis-community');
+  my $provider = Genesis::Kit::Provider->new(type => 'github',
+      owner => 'myorg',
+  );
+
+  # Create a provider from CLI options parsed by parse_opts
+  my %kit_opts;
+  Genesis::Kit::Provider->parse_opts(\@ARGV, \%kit_opts);
+  my $provider = Genesis::Kit::Provider->init(%kit_opts);
+
+  # Get the default provider (Genesis Community)
+  my $provider = Genesis::Kit::Provider->default_provider();
+
+  # Retrieve kit names and versions
+  my @names    = $provider->kit_names();
+  my @versions = $provider->kit_versions('cf');
+
+  # Fetch the latest tarball for a kit
+  my ($name, $version, $path) = $provider->fetch_kit_version('cf', 'latest', '/tmp');
 
 =head1 DESCRIPTION
 
-This class represents a Genesis Kit Provider.  This provider knows how to list
-and fetch kits and their versions provided by that provider.
+C<Genesis::Kit::Provider> is the abstract base class for all kit provider
+implementations. It defines the interface that every provider must satisfy and
+acts as a factory: calling C<new()> or C<init()> on C<Genesis::Kit::Provider>
+directly returns an instance of the appropriate concrete subclass rather than
+of C<Genesis::Kit::Provider> itself.
 
-=head1 CONSTRUCTORS
+A kit provider knows how to enumerate kits, list their available versions, and
+download tarballs (both compiled archives and source archives). Providers differ
+in where kits are hosted: the default provider, L<Genesis::Kit::Provider::GenesisCommunity>,
+retrieves kits from the Genesis Community GitHub organisation, while
+L<Genesis::Kit::Provider::Github> retrieves kits from any arbitrary GitHub
+repository.
 
-=head2 new($path)
-
-Instantiates a new dev kit, using source files in C<$path>.
-
-=head2 downloadable($filter)
-
-Lists the known downloadable compiled kits on the Genesis Community Github
-organization.  If a filter is given, it will be used to limit the kit names to
-match that filter as a regular expression.
-
-An error will be thrown if it cannot reach the github api endpoint for
-genesis-community organization, if the response is not valid JSON, or for
-any other communication error.
-
-=head2 releases($name)
-
-Returns the list of releases for a given repository under the Genesis Community
-Github organization.  This is the full response from Github, converted from
-JSON, and includes all the information for all releases under the given
-repository.  This is primarily a low-level function for C<url> and C<versions>
-
-An error will be thrown if it cannot reach the github api endpoint for
-genesis-community organization, if the repository does not exist,  if the
-response is not valid JSON, or for any other communication error.
-
-=head2 versions($name)
-
-Returns a hash of tag,name,draft,prerelease,body and timestamp for each version
-for the named repository under the Genesis Community Github organization.
-
-An error will be thrown if it cannot reach the github api endpoint for
-genesis-community organization, if the repository does not exist,  if the
-response is not valid JSON, or for any other communication error.
-
-=head2 url($name, $version)
-
-Determines the download URL for this kit, by consulting Github.
-Right now, this is limited to just the C<genesis-community> organization.
-
-If you omit C<$version>, or set it to "latest", the most recent released
-version on Github will be used.  Otherwise, the URL for the given version
-will be used.
-
-An error will be thrown if the version in question does not exist on Github.
-
+Concrete provider subclasses must implement the following abstract methods:
+C<config>, C<check>, C<kit_names>, C<kit_releases>, C<kit_versions>,
+C<fetch_kit_version>, and C<fetch_kit_version_src>. Calling any of these on
+the base class directly triggers a C<bug()> and terminates the process.
 
 =head1 METHODS
 
-=head2 id()
+=head2 new
 
-Returns the identity of the dev kit, which is always C<(dev kit)>.  This is
-useful for error messages and reporting.
+  my $provider = Genesis::Kit::Provider->new(%config);
 
-=head2 name()
+Factory constructor. Inspects C<%config> to determine which concrete provider
+class to instantiate and delegates to that class's C<new()>.
 
-Returns the name of the dev kit, which is always C<dev>.
+Must be called on C<Genesis::Kit::Provider> itself, never on a subclass.
+Calling it on a subclass triggers an internal C<bug()>.
 
-=head2 version()
+B<Parameters:>
 
-Returns the version of the dev kit, which is always C<latest>.
+=over 4
 
-=head2 kit_bug($fmt, ...)
+=item C<type>
 
-Prints an error to the screen, complete with details about how the problem
-at hand is a problem with the (local) development kit.
+The provider type. Recognised values are C<"genesis_community"> and
+C<"github">. When C<type> is absent or set to C<"genesis_community">, a
+L<Genesis::Kit::Provider::GenesisCommunity> instance is returned. When set to
+C<"github">, a L<Genesis::Kit::Provider::Github> instance is returned.
+Additional keys in C<%config> are forwarded to the subclass constructor.
 
-=head2 extract()
+=back
 
-Copies the contents of the dev/ working directory to a temporary workspace,
-and installs the Genesis hooks helper script.  The copy is done to avoid
-accidental modifications to pristine dev kit sources, and to ensure that we
-can safely write the hooks helper.
+B<Returns:>
 
-This method is memoized; subsequent calls to C<extract> will not re-copy the
-dev/ working directory to the temporary workspace.
+An instance of the appropriate L<Genesis::Kit::Provider> subclass.
+
+B<Errors:>
+
+=over 4
+
+=item C<"%s->new is calling %s->new illegally">
+
+Thrown internally via C<bug()> when this method is called on a subclass
+instead of directly on C<Genesis::Kit::Provider>. The two C<%s> placeholders
+are the calling class and C<Genesis::Kit::Provider>, respectively.
+
+=item C<"Unknown kit provider type '$config{type}'">
+
+Thrown when C<type> is present but does not match any known provider.
+
+=back
+
+B<Examples:>
+
+  # Default (Genesis Community) provider
+  my $p = Genesis::Kit::Provider->new();
+  print ref($p); # prints 'Genesis::Kit::Provider::GenesisCommunity'
+
+  # GitHub provider
+  my $p = Genesis::Kit::Provider->new(type => 'github', owner => 'myorg');
+  print ref($p); # prints 'Genesis::Kit::Provider::Github'
+
+=head2 init
+
+  my $provider = Genesis::Kit::Provider->init(%opts);
+
+Factory constructor that builds a provider from CLI option hashes (as
+produced by C<parse_opts()>). Supports loading provider configuration from
+an existing Genesis deployment repository or a YAML/JSON file.
+
+Must be called on C<Genesis::Kit::Provider> itself, never on a subclass.
+
+B<Parameters:>
+
+=over 4
+
+=item C<kit-provider-config>
+
+Optional. Path to either an existing Genesis deployment repository (a
+directory containing C<.genesis/config>) or a YAML/JSON file describing
+provider configuration. When this key is present it takes precedence over all
+other keys: the provider is loaded from the repository or file and returned
+immediately.
+
+=item C<kit-provider>
+
+Optional. The provider type string. Recognised values are C<"genesis-community">
+(the default when this key is absent) and C<"github">. Additional keys required
+by the specific provider (e.g., C<kit-provider-github-owner>) must also be
+present in C<%opts>; they are forwarded to the subclass's C<init()>.
+
+=back
+
+B<Returns:>
+
+An instance of the appropriate L<Genesis::Kit::Provider> subclass.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Unable to read kit-provider config: expecting either a Genesis deployment repo or a YAML/JSON file">
+
+Thrown when C<kit-provider-config> is set but the path does not match any
+recognised format (neither a Genesis repo directory nor an existing file).
+
+=item C<"Unknown kit provider type '$opts{'kit-provider'}'">
+
+Thrown when C<kit-provider> is set but does not match any known provider.
+
+=back
+
+B<Examples:>
+
+  # From a YAML config file
+  my $p = Genesis::Kit::Provider->init('kit-provider-config' => '/path/to/config.yml');
+
+  # Genesis Community provider (default)
+  my $p = Genesis::Kit::Provider->init();
+  print ref($p); # prints 'Genesis::Kit::Provider::GenesisCommunity'
+
+  # GitHub provider
+  my $p = Genesis::Kit::Provider->init('kit-provider' => 'github');
+  print ref($p); # prints 'Genesis::Kit::Provider::Github'
+
+=head2 default_provider
+
+  my $provider = Genesis::Kit::Provider->default_provider();
+
+Returns a new instance of L<Genesis::Kit::Provider::GenesisCommunity>
+constructed with no arguments. This is the default provider used when no
+provider configuration is specified.
+
+B<Returns:>
+
+A L<Genesis::Kit::Provider::GenesisCommunity> instance.
+
+B<Examples:>
+
+  my $p = Genesis::Kit::Provider->default_provider();
+  print ref($p); # prints 'Genesis::Kit::Provider::GenesisCommunity'
+
+=head2 opts
+
+  my @option_specs = Genesis::Kit::Provider->opts();
+
+Returns the list of option specification strings (in C<GetOptions> format)
+that the base provider accepts. The base class returns an empty list;
+subclasses override this method to advertise their own CLI options.
+
+B<Returns:>
+
+A list of option specification strings in C<GetOptions> format. Returns an
+empty list for the base class.
+
+B<Examples:>
+
+  my @specs = Genesis::Kit::Provider->opts();
+  # Returns: () for the base class
+
+=head2 opts_help
+
+  my $text = Genesis::Kit::Provider->opts_help(%config);
+
+Returns a multi-line help string that describes all kit provider options,
+including the general C<--kit-provider> and C<--kit-provider-config>
+options as well as the provider-specific options from all known subclasses.
+
+Must be called on C<Genesis::Kit::Provider> itself, never on a subclass.
+
+B<Parameters:>
+
+=over 4
+
+=item C<type_default_msg>
+
+Optional string appended to the C<--kit-provider> option description as the
+default-value annotation. Defaults to C<'(optional, defaults to "genesis-community")'>.
+
+=item C<valid_types>
+
+Optional arrayref of valid type name strings shown in provider-specific help
+sections. Defaults to C<['genesis-community', 'github']>.
+
+=back
+
+B<Returns:>
+
+A multi-line string containing the full kit provider help text, suitable for
+inclusion in a command's usage output.
+
+B<Errors:>
+
+=over 4
+
+=item C<"%s->new is calling %s->new illegally">
+
+Thrown internally via C<bug()> when this method is called on a subclass
+instead of directly on C<Genesis::Kit::Provider>. The two C<%s> placeholders
+are the calling class and C<Genesis::Kit::Provider>, respectively.
+
+=back
+
+B<Examples:>
+
+  print Genesis::Kit::Provider->opts_help();
+  # prints:
+  #   KIT PROVIDERS
+  #   ...
+  #   --kit-provider <type> (optional, defaults to "genesis-community")
+  #   ...
+
+=head2 parse_opts
+
+  Genesis::Kit::Provider->parse_opts(\@args, \%kit_opts);
+
+Parses kit-provider-related CLI options from C<@args> into C<%kit_opts>.
+Processing stops at C<--> to preserve positional argument boundaries.
+Non-kit-provider arguments that are consumed but not recognized are pushed
+back onto C<@args>.
+
+First extracts C<--kit-provider> to determine which subclass to use, then
+invokes that subclass's C<opts()> to obtain the provider-specific option
+specs and parses those as well. Modifies C<@args> in-place by removing all
+recognized options and leaving unrecognized arguments in place.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$args>
+
+An arrayref of raw command-line argument strings. Modified in-place: all
+consumed option tokens are removed and unrecognized tokens are returned to the
+beginning of the array.
+
+=item C<%kit_opts>
+
+A hashref into which parsed option values are written. Keys use
+C<GetOptions> naming conventions (e.g., C<kit-provider>,
+C<kit-provider-config>).
+
+=back
+
+B<Returns:>
+
+C<1> on success.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Unknown kit provider type '$type'">
+
+Thrown when C<--kit-provider> is present but does not match any known
+provider.
+
+=back
+
+B<Examples:>
+
+  my @args = ('--kit-provider', 'github', '--kit-provider-github-owner', 'myorg', 'deploy');
+  my %kit_opts;
+  Genesis::Kit::Provider->parse_opts(\@args, \%kit_opts);
+  # @args is now ('deploy')
+  # %kit_opts is ('kit-provider' => 'github', 'kit-provider-github-owner' => 'myorg')
+  # Returns: 1
+
+=head2 label
+
+  my $label = $provider->label();
+
+Returns the human-readable label for this provider instance, as stored in
+C<< $provider->{label} >> by the subclass constructor.
+
+B<Returns:>
+
+A string label identifying the provider, or C<undef> if none was set.
+
+B<Examples:>
+
+  print $provider->label(); # prints e.g. 'Genesis Community'
+
+=head2 config
+
+  my %config = $provider->config();
+
+Abstract method. Returns the configuration hash for this provider. The
+returned hash contains the key-value pairs that would be passed to C<new()>
+to recreate an equivalent provider object.
+
+Subclasses B<must> implement this method. Calling it on the base class
+terminates the process via C<bug()>.
+
+B<Returns:>
+
+A hash of configuration items.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Abstract Method: Expecting %s class to define concrete '%' method">
+
+Thrown via C<bug()> when called on the base class. The first C<%s> is the
+class name and C<'%'> is the method name C<config>.
+
+=back
+
+B<Examples:>
+
+  # On a concrete subclass instance:
+  my %config = $provider->config();
+  # Returns: e.g. (type => 'genesis-community')
+
+=head2 check
+
+  my $error = $provider->check();
+
+Abstract method. Tests whether this provider is reachable and operational.
+
+Subclasses B<must> implement this method. Calling it on the base class
+terminates the process via C<bug()>.
+
+B<Returns:>
+
+An error message string if the provider is unavailable, or C<undef>/empty
+string if the provider is accessible.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Abstract Method: Expecting %s class to define concrete '%' method">
+
+Thrown via C<bug()> when called on the base class. The first C<%s> is the
+class name and C<'%'> is the method name C<config>.
+
+=back
+
+B<Examples:>
+
+  my $err = $provider->check();
+  # Returns: undef or empty string if reachable, error message if not
+  if ($err) {
+      die "Provider unavailable: $err\n";
+  }
+
+=head2 kit_names
+
+  my @names = $provider->kit_names($filter);
+
+Abstract method. Returns the list of kit names available from this provider.
+Pass C<undef> or omit C<$filter> to retrieve all kit names.
+
+Subclasses B<must> implement this method. Calling it on the base class
+terminates the process via C<bug()>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$filter>
+
+Optional regular expression string. When provided, only kit names matching
+the expression are returned.
+
+=back
+
+B<Returns:>
+
+A list of kit name strings. Names do not include the C<-genesis-kit> suffix.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Abstract Method: Expecting %s class to define concrete '%' method">
+
+Thrown via C<bug()> when called on the base class. The first C<%s> is the
+class name and C<'%'> is the method name C<kits>.
+
+=back
+
+B<Examples:>
+
+  my @names = $provider->kit_names(undef);
+  # Returns: ('bosh', 'cf', 'concourse', ...)
+
+  my @cf_names = $provider->kit_names('^cf');
+  # Returns: ('cf',)
+
+=head2 kit_releases
+
+  my @releases = $provider->kit_releases($name);
+
+Abstract method. Returns the raw list of release objects for the named kit.
+The structure of each release object is determined by the concrete provider
+subclass.
+
+Subclasses B<must> implement this method. Calling it on the base class
+terminates the process via C<bug()>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The kit name to retrieve releases for (e.g., C<'cf'>).
+
+=back
+
+B<Returns:>
+
+A list of provider-specific release objects.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Abstract Method: Expecting %s class to define concrete '%' method">
+
+Thrown via C<bug()> when called on the base class. The first C<%s> is the
+class name and C<'%'> is the method name C<kit_releases>.
+
+=back
+
+B<Examples:>
+
+  my @releases = $provider->kit_releases('cf');
+  # Returns: list of release objects (structure depends on provider subclass)
+
+=head2 kit_versions
+
+  my @versions = $provider->kit_versions($name, %opts);
+
+Abstract method. Returns version information records for the named kit,
+optionally filtered or limited by C<%opts>.
+
+Subclasses B<must> implement this method. Calling it on the base class
+terminates the process via C<bug()>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The kit name to retrieve versions for (e.g., C<'cf'>).
+
+=item C<draft>
+
+Optional boolean. When true, include draft releases in the results.
+
+=item C<prerelease>
+
+Optional boolean. When true, include pre-release versions in the results.
+
+=item C<latest>
+
+Optional integer. When set, return only the N most recent versions in
+descending version order.
+
+=item C<version>
+
+Optional string. When set, return information for that specific version only.
+
+=back
+
+B<Returns:>
+
+A list of hashrefs. Each hashref contains at minimum:
+
+=over 4
+
+=item * C<version> - the semver version string
+
+=item * C<body> - the release notes text
+
+=item * C<draft> - boolean, true if this is a draft release
+
+=item * C<prerelease> - boolean, true if this is a pre-release
+
+=item * C<date> - the release creation date
+
+=item * C<url> - optional download URL
+
+=back
+
+B<Errors:>
+
+=over 4
+
+=item C<"Abstract Method: Expecting %s class to define concrete '%' method">
+
+Thrown via C<bug()> when called on the base class. The first C<%s> is the
+class name and C<'%'> is the method name C<kit_versions>.
+
+=back
+
+B<Examples:>
+
+  my @versions = $provider->kit_versions('cf');
+  for my $v (@versions) {
+      printf "  %s (%s)\n", $v->{version}, $v->{date};
+  }
+  # prints e.g.:
+  #   2.8.0 (2024-01-15)
+  #   2.7.1 (2023-11-02)
+
+=head2 fetch_kit_version
+
+  my ($name, $version, $file) = $provider->fetch_kit_version($name, $version, $path, $force);
+
+Abstract method. Downloads the compiled kit tarball for the named kit and
+version to the specified directory.
+
+Subclasses B<must> implement this method. Calling it on the base class
+terminates the process via C<bug()>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The kit name to fetch (e.g., C<'cf'>).
+
+=item C<$version>
+
+The kit version to fetch (e.g., C<'2.8.0'> or C<'latest'>).
+
+=item C<$path>
+
+The directory in which to save the downloaded tarball.
+
+=item C<$force>
+
+Optional boolean. When true, overwrite an existing cached tarball.
+
+=back
+
+B<Returns:>
+
+A three-element list: C<($kit_name, $actual_version, $tarball_path)>. The
+C<$actual_version> reflects the resolved version when C<'latest'> was
+requested. C<$tarball_path> is the full path to the saved tarball file.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Abstract Method: Expecting %s class to define concrete '%' method">
+
+Thrown via C<bug()> when called on the base class. The first C<%s> is the
+class name and C<'%'> is the method name C<fetch_kit_version>.
+
+=back
+
+B<Examples:>
+
+  my ($name, $ver, $file) = $provider->fetch_kit_version('cf', 'latest', '/tmp', 0);
+  print "$name/$ver saved to $file\n";
+  # prints e.g.: cf/2.8.0 saved to /tmp/cf-2.8.0.tar.gz
+
+=head2 fetch_kit_version_src
+
+  my ($name, $version, $file) = $provider->fetch_kit_version_src($name, $version, $path, $force);
+
+Abstract method. Downloads the source tarball for the named kit and version
+to the specified directory.
+
+Subclasses B<must> implement this method. Calling it on the base class
+terminates the process via C<bug()>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The kit name to fetch source for (e.g., C<'cf'>).
+
+=item C<$version>
+
+The kit version to fetch (e.g., C<'2.8.0'> or C<'latest'>).
+
+=item C<$path>
+
+The directory in which to save the downloaded source tarball.
+
+=item C<$force>
+
+Optional boolean. When true, overwrite an existing cached source tarball.
+
+=back
+
+B<Returns:>
+
+A three-element list: C<($kit_name, $actual_version, $tarball_path)>. The
+C<$actual_version> reflects the resolved version when C<'latest'> was
+requested. C<$tarball_path> is the full path to the saved source tarball.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Abstract Method: Expecting %s class to define concrete '%' method">
+
+Thrown via C<bug()> when called on the base class. The first C<%s> is the
+class name and C<'%'> is the method name C<fetch_kit_version_src>.
+
+=back
+
+B<Examples:>
+
+  my ($name, $ver, $file) = $provider->fetch_kit_version_src('cf', '2.8.0', '/tmp', 0);
+  print "$name/$ver source saved to $file\n";
+  # prints e.g.: cf/2.8.0 source saved to /tmp/cf-2.8.0-src.tar.gz
+
+=head2 latest_version_of
+
+  my $version = $provider->latest_version_of($name, %opts);
+
+Returns the version string of the most recent release of the named kit.
+Calls C<kit_versions()> with C<latest =E<gt> 1> and returns the C<version>
+field from the first result.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The kit name to query (e.g., C<'cf'>). Required.
+
+=item C<%opts>
+
+Optional. Additional options forwarded to C<kit_versions()> (e.g.,
+C<prerelease =E<gt> 1> to include pre-releases).
+
+=back
+
+B<Returns:>
+
+The latest version string (e.g., C<"2.8.0">), or C<undef> if no versions
+are available.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Missing name for retrieving kit releases">
+
+Thrown when C<$name> is undefined or empty.
+
+=back
+
+B<Examples:>
+
+  my $ver = $provider->latest_version_of('cf');
+  print $ver; # prints e.g. '2.8.0'
+
+  # Including pre-releases
+  my $ver = $provider->latest_version_of('cf', prerelease => 1);
+  print $ver; # prints e.g. '2.9.0-rc1'
+
+=head2 kit_version_info
+
+  my $info = $provider->kit_version_info($name, $version);
+
+Returns the version information hashref for a specific kit version. Calls
+C<kit_versions()> with C<version =E<gt> $version> and returns the first
+result.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The kit name to query (e.g., C<'cf'>). Required.
+
+=item C<$version>
+
+The specific version string to look up (e.g., C<'2.8.0'>).
+
+=back
+
+B<Returns:>
+
+A hashref containing the version record (see C<kit_versions()> for the
+field list), or C<undef> if the version is not found.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Missing name for retrieving kit releases">
+
+Thrown when C<$name> is undefined or empty.
+
+=back
+
+B<Examples:>
+
+  my $info = $provider->kit_version_info('cf', '2.8.0');
+  print $info->{date}; # prints e.g. '2024-01-15'
+
+=head1 ABSTRACT METHODS
+
+The following methods are defined as stubs in C<Genesis::Kit::Provider> and
+B<must> be overridden by every concrete subclass. Calling any of them on the
+base class terminates the process via C<bug()>.
+
+=over 4
+
+=item C<config>
+
+=item C<check>
+
+=item C<kit_names>
+
+=item C<kit_releases>
+
+=item C<kit_versions>
+
+=item C<fetch_kit_version>
+
+=item C<fetch_kit_version_src>
+
+=back
+
+See the individual method entries in L</METHODS> above for the interface
+contract each subclass must honour.
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
 
 =cut

--- a/lib/Genesis/Kit/Provider/GenesisCommunity.pod
+++ b/lib/Genesis/Kit/Provider/GenesisCommunity.pod
@@ -1,63 +1,288 @@
+=encoding utf8
+
 =head1 NAME
 
-Genesis::Kit::Provider::Default
+Genesis::Kit::Provider::GenesisCommunity - Genesis Community kit provider for Genesis deployment kits
+
+=head1 SYNOPSIS
+
+  use Genesis::Kit::Provider;
+
+  # The genesis-community provider is the default; obtain it via the base class factory
+  my $provider = Genesis::Kit::Provider->new(
+      type => 'genesis-community',
+  );
+
+  # Or create one directly (no options needed — it is a singleton)
+  my $provider = Genesis::Kit::Provider::GenesisCommunity->new();
+
+  # List available kits from the Genesis Community organization
+  my @kits = $provider->kit_names();
+
+  # Fetch a specific kit version
+  my ($name, $version, $file) = $provider->fetch_kit_version(
+      'bosh', '2.3.0', '/path/to/cache', 0
+  );
 
 =head1 DESCRIPTION
 
-This class represents a compiled kit, and its distribution as a tarball
-archive.  Most operators use kits in this format.
+C<Genesis::Kit::Provider::GenesisCommunity> is a zero-configuration subclass
+of L<Genesis::Kit::Provider::Github> that hard-codes the
+C<genesis-community> organization on C<github.com> as the kit source.  It
+is the default kit provider type used by Genesis when no explicit provider
+is configured.
 
-=head1 CONSTRUCTORS
+Because the provider target is fixed, no CLI options are required or
+accepted during C<genesis init> or C<genesis update>.  Operators who need
+to point at a different Github organization should use
+L<Genesis::Kit::Provider::Github> instead.
 
-=head2 new(%opts)
-
-Instantiates a new Kit::Compiled object.
-
-The following options are recognized:
-
-=over
-
-=item name
-
-The name of the kit.  This option is B<required>.
-
-=item version
-
-The version of the kit.  This option is B<required>.
-
-=item archive
-
-The absolute path to the compiled kit tarball.  This option is B<required>.
-
-=back
-
+All kit retrieval methods (C<kit_names>, C<kit_releases>, C<kit_versions>,
+C<fetch_kit_version>, C<fetch_kit_version_src>, and C<latest_version_of>)
+are inherited from L<Genesis::Kit::Provider::Github> unchanged and behave
+identically, operating against the C<genesis-community> organization on
+C<github.com>.
 
 =head1 METHODS
 
-=head2 id()
+=head2 init (class method)
 
-Returns the identity of the kit, in the form C<$name/$verison>.  This is
-useful for error messages and reporting.
+  my $provider = Genesis::Kit::Provider::GenesisCommunity->init();
 
-=head2 name()
+Creates a new C<GenesisCommunity> provider during C<genesis init> or
+C<genesis update> when the user selects C<genesis-community> as the
+provider type.  This method accepts no options — the provider target is
+fully determined by the class itself.
 
-Returns the name of the kit.
+Delegates immediately to L</new>.
 
-=head2 version()
+B<Returns:> A new C<Genesis::Kit::Provider::GenesisCommunity> instance.
 
-Returns the version of the kit.
+B<Examples:>
 
-=head2 kit_bug($fmt, ...)
+  my $provider = Genesis::Kit::Provider::GenesisCommunity->init();
+  print $provider->organization(); # prints 'genesis-community'
 
-Prints an error to the screen, complete with details about how the problem
-at hand is not the operator's fault, and that they should file a bug against
-the kit's Github page, or contact the authors.
+=head2 new (class method)
 
-=head2 extract()
+  my $provider = Genesis::Kit::Provider::GenesisCommunity->new();
 
-Extracts the compiled kit tarball to a temporary workspace, and installs the
-Genesis hooks helper script.
+Constructs a new C<GenesisCommunity> provider with all settings
+hard-coded.  The label is set to C<'Genesis Community organization on
+Github'>, the domain to C<'github.com'>, the organization to
+C<'genesis-community'>, and TLS to C<'yes'>.
 
-This method is memoized; subsequent calls to C<extract> will have no effect.
+No configuration parameters are accepted or needed.
+
+B<Returns:> A blessed C<Genesis::Kit::Provider::GenesisCommunity> instance
+backed by an internal C<Service::Github> remote object targeting the
+C<genesis-community> organization.
+
+B<Examples:>
+
+  my $provider = Genesis::Kit::Provider::GenesisCommunity->new();
+  print $provider->label();        # prints 'Genesis Community organization on Github'
+  print $provider->domain();       # prints 'github.com'
+  print $provider->organization(); # prints 'genesis-community'
+  print $provider->tls();          # prints 'yes'
+
+=head2 opts (class method)
+
+  my @specs = Genesis::Kit::Provider::GenesisCommunity->opts();
+
+Returns the list of L<Getopt::Long> option specification strings supported
+by L</init>.  Because the C<genesis-community> provider is a singleton
+with no configurable options, this method returns an empty list.
+
+B<Returns:> An empty list.
+
+B<Examples:>
+
+  my @specs = Genesis::Kit::Provider::GenesisCommunity->opts();
+  print scalar(@specs); # prints '0'
+
+=head2 opts_help
+
+  my $text = $provider->opts_help(%config);
+
+Returns a formatted help string describing the C<genesis-community>
+provider type, for inclusion in command-line help output.  Returns an
+empty string if C<'genesis-community'> is not listed in
+C<$config{valid_types}>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<valid_types>
+
+An array reference of provider type strings that are valid in the current
+context.  The method returns C<''> unless this list contains
+C<'genesis-community'>.
+
+=back
+
+B<Returns:> A multi-line help string describing the C<genesis-community>
+provider, or an empty string if C<'genesis-community'> is not in
+C<valid_types>.
+
+B<Examples:>
+
+  my $help = $provider->opts_help(valid_types => [qw(genesis-community github)]);
+  print $help;
+  # Prints a block beginning with:
+  #   Kit Provider `genesis-community`:
+  #
+  #     This is a singleton kit provider type that points to the Genesis Community
+  #     collection of kits hosted on github.com/genesis-community ...
+
+  # Returns empty when genesis-community is not a valid type
+  my $none = $provider->opts_help(valid_types => ['github']);
+  print length($none); # prints '0'
+
+=head2 config
+
+  my %config = $provider->config();
+
+Returns a configuration hash sufficient to identify this provider type.
+Because the C<genesis-community> provider has no configurable fields, the
+hash contains only the C<type> key.
+
+B<Returns:> A hash with a single key:
+
+=over 4
+
+=item C<type>
+
+Always C<'genesis-community'>.
+
+=back
+
+B<Examples:>
+
+  my %cfg = $provider->config();
+  # %cfg = ( type => 'genesis-community' )
+  print $cfg{type}; # prints 'genesis-community'
+
+=head2 status
+
+  my %status = $provider->status($verbose);
+
+Returns a hash of provider status information suitable for display.
+Delegates connectivity checking and kit enumeration to the parent
+L<Genesis::Kit::Provider::Github/status> implementation, then replaces
+the C<type> key with C<'genesis-community'> and simplifies the C<extras>
+display list to show only the C<Source> label rather than the Github-
+specific C<Name>, C<Domain>, C<Org>, and C<Use TLS> fields.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$verbose>
+
+Optional boolean.  Passed through to the parent C<status> implementation.
+When true, the C<kits> entry in the returned hash is a hash reference
+mapping each kit name to a release count summary string (e.g.,
+C<'3 releases, 1 pre-release'>).  When false or omitted, C<kits> is an
+array reference of sorted kit name strings.
+
+=back
+
+B<Returns:> A hash with the following keys:
+
+=over 4
+
+=item C<type>
+
+Always C<'genesis-community'>.
+
+=item C<extras>
+
+Array reference C<["Source"]> listing the supplemental display key.
+
+=item C<Source>
+
+The provider label (C<'Genesis Community organization on Github'>).
+
+=item C<status>
+
+A status string: C<'ok'> when the connectivity check succeeds, or an
+error message when it fails.
+
+=item C<kits>
+
+When the check succeeds: an array reference of sorted kit names
+(non-verbose), or a hash reference mapping kit names to release summary
+strings (verbose).  C<undef> when the check fails.
+
+=back
+
+B<Examples:>
+
+  my %info = $provider->status();
+  print $info{status};          # prints 'ok' on success
+  print $info{type};            # prints 'genesis-community'
+  print $info{Source};          # prints 'Genesis Community organization on Github'
+  print scalar(@{$info{kits}}); # prints the number of available kits
+
+  my %verbose = $provider->status(1);
+  for my $kit (keys %{$verbose{kits}}) {
+      print "$kit: $verbose{kits}{$kit}\n";
+      # prints e.g. 'bosh: 5 releases, 1 pre-release'
+  }
+
+=head1 INHERITED METHODS
+
+The following methods are inherited from L<Genesis::Kit::Provider::Github>
+and behave identically, operating against the hard-coded
+C<genesis-community> organization on C<github.com>:
+
+=over 4
+
+=item C<label>
+
+=item C<remote>
+
+=item C<domain>
+
+=item C<organization>
+
+=item C<credentials>
+
+=item C<tls>
+
+=item C<check>
+
+=item C<repos_url>
+
+=item C<releases_url>
+
+=item C<base_url>
+
+=item C<kit_names>
+
+=item C<kit_releases>
+
+=item C<kit_versions>
+
+=item C<fetch_kit_version>
+
+=item C<fetch_kit_version_src>
+
+=item C<latest_version_of>
+
+=back
+
+See L<Genesis::Kit::Provider::Github> for full documentation of each
+method.
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
 
 =cut


### PR DESCRIPTION
## Summary

- Rewrite POD for 5 Genesis::Kit modules (Kit, Provider, Compiler, Dev, GenesisCommunity)
- Validate existing POD for 2 modules (Compiled, Github) — no changes needed
- All 7 modules pass pod-validate with 797/797 checks, 0 failures

Resolves [FWT-585](https://fivetwenty.atlassian.net/browse/FWT-585). Unblocks FWT-546, FWT-547, FWT-548.

## Changes

| Module | Action | Methods Documented |
|--------|--------|--------------------|
| Genesis::Kit | Full rewrite | 25 public + 2 internal + 4 abstract |
| Genesis::Kit::Provider | Full rewrite (was copy-paste from Kit::Compiled) | 16 public |
| Genesis::Kit::Compiler | Full rewrite | 4 public + 8 internal |
| Genesis::Kit::Dev | Full rewrite | 7 public |
| Genesis::Kit::Provider::GenesisCommunity | Full rewrite (was copy-paste from Kit::Compiled) | 6 public |
| Genesis::Kit::Compiled | Validated, no changes | 8 methods (72/72 checks) |
| Genesis::Kit::Provider::Github | Validated, no changes | 12 methods (112/112 checks) |

## Unresolved demerits

1. **Kit `provided_configs()`** — extractor fold-marker parsing limitation prevents documenting this method without triggering orphaned_pod failure
2. **Provider `check()`/`opts_help()`** — code has copy-pasted `bug()` calls with wrong method names; POD accurately documents current behavior

## Test plan

- [x] `pod-validate` passes 797/797 checks across all 7 modules
- [x] LLM accuracy and completeness checks pass on all 5 rewritten modules
- [x] Subjective quality review completed (pod-reviewer)
- [x] No code defects found during authoring
- [x] No embedded POD in any .pm file (confirmed: none existed)