### PR TITLE
Add POD for Genesis::Hook hierarchy

### DIFF
--- a/lib/Genesis/Hook.pod
+++ b/lib/Genesis/Hook.pod
@@ -1,0 +1,1123 @@
+=encoding UTF-8
+
+=head1 NAME
+
+Genesis::Hook - Base class for all Genesis kit hook implementations
+
+=head1 SYNOPSIS
+
+    package Genesis::Hook::Blueprint::my_kit;
+    use parent 'Genesis::Hook::Blueprint';
+
+    sub perform {
+        my ($self) = @_;
+
+        $self->check_minimum_genesis_version('3.0.0');
+
+        if ($self->want_feature('ha')) {
+            # include HA manifests
+        }
+
+        my ($out, $rc, $err) = $self->spruce_merge(
+            'base.yml',
+            'networking.yml',
+        );
+
+        $self->done($out);
+    }
+
+    1;
+
+=head1 DESCRIPTION
+
+C<Genesis::Hook> is the base class for all Genesis kit hook implementations.
+Kit authors subclass one of the concrete hook types (e.g.,
+C<Genesis::Hook::Blueprint>, C<Genesis::Hook::Check>,
+C<Genesis::Hook::Features>) and implement the C<perform> method. The base
+class provides the shared infrastructure: environment and kit access, feature
+detection, BOSH and CredHub integration, YAML merging utilities, and the
+init/perform/done lifecycle.
+
+The standard hook lifecycle is:
+
+=over 4
+
+=item 1.
+
+Genesis instantiates the hook via C<init>, passing an C<env> option that
+holds the C<Genesis::Env> object for the deployment being operated on.
+
+=item 2.
+
+Genesis calls C<perform> on the hook. Kit authors implement this method to
+carry out the hook's work.
+
+=item 3.
+
+The hook signals completion by calling C<done>, optionally passing a result
+value. Genesis reads the outcome via C<completed> and C<results>.
+
+=back
+
+Concrete hook subclasses that override C<perform> should call C<$self->done>
+or C<$self->done($value)> before returning. Subclasses that do not implement
+C<perform> will trigger a kit bug error at runtime.
+
+=head1 METHODS
+
+=head2 init
+
+    my $hook = Genesis::Hook->init(%opts);
+
+Constructs and returns a new hook object. C<env> is required in C<%opts>; all
+other key-value pairs are stored verbatim on the object. The hook's type is
+read from the C<GENESIS_KIT_HOOK> environment variable and stored as
+C<< $hook->{type} >>. Traces all environment variables at the C<trace> log
+level during initialization.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+Key-value pairs stored on the hook object. The following key is required:
+
+=over 4
+
+=item C<env>
+
+B<(required)> A C<Genesis::Env> object representing the deployment environment
+that the hook is being run against.
+
+=back
+
+=back
+
+B<Returns:> A blessed hook object of the calling class.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Missing required arguments for a perl-based kit hook call: %s"> -- raised
+via C<bug()> if the C<env> key is absent from C<%opts>. C<%s> is replaced
+with the comma-separated list of missing argument names.
+
+=back
+
+B<Examples:>
+
+    my $hook = Genesis::Hook::Blueprint->init(env => $env);
+    # Returns: a blessed Genesis::Hook::Blueprint object
+
+=head2 perform
+
+    $hook->perform;
+
+Abstract method that must be implemented by every concrete hook subclass.
+The base class implementation calls C<kit_bug> with a message instructing
+the kit author to provide a C<perform> method. Kit authors override this
+method to implement the hook's logic and must call C<done> before returning.
+
+B<Returns:> Nothing -- the base class implementation always calls C<kit_bug>,
+which terminates the process.
+
+B<Examples:>
+
+    package Genesis::Hook::Blueprint::my_kit;
+    use parent 'Genesis::Hook::Blueprint';
+
+    sub perform {
+        my ($self) = @_;
+        # ... hook logic ...
+        $self->done($manifest_yaml);
+        # Returns: nothing (done() handles the result)
+    }
+
+=head2 done
+
+    $hook->done;
+    $hook->done($results);
+
+Marks the hook as complete and records an optional result value. When called
+without arguments, sets the result to C<1> and marks the hook complete. When
+called with a defined C<$results> argument, stores that value and marks the
+hook complete. When called with an explicit C<undef>, stores C<undef> and
+marks the hook as I<not> complete (the C<complete> flag is set to C<0>).
+
+Modifies the object in-place.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$results>
+
+B<(optional)> Any value to record as the hook's result. Pass C<undef>
+explicitly to mark the hook as incomplete.
+
+=back
+
+B<Returns:> The C<$results> value passed in, or C<1> when called with no
+arguments.
+
+B<Examples:>
+
+    # Signal success with no particular result
+    $self->done;
+    # Returns: 1
+
+    # Signal success and return a YAML string to Genesis
+    $self->done($merged_yaml);
+    # Returns: the value of $merged_yaml
+
+    # Signal that no result is available (marks hook incomplete)
+    $self->done(undef);
+    # Returns: undef
+
+=head2 results
+
+    my $value   = $hook->results;
+    my $bool    = $hook->completed;
+    $hook->check_minimum_genesis_version($min_version);
+
+This entry covers three closely related methods that appear together in the
+source:
+
+B<results> -- Returns the result recorded by C<done>, or C<undef> if the
+hook has not been marked complete.
+
+B<completed> -- Returns true if C<done> has been called in a way that marks
+the hook complete (i.e., C<done> was called with a defined argument or with
+no arguments).
+
+B<check_minimum_genesis_version> -- Verifies that the running Genesis version
+is at least C<$min_version>. Both the running version and C<$min_version>
+must be valid semantic version strings. If either is invalid, or if the
+running version is older than required, the method terminates with an
+upgrade prompt.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$min_version>
+
+A semantic version string (e.g., C<'3.0.0'>) specifying the minimum
+required Genesis version. Used by C<check_minimum_genesis_version> only.
+
+=back
+
+B<Returns:>
+
+C<results> returns the stored result value, or C<undef> if C<completed>
+returns false.
+
+C<completed> returns the value of the internal C<complete> flag (C<1>
+or C<0>).
+
+C<check_minimum_genesis_version> returns nothing on success.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"The %s kit %s hook requires Genesis v%s or higher -- cannot continue.
+Please upgrade using #G{%s upgrade}"> -- raised via C<bail()> by
+C<check_minimum_genesis_version> if the running Genesis version is too old
+or either version string is not a valid semver. The placeholders are: kit
+identifier, hook type, minimum version string, and the genesis binary name.
+
+=back
+
+B<Examples:>
+
+    $hook->done('some output');
+    print $hook->completed ? "yes" : "no";
+    # Returns: yes
+
+    my $r = $hook->results;
+    # Returns: 'some output'
+
+    $hook->check_minimum_genesis_version('3.0.0');
+    # Returns: nothing on success; dies if version requirement not met
+
+=head2 env
+
+    my $env = $hook->env;
+
+Returns the C<Genesis::Env> object associated with this hook, as passed to
+C<init>.
+
+Also provides C<deployed> -- returns C<1> if the environment has already
+been deployed (its current deployment state is C<'deployed'>), or C<0>
+otherwise.
+
+    my $bool = $hook->deployed;
+
+B<Returns:>
+
+C<env> returns the C<Genesis::Env> object stored on the hook.
+
+C<deployed> returns C<1> or C<0>.
+
+B<Examples:>
+
+    my $env = $hook->env;
+    print $env->name;
+    # Returns: the environment's name
+
+    if ($hook->deployed) {
+        my $data = $hook->exodus_data('director_url');
+    }
+    # Returns: 1 if already deployed, 0 otherwise
+
+=head2 use_create_env
+
+    my $bool = $hook->use_create_env;
+
+Returns true if the environment is configured to use C<bosh create-env>
+rather than a standard BOSH director deployment. Returns C<undef> or false
+if no environment is associated with the hook.
+
+B<Returns:> The boolean result of C<< $env->use_create_env >>, or C<undef>.
+
+B<Examples:>
+
+    if ($hook->use_create_env) {
+        # this is a proto/create-env environment
+    }
+    # Returns: 1 if using create-env, undef otherwise
+
+=head2 features
+
+    my @features = $hook->features;
+
+Returns the list of features active for the environment. The list is
+retrieved from the environment object on first call and cached on the hook.
+
+B<Returns:> A list of feature name strings.
+
+B<Examples:>
+
+    my @features = $hook->features;
+    # Returns: ('ha', 'tls', ...)
+
+=head2 set_features
+
+    $hook->set_features();
+
+Replaces the hook's cached feature list with the supplied C<@features>.
+Clears the internal feature-lookup cache so that subsequent calls to
+C<want_feature> use the new list.
+
+Modifies the object in-place.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@features>
+
+The new list of feature name strings to activate.
+
+=back
+
+B<Returns:> The method has no meaningful return value.  The implicit return is
+an internal implementation detail and should not be relied upon.
+
+B<Examples:>
+
+    $hook->set_features('ha', 'tls');
+    print $hook->want_feature('ha') ? "yes" : "no";
+    # Returns: yes
+
+=head2 want_feature
+
+    my $bool = $hook->want_feature($feature);
+
+Tests whether a given feature is active. C<$feature> may be a plain string
+or a compiled regular expression. For plain strings, returns a true value
+if the feature is present in the active feature set. For regular expressions,
+returns C<1> if at least one active feature name matches, or C<0> if none
+match.
+
+The internal feature lookup hash is built lazily on the first call and
+cached until C<set_features> is called.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$feature>
+
+A feature name string, or a C<Regexp> object (e.g., C<qr/^proto-/>) to
+match against all active feature names.
+
+=back
+
+B<Returns:> A true value if the feature is active, false otherwise. Returns
+C<1> for regex matches, or the hash slot value (C<1>) for exact string
+matches.
+
+B<Examples:>
+
+    # Exact match
+    if ($hook->want_feature('ha')) {
+        # include HA manifests
+    }
+    # Returns: 1 if 'ha' is in the feature set, undef otherwise
+
+    # Regex match
+    my $has_proto = $hook->want_feature(qr/^proto-/);
+    # Returns: 1 if any feature name starts with 'proto-', 0 otherwise
+
+=head2 wants_feature
+
+    my $bool    = $hook->wants_feature($feature, $feature2);
+    my $iaas    = $hook->iaas;
+    my $scale   = $hook->scale;
+    my $bool    = $hook->is_ocfp;
+    my $name    = $hook->cpi_name;
+    my $bool    = $hook->cpi_enabled;
+    my $kit     = $hook->kit;
+    $hook->kit_bug($msg, @args);
+
+This entry covers C<wants_feature> and the environment-delegation accessors
+that appear together in the source.
+
+B<wants_feature> -- Alias for C<want_feature>. Accepts the same arguments
+and returns the same value.
+
+B<iaas> -- Returns the IaaS type string for the environment (e.g., C<'aws'>,
+C<'vsphere'>, C<'azure'>), or C<undef> if no environment is set.
+
+B<scale> -- Returns the scale classification for the environment (e.g.,
+C<'dev'>, C<'prod'>), or C<undef> if no environment is set.
+
+B<is_ocfp> -- Returns true if the environment is an OCFP-managed environment,
+or C<undef> if no environment is set.
+
+B<cpi_name> -- Returns the CPI name for the environment (e.g., C<'aws_cpi'>,
+C<'vsphere_cpi'>), or C<undef> if no environment is set.
+
+B<cpi_enabled> -- Returns true if the environment's CPI is enabled, or
+C<undef> if no environment is set.
+
+B<kit> -- Returns the C<Genesis::Kit> object for the environment's kit, or
+C<undef> if no environment is set.
+
+B<kit_bug> -- Reports a kit bug by delegating to
+C<< $hook->kit->kit_bug($msg, @args) >>. If no kit is available, dies with
+an error identifying the environment.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$feature>
+
+For C<wants_feature>: a feature name string or C<Regexp> object.
+
+=item C<$msg>
+
+For C<kit_bug>: a C<sprintf>-style format string describing the bug.
+
+=item C<@args>
+
+For C<kit_bug>: arguments for the format string.
+
+=back
+
+B<Returns:>
+
+C<wants_feature> returns a true value if the feature is active, false
+otherwise.
+
+C<iaas>, C<scale>, C<is_ocfp>, C<cpi_name>, C<cpi_enabled>, and C<kit>
+return the corresponding value from the environment object, or C<undef> if
+no environment is set.
+
+C<kit_bug> never returns -- it always terminates the process via C<bail()>.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Kit bug detected, but cannot determine kit for %s/%s"> -- raised by
+C<kit_bug> if C<kit> returns undef. The first C<%s> is the environment
+name and the second is the environment type.
+
+=back
+
+B<Examples:>
+
+    if ($hook->wants_feature('mtls')) {
+        # mTLS feature is active
+    }
+    # Returns: 1 if active, undef otherwise
+
+    my $iaas = $hook->iaas;
+    # Returns: 'aws'
+
+    $hook->kit_bug("Unexpected option value %s: %s", 'mode', $mode);
+    # Returns: never (always dies)
+
+=head2 kit_has_file
+
+    my $bool = $hook->kit_has_file($file);
+
+Tests whether the given C<$file> exists as a plain file inside the kit's
+directory.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$file>
+
+A path relative to the kit root.
+
+=back
+
+B<Returns:> True if the file exists and is a plain file, false otherwise.
+
+B<Examples:>
+
+    if ($hook->kit_has_file('hooks/post-deploy')) {
+        # kit ships a post-deploy hook
+    }
+    # Returns: 1 if the file exists, empty string otherwise
+
+=head2 supports_iaas
+
+    my $bool = $hook->supports_iaas;
+
+Returns true if the environment's IaaS type appears in the kit metadata's
+C<supports> list.
+
+B<Returns:> True if the IaaS is in the kit's supported list, false otherwise.
+
+B<Examples:>
+
+    unless ($hook->supports_iaas) {
+        # warn that this IaaS is not supported
+    }
+    # Returns: 1 if supported, empty string otherwise
+
+=head2 relative_env_path
+
+    my $path = $hook->relative_env_path;
+
+Returns a human-readable path to the environment file, relative to the
+directory from which genesis was originally invoked
+(C<GENESIS_ORIGINATING_DIR>).
+
+B<Returns:> A string path to the environment file.
+
+B<Examples:>
+
+    my $path = $hook->relative_env_path;
+    # Returns: './envs/dev/us-east-1.yml'
+
+=head2 titleize
+
+    my @titled = titleize(@words);
+
+Applies title-case formatting to each string in C<@words>. Each word
+beginning with a letter or apostrophe is capitalized with the remainder
+lowercased.  This is a plain function, not a method -- it operates
+directly on its argument list without stripping an invocant.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@words>
+
+Strings to title-case.
+
+=back
+
+B<Returns:> A list of title-cased strings.
+
+B<Examples:>
+
+    my @t = titleize('hello world');
+    # Returns: ('Hello World')
+
+=head2 spruce_merge
+
+    my $yaml = $hook->spruce_merge(@args);
+    my ($yaml, $rc, $err) = $hook->spruce_merge(\%run_opts, @args);
+
+Runs C<spruce merge> on a list of YAML files and raw hash arguments. Each
+element of C<@args> may be:
+
+=over 4
+
+=item *
+
+A hash reference -- serialized to a temporary YAML file and included as a
+merge input.
+
+=item *
+
+A string beginning with C<-> -- treated as a C<spruce> command-line option.
+If the option is C<--cherry-pick> or C<--prune>, the immediately following
+argument is consumed as its value.
+
+=item *
+
+An absolute file path that exists on disk -- included directly.
+
+=item *
+
+A relative path that resolves to an existing file under the kit root via
+C<< $kit->path($arg) >> -- resolved and included.
+
+=back
+
+In list context, returns the raw output, exit code, and error string from
+C<spruce merge>, allowing the caller to handle errors. In scalar context,
+terminates on non-zero exit.
+
+An optional C<\%run_opts> hash reference may be passed as the first argument
+to control the underlying C<run> call.
+
+B<Parameters:>
+
+=over 4
+
+=item C<\%run_opts>
+
+B<(optional)> A hash reference of options for the underlying C<run> call.
+Must be the first argument if present.
+
+=item C<@args>
+
+Files, hash references, and C<spruce> flags to pass to C<spruce merge>.
+
+=back
+
+B<Returns:>
+
+In scalar context, returns the merged YAML output string.
+
+In list context, returns C<($yaml, $rc, $err)> -- the output, exit code, and
+error string from C<spruce merge>.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Invalid argument for spruce merge: %s"> -- raised via C<bug()> if an
+argument is neither a hash reference, a flag, nor an existing file. C<%s>
+is replaced with the unrecognized argument.
+
+=item *
+
+C<"Failed to merge spruce files: %s"> -- raised via C<bail()> in scalar
+context if C<spruce merge> exits with a non-zero status. C<%s> is replaced
+with the error output from C<spruce>.
+
+=back
+
+B<Examples:>
+
+    # Scalar context -- terminates on error
+    my $yaml = $hook->spruce_merge('base.yml', 'networking.yml');
+    # Returns: merged YAML string
+
+    # List context -- caller handles errors
+    my ($out, $rc, $err) = $hook->spruce_merge('base.yml', 'override.yml');
+    # Returns: ($yaml_string, 0, '') on success
+
+    # Mix of files and inline data
+    my $yaml = $hook->spruce_merge(
+        'base.yml',
+        { meta => { name => $hook->env->name } },
+    );
+    # Returns: merged YAML string
+
+    # With spruce options
+    my $yaml = $hook->spruce_merge(
+        'base.yml',
+        '--prune', 'meta',
+        'overlay.yml',
+    );
+    # Returns: merged YAML string with 'meta' key pruned
+
+=head2 TRUE
+
+    my $true  = Genesis::Hook->TRUE($ops, @required);
+    my $false = Genesis::Hook->FALSE;
+    my $null  = Genesis::Hook->NULL;
+
+JSON/YAML boolean and null helpers. These four methods are documented
+together because they appear in the source as a group with C<check_for_required_args>.
+
+B<TRUE> returns the JSON boolean true value, suitable for use in data
+structures that will be serialized to JSON or YAML.
+
+B<FALSE> returns the JSON boolean false value.
+
+B<NULL> returns the JSON null value.
+
+B<check_for_required_args> validates that all keys listed in C<@required>
+are present in the hash reference C<$ops>. See L</check_for_required_args>
+under L</INTERNAL METHODS> for details; it is documented there in full
+because it is grouped with these methods in the source.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$ops>
+
+For C<check_for_required_args>: a hash reference of constructor options to
+validate. Not used by C<TRUE>, C<FALSE>, or C<NULL>.
+
+=item C<@required>
+
+For C<check_for_required_args>: the list of key names that must be defined
+in C<$ops>.
+
+=back
+
+B<Returns:>
+
+C<TRUE> returns the JSON boolean true singleton (JSON::PP::true).
+
+C<FALSE> returns the JSON boolean false singleton (JSON::PP::false).
+
+C<NULL> returns the JSON null singleton (JSON::PP::null).
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Missing required arguments for a perl-based kit hook call: %s"> -- raised
+via C<bug()> by C<check_for_required_args> if any required keys are absent.
+C<%s> is replaced with the comma-separated list of missing key names.
+
+=back
+
+B<Examples:>
+
+    my $data = {
+        enabled => $hook->TRUE,
+        debug   => $hook->FALSE,
+        comment => $hook->NULL,
+    };
+    # Returns: a hash with JSON-compatible boolean and null values
+
+=head2 require_hook_lib
+
+    Genesis::Hook->require_hook_lib;
+
+Adds the C<lib/> directory adjacent to the calling file to Perl's C<@INC>,
+allowing hook modules to load local library files. This method uses
+C<caller()> to determine the calling file's location.
+
+B<Returns:> Nothing meaningful (the return value of the internal C<eval>).
+
+B<Examples:>
+
+    # At the top of a kit hook module:
+    Genesis::Hook->require_hook_lib;
+    use MyKit::Helper;
+    # Returns: nothing meaningful
+
+=head2 get_config_override
+
+    my $value = $hook->get_config_override($key, $default);
+
+Looks up a BOSH config override value from the environment's manifest. The
+lookup path is C<bosh-configs.E<lt>typeE<gt>.E<lt>keyE<gt>>, where the type
+(C<cloud>, C<runtime>, or C<cpi>) is inferred from the hook's class unless
+the key already starts with one of those prefixes.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$key>
+
+The configuration key to look up. If it begins with C<cloud.>, C<runtime.>,
+or C<cpi.>, it is used as-is under C<bosh-configs>. Otherwise, the type
+prefix is determined by the hook's class (C<Genesis::Hook::CloudConfig>,
+C<Genesis::Hook::RuntimeConfig>, or C<Genesis::Hook::CpiConfig>).
+
+=item C<$default>
+
+B<(optional)> The default value to return if the key is not found.
+
+=back
+
+B<Returns:> The resolved value from the environment's manifest, or
+C<$default> if absent.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"%s hooks must specify the bosh_config type as the first part of the
+lookup key"> -- raised via C<bail()> if the hook is not a known config hook
+class and C<$key> has no recognized type prefix. C<%s> is replaced with the
+parent class name.
+
+=back
+
+B<Examples:>
+
+    # From a CloudConfig hook -- key resolved under bosh-configs.cloud.*
+    my $networks = $hook->get_config_override('networks', []);
+    # Returns: the value of bosh-configs.cloud.networks, or []
+
+    # Explicit type prefix -- works from any hook class
+    my $rules = $hook->get_config_override('runtime.addons', []);
+    # Returns: the value of bosh-configs.runtime.addons, or []
+
+=head2 exodus_data
+
+    my $hashref = $hook->exodus_data();
+    my $value   = $hook->exodus_data;
+    my @values  = $hook->exodus_data;
+
+Retrieves exodus metadata for the environment. The full exodus hash is
+fetched once from C<< $env->exodus_lookup('.', {}) >> and cached on the
+hook for subsequent calls.
+
+With no arguments, returns the full exodus data hash reference. With a
+single key, returns the value for that key. With multiple keys, returns the
+corresponding values -- as a list in list context, or as an array reference
+in scalar context.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$key>, C<$key2>, ...
+
+B<(optional)> One or more exodus data keys to retrieve.
+
+=back
+
+B<Returns:>
+
+With no arguments, returns a hash reference of all exodus data.
+
+With one argument, returns the scalar value for that key.
+
+With two or more arguments, returns a list of values in list context, or an
+array reference in scalar context.
+
+B<Examples:>
+
+    # All exodus data
+    my $data = $hook->exodus_data;
+    # Returns: { director_url => '...', ... }
+
+    # Single key
+    my $url = $hook->exodus_data('director_url');
+    # Returns: 'https://bosh.example.com'
+
+    # Multiple keys in list context
+    my ($url, $user) = $hook->exodus_data('director_url', 'admin_username');
+    # Returns: ('https://bosh.example.com', 'admin')
+
+    # Multiple keys in scalar context
+    my $aref = $hook->exodus_data('director_url', 'admin_username');
+    # Returns: ['https://bosh.example.com', 'admin']
+
+=head2 bosh
+
+    my $bosh = $hook->bosh;
+
+Returns a connected and validated BOSH client object for the environment's
+BOSH director. The client is created on the first call and cached for
+subsequent calls.
+
+B<Returns:> A connected BOSH client object.
+
+B<Examples:>
+
+    my $bosh = $hook->bosh;
+    my ($out, $rc) = $bosh->execute('deployments', '--column', 'name');
+    # Returns: the cached BOSH client object
+
+=head2 read_json_from_bosh
+
+    my $rows = $hook->read_json_from_bosh(@args);
+
+Runs a BOSH command with C<--json> appended and parses the first table's
+rows from the JSON response. Calls C<bail()> on failure.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@args>
+
+Command-line arguments to pass to the BOSH execute method (the C<--json>
+flag is appended automatically).
+
+=back
+
+B<Returns:> An array reference of row hash references from the first table
+in the BOSH JSON output.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Failed to read JSON from BOSH command: %s"> -- raised via C<bail()> if
+the BOSH command exits with a non-zero status. C<%s> is replaced with the
+error output.
+
+=back
+
+B<Examples:>
+
+    my $rows = $hook->read_json_from_bosh('deployments', '--column', 'name');
+    # Returns: [{ name => 'my-deployment' }, ...]
+
+=head2 get_credhub_variable
+
+    my $cred_name = $hook->get_credhub_variable($prefix, $path, $key, $value);
+
+Computes a deterministic CredHub credential name by hashing the path, key,
+and value together. The name is of the form
+C<"$prefix$path--$key--$sha1">, where the SHA-1 digest is the first 8 hex
+characters of C<sha1("$path--$key--$value")>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$prefix>
+
+A string prefix for the CredHub credential name.
+
+=item C<$path>
+
+The path component used in the hash and in the credential name.
+
+=item C<$key>
+
+The key component used in the hash and in the credential name.
+
+=item C<$value>
+
+The value hashed into the credential name to make it deterministic and
+unique per value.
+
+=back
+
+B<Returns:> A credential name string of the form
+C<"$prefix$path--$key--$sha1">.
+
+B<Examples:>
+
+    my $name = $hook->get_credhub_variable('/bosh/', 'certs', 'ca', $ca_pem);
+    # Returns: '/bosh/certs--ca--a1b2c3d4'
+
+=head2 load_hook_module
+
+    my $module = Genesis::Hook->load_hook_module($file, $kit);
+
+Loads a Perl module file for a kit hook. If C<$file> is not an absolute
+path, it is resolved relative to the kit's root. The module's package name
+is retrieved from the kit and the file is C<require>d only if it has not
+already been loaded (checked via C<%INC>). After loading, the module is
+registered in C<%INC> to prevent redefinition warnings on subsequent calls.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$file>
+
+Path to the Perl module file. If not absolute, resolved relative to the
+kit root.
+
+=item C<$kit>
+
+A C<Genesis::Kit> object used to resolve the file path and retrieve the
+module's package name.
+
+=back
+
+B<Returns:> The package name string of the loaded hook module.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Hook module %s does not exist for kit %s"> -- raised if the kit cannot
+provide a module name for the file. The first C<%s> is the resolved file
+path and the second is the kit identifier.
+
+=item *
+
+C<"Failed to load hook module %s: %s"> -- raised if C<require> fails. The
+first C<%s> is the file path and the second is the Perl error string.
+
+=back
+
+B<Examples:>
+
+    my $pkg = Genesis::Hook->load_hook_module('hooks/blueprint.pm', $kit);
+    # Returns: 'Genesis::Hook::Blueprint::my_kit'
+
+=head2 tempfile
+
+    my $path = $hook->tempfile;
+    my $path = $hook->tempfile($name);
+
+Returns the full path to a file inside the environment's work directory.
+If C<$name> is omitted, a name of the form
+C<tempfile-E<lt>timestampE<gt>-E<lt>randomE<gt>> is generated. The file
+itself is not created; only the path is returned.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+B<(optional)> The filename to use within the work directory. Defaults to an
+auto-generated name based on the current time and a random number.
+
+=back
+
+B<Returns:> The full path string for the temporary file.
+
+B<Examples:>
+
+    my $path = $hook->tempfile('manifest.yml');
+    # Returns: '/path/to/env/work/manifest.yml'
+
+    my $path = $hook->tempfile;
+    # Returns: '/path/to/env/work/tempfile-1710000000-4321'
+
+=head2 tempdir
+
+    my $path = $hook->tempdir;
+    my $path = $hook->tempdir($name);
+
+Returns the full path to a directory inside the environment's work directory,
+creating it if it does not already exist. If C<$name> is omitted, a name of
+the form C<tempdir-E<lt>timestampE<gt>-E<lt>randomE<gt>> is generated.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+B<(optional)> The directory name to use within the work directory. Defaults
+to an auto-generated name based on the current time and a random number.
+
+=back
+
+B<Returns:> The full path string for the temporary directory.
+
+B<Examples:>
+
+    my $dir = $hook->tempdir('staging');
+    # Returns: '/path/to/env/work/staging' (created if absent)
+
+    my $dir = $hook->tempdir;
+    # Returns: '/path/to/env/work/tempdir-1710000000-9876' (created if absent)
+
+=head1 ABSTRACT METHODS
+
+The following method must be implemented by every concrete hook subclass.
+The base class implementation calls C<kit_bug> and terminates with an error.
+
+=head2 perform
+
+    $hook->perform;
+
+Carries out the hook's work. The implementation must call C<$self->done> or
+C<$self->done($result)> before returning to signal completion. See
+C<Genesis::Hook::Blueprint>, C<Genesis::Hook::Check>,
+and C<Genesis::Hook::Features> for examples of complete implementations.
+
+B<Returns:> Whatever value was passed to C<done>, made available via
+C<results>. The return value of C<perform> itself is not used by Genesis;
+only the value recorded via C<done> matters.
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 check_for_required_args
+
+    Genesis::Hook->check_for_required_args(\%opts, @required);
+
+Validates that all keys listed in C<@required> are present (defined) in
+C<%opts>. Used by C<init> to enforce required constructor arguments.
+
+B<Parameters:>
+
+=over 4
+
+=item C<\%opts>
+
+A hash reference of the options to check.
+
+=item C<@required>
+
+The list of key names that must be defined in C<%opts>.
+
+=back
+
+B<Returns:> C<1> if all required keys are present.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Missing required arguments for a perl-based kit hook call: %s"> -- raised
+via C<bug()> if any required keys are absent. C<%s> is replaced with the
+comma-separated list of missing key names.
+
+=back
+
+B<Examples:>
+
+    Genesis::Hook->check_for_required_args(\%opts, qw/env/);
+    # Returns: 1 if 'env' is present in %opts; dies otherwise
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Hook/Addon.pod
+++ b/lib/Genesis/Hook/Addon.pod
@@ -1,0 +1,378 @@
+=encoding UTF-8
+
+=head1 NAME
+
+Genesis::Hook::Addon - Hook implementation for Genesis kit addon subcommands
+
+=head1 SYNOPSIS
+
+    package Genesis::Hook::Addon::my_kit;
+    use parent 'Genesis::Hook::Addon';
+
+    sub perform {
+        my ($self) = @_;
+
+        my $script = $self->{script};
+
+        if ($script eq 'rotate-creds') {
+            # handle the rotate-creds addon subcommand
+            $self->vault->rotate($self->env->name . '/creds');
+            $self->done(1);
+        } else {
+            $self->kit_bug("Unknown addon script: %s", $script);
+        }
+    }
+
+    sub cmd_details {
+        return "Rotate all credentials for this deployment.";
+    }
+
+    1;
+
+=head1 DESCRIPTION
+
+C<Genesis::Hook::Addon> is the base class for addon hook implementations in
+Genesis kits. Addon hooks respond to C<genesis do E<lt>envE<gt> E<lt>cmdE<gt>>
+invocations and can implement one or more subcommands.
+
+An addon hook receives the name of the subcommand to run via
+C<< $self->{script} >> and any additional arguments via C<< $self->{args} >>.
+Kit authors subclass C<Genesis::Hook::Addon> and implement the C<perform>
+method to dispatch on C<< $self->{script} >>.
+
+The standard pattern for a multi-command addon is to keep all subcommands in
+C<hooks/addon.pm> and dispatch within C<perform>. Alternatively, individual
+subcommands may be placed in separate files named
+C<hooks/addon-E<lt>cmdE<gt>.pm>, each implementing their own C<perform> method.
+Both Perl module and shell script forms of per-command addon files are
+supported; if both C<hooks/addon-E<lt>cmdE<gt>.pm> and
+C<hooks/addon-E<lt>cmdE<gt>> exist, the Perl module takes precedence.
+
+The class also provides C<help>, which enumerates all available addon
+subcommands by querying each addon file's C<cmd_details> method (for Perl
+modules) or running the script with a C<help> argument (for shell scripts).
+If C<init> is called with C<help =E<gt> 1> in C<%opts>, C<help> is invoked
+automatically and the process exits before C<perform> is reached.
+
+This class inherits all hook infrastructure from L<Genesis::Hook>, including
+environment access, feature detection, BOSH and vault integration, and YAML
+merge utilities.
+
+=head1 METHODS
+
+=head2 init
+
+    my $hook = Genesis::Hook::Addon->init(%opts);
+
+Constructs and returns a new addon hook object. Delegates to the parent
+C<init> method after validating that the required keys are present.
+If C<$opts{help}> is true, calls C<help> immediately and exits the process
+before returning.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+Key-value pairs passed to the hook constructor. The following keys are
+required:
+
+=over 4
+
+=item C<env>
+
+B<(required)> A C<Genesis::Env> object for the deployment being operated on.
+
+=item C<kit>
+
+B<(required)> The C<Genesis::Kit> object for the kit providing this hook.
+
+=item C<script>
+
+B<(required)> The name of the addon subcommand being invoked (e.g.,
+C<'rotate-creds'>).
+
+=item C<args>
+
+B<(required)> An array reference of additional command-line arguments passed
+after the subcommand name.
+
+=item C<help>
+
+B<(optional)> If true, C<help> is called immediately and the process exits
+before C<perform> is reached.
+
+=back
+
+=back
+
+B<Returns:> A blessed C<Genesis::Hook::Addon> object (or subclass instance).
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Missing required arguments for a perl-based kit hook call: %s"> -- raised
+via C<bug()> if any of C<env>, C<kit>, C<script>, or C<args> are absent from
+C<%opts>. C<%s> is replaced with the comma-separated list of missing argument
+names.
+
+=back
+
+B<Examples:>
+
+    my $hook = Genesis::Hook::Addon->init(
+        env    => $env,
+        kit    => $kit,
+        script => 'rotate-creds',
+        args   => [],
+    );
+    # Returns: a blessed Genesis::Hook::Addon object
+
+    # With help flag -- prints help and exits
+    my $hook = Genesis::Hook::Addon->init(
+        env    => $env,
+        kit    => $kit,
+        script => 'rotate-creds',
+        args   => [],
+        help   => 1,
+    );
+    # Returns: never (process exits after printing help)
+
+=head2 help
+
+    $hook->help;
+    $hook->help(%addons);
+
+Displays help text for the available addon subcommands defined by the kit.
+
+If the hook object defines a C<cmd_details> method and it returns a plain
+string, that string is printed and the method returns immediately. If
+C<cmd_details> returns a hash reference (mapping command names to
+descriptions), those entries are merged into the C<%addons> accumulator
+instead and processing continues.
+
+The method then scans for extended addon files in the kit's C<hooks/>
+directory matching C<addon-*>. For each matching Perl module
+(C<addon-E<lt>cmdE<gt>.pm>), the module is loaded and its C<cmd_details>
+result is collected. For each matching shell script (C<addon-E<lt>cmdE<gt>>),
+the script is invoked with a C<help> argument and its output is captured.
+Perl module files take precedence over shell scripts when both exist for the
+same command name.
+
+After all sources are gathered, the combined set of commands and descriptions
+is printed to standard error in sorted order. If no addon subcommands are
+found, a message indicating the kit defines no addons is printed instead.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%addons>
+
+B<(optional)> An initial map of command names to description strings. Callers
+may pre-populate this to inject additional entries before the kit sources are
+scanned. Defaults to an empty hash.
+
+=back
+
+B<Returns:> C<1> after printing help for a single-command hook (when
+C<cmd_details> returns a plain string). C<0> if no addons are defined for
+the kit. The result of C<done(1)> after printing the multi-command addon
+listing.
+
+B<Examples:>
+
+    $hook->help;
+    # Returns: prints addon help to STDERR; returns done(1) or 0
+
+    # Pre-populate an extra command entry
+    $hook->help('extra-cmd' => 'Description of extra-cmd.');
+    # Returns: prints combined help including 'extra-cmd'
+
+=head2 parse_options
+
+    my %opts  = $hook->parse_options(\@opt_defn, %defaults);
+    my $href  = $hook->parse_options(\@opt_defn, %defaults);
+
+Parses command-line options from C<< $self->{args} >> using
+C<GetOptionsFromArray> from the Getopt::Long CPAN module. The parser
+configuration is set to C<no_ignore_case>, C<bundling>, C<no_pass_through>,
+C<auto_abbrev>, and C<permute> before parsing.
+
+Unknown options (any remaining element in C<< $self->{args} >> that begins
+with C<->) trigger a fatal error after parsing completes.
+
+B<Parameters:>
+
+=over 4
+
+=item C<\@opt_defn>
+
+B<(required)> An array reference of option specification strings in
+Getopt::Long format (e.g., C<['verbose|v', 'output|o=s']>).
+
+=item C<%defaults>
+
+B<(optional)> Initial values for the options hash. Keys that are not
+overridden by command-line arguments retain their default values.
+
+=back
+
+B<Returns:>
+
+In list context, returns the parsed options as a flat C<%opts> hash.
+
+In scalar context, returns a reference to the parsed options hash.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Error parsing command line arguments"> -- raised via C<bail()> if
+C<GetOptionsFromArray> fails (e.g., a required option argument is missing or
+an option string is unrecognized by the parser).
+
+=item *
+
+C<"Unknown option(s) passed to %s: %s"> -- raised via C<bail()> if any
+element remaining in C<< $self->{args} >> after parsing begins with C<->.
+The first C<%s> is the hook's label and the second is the comma-separated
+list of unrecognized option strings.
+
+=back
+
+B<Examples:>
+
+    # List context -- returns flat hash
+    my %opts = $hook->parse_options(
+        ['verbose|v', 'output|o=s'],
+        output => 'default.txt',
+    );
+    # Returns: (verbose => undef, output => 'default.txt') if no flags passed
+
+    # Scalar context -- returns hash reference
+    my $opts = $hook->parse_options(['dry-run|n']);
+    # Returns: { 'dry-run' => undef } if --dry-run was not in $self->{args}
+
+=head2 vault
+
+    my $vault = $hook->vault;
+
+Returns the vault service object for the environment's secrets store. The
+result is cached on the hook after the first call.
+
+B<Returns:> The vault service object from C<< $self->env->secrets_store->service >>.
+
+B<Examples:>
+
+    my $vault = $hook->vault;
+    $vault->get($hook->env->name . '/db/password');
+    # Returns: the cached vault service object
+
+=head2 results
+
+    my $result = $hook->results;
+
+Returns C<1> unconditionally, indicating that addon hooks always report a
+successful result. This overrides the C<Genesis::Hook> base class
+implementation, which returns the value stored by C<done>.
+
+B<Returns:> C<1>
+
+B<Examples:>
+
+    my $r = $hook->results;
+    # Returns: 1
+
+=head1 ABSTRACT METHODS
+
+The following method must be implemented by every concrete addon hook
+subclass. It is not implemented in this base class.
+
+=head2 perform
+
+    $hook->perform;
+
+Carries out the addon subcommand identified by C<< $self->{script} >>. The
+implementation should dispatch on C<< $self->{script} >>, execute the
+appropriate logic, and call C<< $self->done >> before returning.
+
+Additional command-line arguments are available via C<< $self->{args} >>
+and may be parsed with C<parse_options>.
+
+B<Returns:> Whatever value is passed to C<done>, made available via
+C<results>.
+
+B<Examples:>
+
+    sub perform {
+        my ($self) = @_;
+        my $script = $self->{script};
+        if ($script eq 'rotate-creds') {
+            $self->vault->rotate($self->env->name . '/creds');
+            $self->done(1);
+        } else {
+            $self->kit_bug("Unknown addon script: %s", $script);
+        }
+    }
+    # Returns: nothing (done() handles the result)
+
+=head1 OVERRIDE POINTS
+
+The following method may optionally be implemented by subclasses to provide
+help text for the addon.
+
+=head2 cmd_details
+
+    my $text = $hook->cmd_details;
+    my $hash = $hook->cmd_details;
+
+Returns help text for the addon subcommand(s). This method is not defined in
+the base class; the base class checks for its existence via C<can()> before
+calling it.
+
+If the hook file is C<hooks/addon.pm> (the primary multi-command addon), this
+method may return either a plain string (description of the single command) or
+a hash reference mapping subcommand names to their descriptions.
+
+If the hook file is a named subcommand file (e.g., C<hooks/addon-rotate.pm>),
+this method must return a plain string, since named subcommand files represent
+a single command each.
+
+B<Returns:>
+
+A plain string description, or a hash reference mapping command names to
+description strings (C<hooks/addon.pm> only).
+
+B<Examples:>
+
+    # Single-command hook (hooks/addon-rotate.pm):
+    sub cmd_details {
+        return "Rotate all credentials for this deployment.";
+    }
+    # Returns: 'Rotate all credentials for this deployment.'
+
+    # Multi-command hook (hooks/addon.pm):
+    sub cmd_details {
+        return {
+            'rotate-creds' => 'Rotate all credentials for this deployment.',
+            'smoke-test'   => 'Run smoke tests against the deployed environment.',
+        };
+    }
+    # Returns: { 'rotate-creds' => '...', 'smoke-test' => '...' }
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Hook/Blueprint.pod
+++ b/lib/Genesis/Hook/Blueprint.pod
@@ -1,0 +1,514 @@
+=encoding UTF-8
+
+=head1 NAME
+
+Genesis::Hook::Blueprint - Hook subclass for assembling the YAML file list for a BOSH deployment
+
+=head1 SYNOPSIS
+
+    package Genesis::Hook::Blueprint::my_kit;
+    use parent 'Genesis::Hook::Blueprint';
+
+    sub perform {
+        my ($self) = @_;
+
+        $self->check_minimum_genesis_version('3.0.0');
+
+        $self->validate_features(
+            valid_features => [qw(ha tls external-db)],
+            deprecated_features => {
+                'postgres' => { replace => 'external-db', msg => 'use external-db instead' },
+            },
+        );
+
+        $self->add_files('base/base.yml');
+        $self->add_files_if_wants('ha', 'base/ha.yml');
+        $self->add_files_if_exists('ops/custom.yml');
+
+        $self->done($self->results);
+    }
+
+    1;
+
+=head1 DESCRIPTION
+
+C<Genesis::Hook::Blueprint> is the concrete hook base class for kit blueprint
+hooks. Kit authors subclass this class and implement C<perform> to build the
+ordered list of YAML files that Genesis passes to C<spruce merge> when
+assembling a deployment manifest.
+
+The blueprint hook lifecycle is:
+
+=over 4
+
+=item 1.
+
+Genesis calls C<init>, which delegates to L<Genesis::Hook/init> and then
+initializes C<< $hook->{features} >> from the environment and sets
+C<< $hook->{files} >> to an empty array reference.
+
+=item 2.
+
+Genesis calls C<perform> on the concrete subclass. The C<perform>
+implementation uses the file-management and feature-validation methods
+provided by this class to build up the file list.
+
+=item 3.
+
+The kit calls C<< $self->done($self->results) >> to signal completion and
+hand the assembled file list back to Genesis.
+
+=back
+
+This class extends L<Genesis::Hook> and inherits all of its methods for
+feature detection, environment and kit access, BOSH integration, and YAML
+merging. See L<Genesis::Hook> for full documentation of inherited methods.
+
+=head1 METHODS
+
+=head2 init
+
+    my $hook = Genesis::Hook::Blueprint->init;
+
+Constructs and returns a new blueprint hook object. Delegates to
+L<Genesis::Hook/init> for the base initialization, then populates
+C<< $hook->{features} >> from the environment's current feature list and
+initializes C<< $hook->{files} >> to an empty array reference.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+Key-value pairs forwarded to L<Genesis::Hook/init>. The C<env> key is
+required. See L<Genesis::Hook/init> for the full list of accepted keys.
+
+=back
+
+B<Returns:> A blessed C<Genesis::Hook::Blueprint> object (or a subclass
+object when called on a subclass).
+
+B<Examples:>
+
+    my $hook = Genesis::Hook::Blueprint->init;
+    # Returns: a blessed Genesis::Hook::Blueprint object (call with env => $env)
+
+
+=head2 add_files
+
+    $hook->add_files;
+
+Appends one or more filenames to the blueprint's ordered file list. Files
+are added in the order supplied and are included in the final manifest merge
+in that order.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@files>
+
+One or more file path strings to append to the file list.
+
+=back
+
+B<Returns:> Nothing.
+
+B<Examples:>
+
+    $self->add_files;  # call with one or more filenames
+    # Returns: nothing (files are appended to the internal list)
+
+=head2 add_files_if_wants
+
+    $hook->add_files_if_wants($feature_test, @files);
+
+Appends the given files to the file list only if the environment has the
+specified feature active. If C<want_feature($feature_test)> returns false,
+the call is a no-op.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$feature_test>
+
+A feature name string or a compiled C<Regexp> object. Passed directly to
+C<want_feature>; see L<Genesis::Hook/want_feature> for matching semantics.
+
+=item C<@files>
+
+One or more file path strings to append when the feature is active.
+
+=back
+
+B<Returns:> Nothing.
+
+B<Examples:>
+
+    $self->add_files_if_wants('ha', 'base/ha.yml');
+    # Returns: nothing (appends 'base/ha.yml' to file list when 'ha' is active)
+
+    $self->add_files_if_wants(qr/^proto-/, 'base/proto.yml');
+    # Returns: nothing (appends 'base/proto.yml' when any feature matching ^proto- is active)
+
+=head2 add_files_if_exists
+
+    $hook->add_files_if_exists(@files);
+
+Appends each file to the file list only if that file exists on disk.
+Relative paths are resolved under the kit root via C<< $kit->path($file) >>.
+Absolute paths must fall under the environment's base directory; absolute
+paths that resolve outside the environment directory are silently skipped
+with a debug log message.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@files>
+
+One or more file paths to test and conditionally append. Relative paths are
+resolved against the kit root. Absolute paths must be within the environment
+base directory.
+
+=back
+
+B<Returns:> Nothing.
+
+B<Examples:>
+
+    $self->add_files_if_exists('overlays/custom.yml');
+    # Returns: nothing (appends 'overlays/custom.yml' if it exists under the kit root)
+
+    $self->add_files_if_exists('/path/to/env/ops/override.yml');
+    # Returns: nothing (appends the absolute path only if it exists and is within the env dir)
+
+=head2 remove_files
+
+    $hook->remove_files;
+
+Removes the specified filenames from the blueprint's file list. Any file in
+C<@files> that appears in the current list is removed; files not present in
+the list are ignored. The list order of remaining files is preserved.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@files>
+
+One or more file path strings to remove from the file list.
+
+=back
+
+B<Returns:> Nothing.
+
+B<Examples:>
+
+    $self->remove_files;  # call with one or more filenames to remove
+    # Returns: nothing (matching files are removed from the internal list)
+
+=head2 exchange_files
+
+    $hook->exchange_files(%exchange);
+
+Replaces files in the current list in-place using a substitution map. For
+each entry in the file list, if the entry's value appears as a key in
+C<%exchange>, it is replaced with the corresponding value. The replacement
+stops early once all keys in C<%exchange> have been consumed.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%exchange>
+
+A hash mapping old filenames to new filenames. Each key that matches a
+filename in the current list is replaced by its corresponding value.
+
+=back
+
+B<Returns:> Nothing.
+
+B<Examples:>
+
+    $self->exchange_files(
+        'base/networking-v1.yml' => 'base/networking-v2.yml',
+    );
+    # Returns: nothing (replaces 'base/networking-v1.yml' with 'base/networking-v2.yml' in-place)
+
+=head2 ops_dir
+
+    my $dir = $hook->ops_dir;
+
+Returns the ops directory path for the environment. The value is read from
+the environment's C<genesis.ops_dir> parameter. If the parameter is not set,
+the default value C<'ops'> is returned.
+
+B<Returns:> A string directory path, defaulting to C<'ops'>.
+
+B<Examples:>
+
+    my $dir = $hook->ops_dir;
+    # Returns: 'ops' (default), or the value of genesis.ops_dir if set
+
+=head2 upstream_dir
+
+    my $dir = $hook->upstream_dir;
+
+Returns the upstream directory path stored on the hook object, with a
+trailing slash appended if not already present. Returns C<undef> if no
+upstream directory has been configured on the hook.
+
+B<Returns:> The upstream directory string with a trailing slash, or C<undef>
+if C<< $hook->{upstream_dir} >> is not set.
+
+B<Examples:>
+
+    # When upstream_dir is set to 'upstream'
+    my $dir = $hook->upstream_dir;
+    # Returns: 'upstream/'
+
+    # When upstream_dir is not configured
+    my $dir = $hook->upstream_dir;
+    # Returns: undef
+
+=head2 upstream_pattern_match
+
+    my $re = $hook->upstream_pattern_match;
+
+Returns the regular expression used to identify upstream operation features.
+If C<< $hook->{upstream_pattern_match} >> is set, that value is returned.
+Otherwise the default pattern C<qr/^operations\/(.*)$/> is returned.
+
+B<Returns:> A compiled C<Regexp> object.
+
+B<Examples:>
+
+    my $re = $hook->upstream_pattern_match;
+    # Returns: qr/^operations\/(.*)$/ (default)
+
+    if ('operations/ha' =~ $hook->upstream_pattern_match) {
+        # feature is an upstream operation reference
+    }
+
+=head2 validate_features
+
+    $hook->validate_features(%opts);
+
+Validates the environment's features against a set of known-valid, deprecated,
+and mutually exclusive feature definitions. Valid features are accepted;
+deprecated features are translated to their replacements with warnings;
+features matching the upstream pattern are looked up in the kit's upstream
+directory; features matching ops files in the environment's ops directory are
+accepted as custom ops features; all remaining features produce errors.
+
+After validation, the hook's feature list is updated via C<set_features> to
+contain only the curated (accepted) feature names.
+
+If any warnings were generated, they are reported via the Genesis
+C<warning> function. If any errors were generated, the method terminates
+via C<bail()>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<valid_features>
+
+B<(required)> Either an array reference of valid feature name strings, or a
+hash reference mapping feature names to true values. Any feature not in this
+set (and not otherwise handled) is rejected as invalid.
+
+=item C<deprecated_features>
+
+B<(optional)> A hash reference mapping deprecated feature names to resolution
+descriptors. Each value may be a plain string (treated as a single replacement
+feature), or a hash reference with the following keys:
+
+=over 4
+
+=item C<replace>
+
+A string (single replacement feature), an array reference of replacement
+feature names (multiple replacements), or an empty array reference (feature
+is now default behavior and can be removed).
+
+=item C<msg>
+
+An optional message string appended to the warning or error text.
+
+=back
+
+=item C<mutually_exclusive_features>
+
+B<(optional)> A hash reference mapping group names to array references of
+feature names. If more than one feature from any group is active after
+validation, an error is raised.
+
+=item C<warnings>
+
+B<(optional)> An array reference of pre-existing warning strings to include
+in the warning output.
+
+=item C<errors>
+
+B<(optional)> An array reference of pre-existing error strings to include in
+the error output.
+
+=back
+
+B<Returns:> Nothing. Terminates via C<bail()> if any validation errors are
+found.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Invalid valid_features parameter: expected a hash or array reference, got %s">
+-- raised via C<bail()> if C<valid_features> is neither a hash reference nor
+an array reference. C<%s> is replaced with the type string of the value
+received, or a representation of the scalar value.
+
+=item *
+
+C<"\nFeature validation encountered the following errors:\n%s"> -- raised via
+C<bail()> if any features are invalid, removed, or mutually exclusive. C<%s>
+is replaced with the formatted list of error messages.
+
+=back
+
+B<Examples:>
+
+    $self->validate_features(
+        valid_features => [qw(ha tls external-db)],
+        deprecated_features => {
+            'postgres' => { replace => 'external-db' },
+            'old-tls'  => { replace => ['tls'], msg => 'updated in v2.0' },
+            'legacy'   => { replace => [], msg => 'now enabled by default' },
+        },
+        mutually_exclusive_features => {
+            'database' => [qw(internal-db external-db)],
+        },
+    );
+    # Returns: nothing on success; calls bail() if validation fails
+
+=head2 results
+
+    my $files = $hook->results;
+
+Returns the assembled file list after the blueprint hook has completed.
+Terminates with an error if the hook has not been marked complete, or if the
+file list is empty.
+
+B<Returns:> An array reference of file path strings representing the ordered
+list of YAML files to merge into the deployment manifest.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Blueprint hook could not be run"> -- raised via C<bail()> if the hook has
+not been marked complete (i.e., C<done> was never called, or was called with
+C<undef>).
+
+=item *
+
+C<"Could not determine which YAML files to merge: 'blueprint' specified no files">
+-- raised via C<bail()> if the hook completed but no files were added to the
+list.
+
+=back
+
+B<Examples:>
+
+    $self->done($self->results);
+    my $files = $hook->results;
+    # Returns: ['base/base.yml', 'base/ha.yml', ...]
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _handle_deprecated_feature
+
+    $hook->_handle_deprecated_feature(
+        $feature, $resolution,
+        $curated_features, $warnings_ref, $errors_ref
+    );
+
+Processes a single deprecated feature entry during C<validate_features>.
+Interprets the C<$resolution> descriptor to determine whether the feature
+should be replaced by one or more new features, silently removed (now default
+behavior), or rejected with an error. Appends warning or error messages to the
+supplied array references as appropriate.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$feature>
+
+The deprecated feature name being processed.
+
+=item C<$resolution>
+
+A hash reference (or plain string, which is promoted to
+C<< { replace => $string } >>) describing how to handle the deprecated
+feature. Recognized keys are C<replace> and C<msg>. If the hash has a
+C<params> key, the method terminates with an unimplemented error.
+
+=item C<$curated_features>
+
+An array reference to which replacement feature names are appended when the
+deprecated feature has replacements.
+
+=item C<$warnings_ref>
+
+An array reference to which warning strings are appended.
+
+=item C<$errors_ref>
+
+An array reference to which error strings are appended.
+
+=back
+
+B<Returns:> C<1>.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Feature replacement by params not yet implemented for $feature"> -- raised
+via C<bail()> if the resolution hash contains a C<params> key. C<$feature>
+is interpolated directly into the string.
+
+=back
+
+B<Examples:>
+
+    $self->_handle_deprecated_feature(
+        'old-ssl', { replace => 'tls' },
+        \@curated, \@warnings, \@errors,
+    );
+    # Appends 'tls' to @curated and a deprecation warning to @warnings
+    # Returns: 1
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Hook/Check.pod
+++ b/lib/Genesis/Hook/Check.pod
@@ -1,0 +1,498 @@
+=encoding UTF-8
+
+=head1 NAME
+
+Genesis::Hook::Check - Hook implementation for kit environment pre-flight checks
+
+=head1 SYNOPSIS
+
+    package Genesis::Hook::Check::my_kit;
+    use parent 'Genesis::Hook::Check';
+
+    sub perform {
+        my ($self) = @_;
+
+        $self->start_check('cloud-config');
+        $self->has_entry('cloud-config', 'vm_type',     'small');
+        $self->has_entry('cloud-config', 'network',     'default');
+        $self->check_result('cloud-config');
+
+        $self->start_check('environment');
+        $self->has_entry('environment', 'params', 'base_domain');
+        $self->check_result('environment');
+
+        $self->done(0);
+    }
+
+    1;
+
+=head1 DESCRIPTION
+
+C<Genesis::Hook::Check> is the base class for kit check hooks. Kit authors
+subclass this module and implement the C<perform> method to verify that the
+environment is correctly configured before a deployment is attempted.
+
+A check hook typically iterates over a set of named checks, printing
+pass/fail results for each one. The methods provided by this class handle
+the structured output formatting and record-keeping for those results.
+
+The check lifecycle follows three phases for each config area being checked:
+
+=over 4
+
+=item 1.
+
+Call C<start_check> to announce the category being checked (e.g.,
+C<'cloud-config'>, C<'runtime-config'>, or C<'environment'>).
+
+=item 2.
+
+Call C<has_entry> one or more times to verify that specific named entries
+exist in the appropriate BOSH config or environment manifest.
+
+=item 3.
+
+Call C<check_result> to print the aggregate pass/fail result for that
+category.
+
+=back
+
+This class inherits from L<Genesis::Hook>. See L<Genesis::Hook> for the
+full lifecycle description, including C<init>, C<done>, C<env>, C<features>,
+and all other base class methods.
+
+=head1 METHODS
+
+=head2 init
+
+    my $hook = Genesis::Hook::Check->init();
+
+Constructs and returns a new check hook object. Validates that the required
+C<env> and C<kit> keys are present in the initialization arguments (passed
+as a flat key-value list), then delegates to C<< Genesis::Hook->init >> to
+complete initialization.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+Key-value pairs stored on the hook object. The following keys are required:
+
+=over 4
+
+=item C<env>
+
+B<(required)> A C<Genesis::Env> object representing the deployment environment.
+
+=item C<kit>
+
+B<(required)> A C<Genesis::Kit> object for the kit being checked.
+
+=back
+
+=back
+
+B<Returns:> A blessed C<Genesis::Hook::Check> object (or a subclass thereof).
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Missing required arguments for a perl-based kit hook call: %s"> -- raised
+via C<bug()> if either C<env> or C<kit> is absent from C<%opts>. C<%s> is
+replaced with the comma-separated list of missing argument names.
+
+=back
+
+B<Examples:>
+
+    my $hook = Genesis::Hook::Check->init(env => $env, kit => $kit);
+    # Returns: a blessed Genesis::Hook::Check object
+
+=head2 start_check
+
+    $hook->start_check($type);
+
+Prints a formatted status line announcing the start of checks for the given
+C<$type> category. Hyphens and underscores in C<$type> are replaced with
+spaces in the output.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$type>
+
+A string label for the category of checks being started (e.g.,
+C<'cloud-config'>, C<'runtime-config'>, C<'environment'>).
+
+=back
+
+B<Returns:> Nothing meaningful.
+
+B<Examples:>
+
+    $hook->start_check('cloud-config');
+    # prints: "  - checking cloud config..."
+
+    $hook->start_check('runtime_config');
+    # prints: "  - checking runtime config..."
+
+=head2 check_result
+
+    my $ok = $hook->check_result($config, $result, $message);
+
+Records and displays the final pass/fail status for a config category. If
+C<$result> is not explicitly provided, the result is derived from the
+accumulated C<has_entry> checks for C<$config>: all entries must have passed
+for the result to be C<'passed'>; any failure produces C<'failed'>.
+
+The C<$result> argument accepts the following values, which are normalized
+before display:
+
+=over 4
+
+=item *
+
+C<'error'>, a false value, or C<0> -- normalized to C<'failed'>
+
+=item *
+
+C<'ok'>, C<'passed'>, or C<'1'> -- normalized to C<'passed'>
+
+=item *
+
+Any other truthy string (e.g., C<'warning'>) -- displayed as-is, colored
+yellow
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item C<$config>
+
+The config category label (e.g., C<'cloud-config'>). Hyphens and underscores
+are replaced with spaces in the output.
+
+=item C<$result>
+
+B<(optional)> An explicit result value. When not provided (C<undef>), the
+result is computed from the C<has_entry> checks recorded for C<$config>.
+
+=item C<$message>
+
+B<(optional)> An additional message appended to the result line, separated
+by C<" - ">.
+
+=back
+
+B<Returns:> C<1> if the result is C<'passed'> or any other non-failed value;
+C<0> if the result is C<'failed'>.
+
+B<Examples:>
+
+    # Explicit pass
+    my $ok = $hook->check_result('cloud-config', 'passed');
+    # Returns: 1
+
+    # Derive result from accumulated has_entry checks
+    $hook->has_entry('cloud-config', 'vm_type', 'small');
+    my $ok = $hook->check_result('cloud-config');
+    # Returns: 1 if all prior cloud-config has_entry checks passed, 0 otherwise
+
+    # With an explicit message
+    my $ok = $hook->check_result('environment', 0, 'missing required params');
+    # Returns: 0
+
+=head2 has_entry
+
+    $hook->has_entry($config, $type, $name, @args);
+
+Checks whether a named entry of the given type exists in the specified config
+source, then prints a formatted check-mark or cross-mark result. The check
+result is stored internally and accumulated for a subsequent C<check_result>
+call.
+
+The C<$config> argument determines which backing method is used:
+
+=over 4
+
+=item C<'cloud-config'>
+
+Delegates to C<has_cloud_config_entry>.
+
+=item C<'runtime-config'>
+
+Delegates to C<has_runtime_config_entry>.
+
+=item C<'environment'>
+
+Delegates to C<has_environment_entry>.
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item C<$config>
+
+The config source to check. Must be one of C<'cloud-config'>,
+C<'runtime-config'>, or C<'environment'>.
+
+=item C<$type>
+
+The entry type within the config source (e.g., C<'vm_type'>, C<'network'>,
+C<'params'>, C<'job'>).
+
+=item C<$name>
+
+The name of the specific entry to look up.
+
+=item C<@args>
+
+Additional arguments passed through to the underlying check method.
+Interpretation depends on C<$config> and C<$type>; see
+C<has_cloud_config_entry>, C<has_runtime_config_entry>, and
+C<has_environment_entry> for details.
+
+=back
+
+B<Returns:> Nothing meaningful.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Unknown check type: %s - expecting 'cloud-config', 'runtime-config' or 'environment'"> --
+printed via the Genesis error logger if C<$config> is not one of the three recognized values.
+Returns C<0> without storing a check result.
+
+=back
+
+B<Examples:>
+
+    $hook->has_entry('cloud-config', 'vm_type', 'small');
+    # prints: a checkmark/cross with "vm type small"
+
+    $hook->has_entry('environment', 'params', 'base_domain');
+    # prints: a checkmark/cross with "params.base_domain is provided"
+
+    $hook->has_entry('runtime-config', 'job', 'bosh-dns');
+    # prints: a checkmark/cross with "bosh-dns job exists"
+
+=head2 has_cloud_config_entry
+
+    my $ok = $hook->has_cloud_config_entry($type, $name, @args);
+
+Checks whether a named entry of the given C<$type> exists in the environment's
+cloud config. The cloud config is fetched from the environment on the first
+call and cached for subsequent calls. The C<$type> string is pluralized for
+the key lookup (e.g., C<'vm_type'> becomes C<'vm_types'>).
+
+B<Parameters:>
+
+=over 4
+
+=item C<$type>
+
+The cloud-config resource type (e.g., C<'vm_type'>, C<'network'>,
+C<'disk_type'>).
+
+=item C<$name>
+
+The name of the entry to search for within the pluralized type list.
+
+=item C<@args>
+
+Currently unused; reserved for future extension.
+
+=back
+
+B<Returns:> C<1> if an entry with the given C<$name> exists in the cloud
+config under the pluralized C<$type> key, C<0> otherwise.
+
+B<Examples:>
+
+    my $ok = $hook->has_cloud_config_entry('vm_type', 'small');
+    # Returns: 1 if cloud config has a vm_types entry named 'small', 0 otherwise
+
+    my $ok = $hook->has_cloud_config_entry('network', 'default');
+    # Returns: 1 if cloud config has a networks entry named 'default', 0 otherwise
+
+=head2 has_runtime_config_entry
+
+    my ($ok, @msg) = $hook->has_runtime_config_entry($type, $name, @args);
+
+Checks whether a named entry of the given C<$type> exists in the environment's
+runtime config. Currently only supports C<$type eq 'job'>, which checks
+whether a job with the given C<$name> appears in any addon within the runtime
+config. The runtime config is fetched on the first call and cached; the
+unique list of job names across all addons is also cached after the first
+call.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$type>
+
+The runtime-config entry type to check. Currently only C<'job'> is supported.
+
+=item C<$name>
+
+The name of the job to search for across all runtime config addons.
+
+=item C<@args>
+
+Currently unused; reserved for future extension.
+
+=back
+
+B<Returns:> In list context, a two-or-three element list: the boolean result
+(C<1> or C<0>), a C<sprintf>-style format string for the display message,
+and the job name.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Unknown check type: %s - expecting 'job' (might have to add %s implementation)"> --
+raised via C<bug()> if C<$type> is not C<'job'>. Both C<%s> placeholders are
+replaced with C<$type>.
+
+=back
+
+B<Examples:>
+
+    my ($ok) = $hook->has_runtime_config_entry('job', 'bosh-dns');
+    # Returns: (1) if bosh-dns appears as a job in any runtime config addon
+
+=head2 has_environment_entry
+
+    my ($ok, @msg) = $hook->has_environment_entry($type, $name, @args);
+
+Checks whether an entry exists in the environment's manifest. The full
+environment manifest is fetched on the first call and cached. Supports two
+check types: C<'params'> and C<'exodus'>.
+
+For C<$type eq 'params'>, the named parameter is looked up under
+C<params.$name> in the environment manifest. The C<@args> list is interpreted
+as a flat hash of options:
+
+=over 4
+
+=item C<type =E<gt> $reqtype>
+
+Checks that the parameter exists and is of the given type. Supported type
+strings include C<'string'>, C<'undefined'>, and reference types (via
+C<ref()>). When C<$reqtype> is C<'undefined'>, passes if the parameter is
+not defined.
+
+=item C<value_in =E<gt> \@allowed>
+
+Checks that the parameter value is one of the values in C<\@allowed>.
+
+=item C<retired =E<gt> 1>
+
+Checks that the parameter is I<not> defined (i.e., has been removed from
+the environment). Passes if the parameter is absent.
+
+=item C<msg =E<gt> $custom_message>
+
+Overrides the default display message for this check.
+
+=back
+
+When none of C<type>, C<value_in>, or C<retired> are given, the check simply
+verifies that the parameter is defined.
+
+For C<$type eq 'exodus'>, checks whether exodus data exists for the
+environment. When neither C<env> nor C<deployment> options are given, checks
+whether the current environment's own exodus data contains the C<name> key.
+When C<deployment> is provided, looks up the named C<$name> key in the exodus
+data for the specified environment and deployment path.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$type>
+
+The entry category to check: C<'params'> or C<'exodus'>.
+
+=item C<$name>
+
+For C<'params'>: the parameter name under C<params> in the manifest.
+For C<'exodus'>: the exodus key to look up.
+
+=item C<@args>
+
+A flat list of key-value option pairs (interpreted as C<%opts>). See above
+for supported keys.
+
+=back
+
+B<Returns:> In list context, a list of two or three elements: the boolean
+result (C<1> or C<0>), a C<sprintf>-style format string for the display
+message, and one or more format arguments.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Unknown check type: %s - expecting 'params' (might have to add %s implementation)"> --
+raised via C<bug()> if C<$type> is not C<'params'> or C<'exodus'>. Both
+C<%s> placeholders are replaced with C<$type>.
+
+=back
+
+B<Examples:>
+
+    # Check that a param is defined
+    my ($ok) = $hook->has_environment_entry('params', 'base_domain');
+    # Returns: (1) if params.base_domain is defined in the environment manifest
+
+    # Check that a param is a string
+    my ($ok) = $hook->has_environment_entry('params', 'base_domain', type => 'string');
+    # Returns: (1) if params.base_domain is defined (any non-reference value)
+
+    # Check that a param holds one of the allowed values
+    my ($ok) = $hook->has_environment_entry('params', 'scale',
+        value_in => [qw(dev staging prod)]);
+    # Returns: (1) if params.scale is one of dev, staging, or prod
+
+    # Check that a retired param has been removed
+    my ($ok) = $hook->has_environment_entry('params', 'old_param', retired => 1);
+    # Returns: (1) if params.old_param is not defined
+
+    # Check exodus data for current environment
+    my ($ok) = $hook->has_environment_entry('exodus', 'director_url');
+    # Returns: (1) if the environment's own exodus data contains the 'name' key
+
+    # Check exodus data for another deployment
+    my ($ok) = $hook->has_environment_entry('exodus', 'director_url',
+        deployment => 'bosh/bosh');
+    # Returns: (1) if director_url exists in exodus for bosh/bosh
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Hook/CloudConfig.pod
+++ b/lib/Genesis/Hook/CloudConfig.pod
@@ -1,0 +1,2247 @@
+=encoding UTF-8
+
+=head1 NAME
+
+Genesis::Hook::CloudConfig - Hook subclass for generating BOSH cloud configs from Genesis environments
+
+=head1 SYNOPSIS
+
+    package Genesis::Hook::CloudConfig::my_kit;
+    use parent 'Genesis::Hook::CloudConfig';
+
+    sub perform {
+        my ($self) = @_;
+
+        my $config = {};
+
+        push @{$config->{azs}}, {
+            name             => 'z1',
+            cloud_properties => { availability_zone => 'us-east-1a' },
+        };
+
+        push @{$config->{vm_types}}, $self->vm_type_definition(
+            'default',
+            common                  => { instance_type => 't3.medium' },
+            cloud_properties_for_iaas => { aws => { instance_type => 't3.medium' } },
+        );
+
+        push @{$config->{networks}}, $self->network_definition(
+            'deployment',
+            strategy       => 'ocfp',
+            dynamic_subnets => { subnets => undef, allocation => { size => 64 } },
+        );
+
+        $self->done($config);
+    }
+
+    1;
+
+=head1 DESCRIPTION
+
+C<Genesis::Hook::CloudConfig> is the base class for Genesis kit hooks that
+generate BOSH cloud configs. Kit authors subclass this class, implement
+C<perform>, build a cloud config hashref using the provided definition
+helpers, and call C<done($config)> when finished.
+
+The class extends C<Genesis::Hook> with cloud-config-specific functionality:
+
+=over 4
+
+=item *
+
+AZ lookup and CPI-shadow AZ generation
+
+=item *
+
+Network definition building (OCFP dynamic, greedy, and VIP strategies)
+
+=item *
+
+Subnet range calculation and allocation tracking (including Logical Subnet
+Amalgamation for multi-AZ shared-CIDR deployments)
+
+=item *
+
+VM type, VM extension, and disk type definition helpers
+
+=item *
+
+User- and director-level override application from environment files
+
+=back
+
+When C<done> is called, the class validates the config hashref, processes
+subnets into BOSH-compatible form (including LSA conversion), serializes the
+result to canonical YAML with deterministic key ordering, and stores it on
+the object for retrieval via C<results>.
+
+Instances are cached per C<id> (basename plus optional purpose), so multiple
+calls to C<init> for the same deployment return the same object.
+
+See also:
+
+=over 4
+
+=item L<Genesis::Hook>
+
+=item L<Genesis::Hook::CloudConfig::LookupRef>
+
+=item L<Genesis::Hook::CloudConfig::LookupNetworkRef>
+
+=item L<Genesis::Hook::CloudConfig::LookupSubnetRef>
+
+=item L<Genesis::Hook::CloudConfig::Helpers>
+
+=back
+
+=head1 METHODS
+
+=head2 init
+
+    my $hook = Genesis::Hook::CloudConfig->init(%opts);
+
+Constructs and returns a cloud config hook object. The C<env> key in C<%opts>
+is required. If the environment uses C<create-env> (i.e., is a BOSH director
+bootstrap environment), the call dies because directors have no cloud config
+of their own.
+
+The object is cached by a composite key built from C<basename> and C<purpose>,
+so calling C<init> again with the same parameters returns the previously
+constructed object without reinitializing.
+
+Calls the base-class C<init> to set up shared hook state, then populates:
+
+=over 4
+
+=item *
+
+C<overrides> — environment and director cloud-config override data
+
+=item *
+
+C<network> — BOSH director network data fetched from director exodus
+
+=item *
+
+C<ocfp_config> — OCFP C<net>/C<vpc> config, only for OCFP environments
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+Key-value pairs. The following keys are recognized:
+
+=over 4
+
+=item C<env>
+
+B<(required)> A C<Genesis::Env> object for the deployment being operated on.
+
+=item C<purpose>
+
+B<(optional)> A subtype string appended to the basename to form the object
+identity key. Defaults to the C<GENESIS_CLOUD_CONFIG_SUBTYPE> environment
+variable if set.
+
+=item C<basename>
+
+B<(optional)> The base name used to prefix component names. Defaults to
+C<< env->name . '.' . env->type >>.
+
+=back
+
+=back
+
+B<Returns:> A blessed C<Genesis::Hook::CloudConfig> object (or a subclass
+instance if called on a subclass).
+
+B<Errors:>
+
+=over 4
+
+=item C<"Create-env environments do not have deployment cloud configs,as there is no director to upload them to.">
+
+Thrown when C<env> uses create-env mode.
+
+=back
+
+B<Examples:>
+
+    my $hook = Genesis::Hook::CloudConfig->init(env => $env);
+    # Returns: a Genesis::Hook::CloudConfig instance
+
+=head2 done
+
+    $self->done($contents);
+
+Marks the cloud config hook as complete. Validates that C<$contents> is a
+hashref, processes subnet definitions into BOSH-compatible form (converting
+shared-CIDR subnets into Logical Subnet Amalgamations as needed), serializes
+the result to YAML with deterministic key ordering (C<name> first,
+C<cloud_properties> last), and stores the result on the object.
+
+Modifies the object in-place by setting C<< $self->{contents} >>.
+
+After this call, C<completed> returns true and C<results> returns the
+serialized cloud config.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$contents>
+
+B<(required)> A hashref containing the full BOSH cloud config structure.
+Expected keys include C<azs>, C<vm_types>, C<disk_types>, C<networks>, and
+C<vm_extensions>, though the structure is not validated beyond the type check.
+
+=back
+
+B<Returns:> The return value of the base class C<done> method.
+
+B<Errors:>
+
+=over 4
+
+=item C<"CloudConfig hook must return a hashref containing the cloud config - got %s">
+
+Thrown when C<$contents> is not a hashref. C<%s> is replaced with the ref
+type of the argument, or C<'scalar value'> if it is not a reference.
+
+=back
+
+B<Examples:>
+
+    $self->done({
+        azs      => [{ name => 'z1', cloud_properties => {} }],
+        vm_types => [{ name => 'default', cloud_properties => {} }],
+    });
+    # Returns: the base-class done() return value; sets hook as completed
+
+=head2 results
+
+    my ($config, $network) = $self->results;
+    my $hashref = $self->results;
+
+Returns the cloud config produced by the hook after it has completed. Returns
+C<undef> (with a trace-level warning) if called before the hook completes.
+
+B<Returns:>
+
+In list context, returns a two-element list:
+
+=over 4
+
+=item C<$config>
+
+The serialized cloud config as a YAML string.
+
+=item C<$network>
+
+The BOSH director network data hashref used during config generation.
+
+=back
+
+In scalar context, returns a hashref with keys C<config> and C<network>.
+
+B<Examples:>
+
+    # List context
+    my ($yaml, $net) = $self->results;
+    # Returns: ('--- azs: ...', { azs => {...}, subnets => {...} })
+
+    # Scalar context
+    my $r = $self->results;
+    # Returns: { config => '--- azs: ...', network => {...} }
+
+=head2 basename
+
+    my $base   = $self->basename;
+    my $yaml   = $self->contents;
+    my $path   = $self->overrides_base;
+    my $name   = $self->name_for(@parts);
+
+Accessor methods for common cloud config properties.
+
+C<basename> returns the basename string used to prefix all component names.
+It defaults to C<< env_name.env_type >> unless overridden at construction
+time.
+
+C<contents> returns the serialized YAML cloud config string stored by
+C<done>. Returns an empty hashref if C<done> has not been called yet.
+
+C<overrides_base> returns the base lookup path used to find cloud config
+override definitions in the environment file. Always returns
+C<'bosh-configs.cloud'>.
+
+C<name_for> constructs a component name by joining the hook's C<basename>
+with the hyphen-joined C<@parts>, separated by dots. One or more part
+strings should be provided.
+
+B<Returns:>
+
+=over 4
+
+=item C<basename>
+
+A string of the form C<< env_name.env_type >>.
+
+=item C<contents>
+
+A YAML string, or an empty hashref before C<done> is called.
+
+=item C<overrides_base>
+
+The string C<'bosh-configs.cloud'>.
+
+=item C<name_for>
+
+A string of the form C<< basename.part1-part2-... >>.
+
+=back
+
+B<Examples:>
+
+    my $base = $self->basename;
+    # Returns: 'my-env.bosh'
+
+    my $yaml = $self->contents;
+    # Returns: "azs:\n- name: z1\n  cloud_properties: ...\n"
+
+    my $path = $self->overrides_base;
+    # Returns: 'bosh-configs.cloud'
+
+    my $name = $self->name_for('vm', 'default');
+    # Returns: 'my-env.bosh.vm-default'
+
+=head2 for_scale
+
+    my $value = $self->for_scale(\%map, $default);
+
+Looks up the current environment scale in C<%map> and returns the
+corresponding value. If the scale is not found, returns C<$default>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<\%map>
+
+A hashref mapping scale names (e.g., C<'dev'>, C<'prod'>) to values.
+
+=item C<$default>
+
+B<(optional)> Value to return when the current scale is not in C<%map>.
+
+=back
+
+B<Returns:> The value from C<%map> for the current scale, or C<$default>.
+
+B<Examples:>
+
+    my $size = $self->for_scale({ dev => 1, prod => 3 }, 2);
+    # Returns: 1  (if scale is 'dev')
+
+=head2 for_iaas
+
+    my $value = $self->for_iaas(\%map, $default);
+
+Looks up the current environment IaaS in C<%map> and returns the
+corresponding value. If the IaaS is not found, returns C<$default>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<\%map>
+
+A hashref mapping IaaS names (e.g., C<'aws'>, C<'azure'>, C<'vsphere'>) to
+values.
+
+=item C<$default>
+
+B<(optional)> Value to return when the current IaaS is not in C<%map>.
+
+=back
+
+B<Returns:> The value from C<%map> for the current IaaS, or C<$default>.
+
+B<Examples:>
+
+    my $type = $self->for_iaas({ aws => 't3.medium', vsphere => 'small' }, 'medium');
+    # Returns: 't3.medium'  (if IaaS is 'aws')
+
+=head2 lookup_ref
+
+    my $ref = $self->lookup_ref($paths, $default);
+
+Creates a L<Genesis::Hook::CloudConfig::LookupRef> that defers resolution of
+a value until the config definition is processed. The ref is resolved against
+C<< $env->params >> when the definition is applied.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$paths>
+
+A string or arrayref of environment parameter paths to look up.
+
+=item C<$default>
+
+B<(optional)> Value to return if none of the paths yield a defined value.
+
+=back
+
+B<Returns:> A C<Genesis::Hook::CloudConfig::LookupRef> object.
+
+B<Examples:>
+
+    my $ref = $self->lookup_ref('params.instance_type', 't3.medium');
+    # Returns: a LookupRef that resolves to the instance_type param
+
+=head2 network_reference
+
+    my $ref = $self->network_reference();
+
+Creates a L<Genesis::Hook::CloudConfig::LookupNetworkRef> that defers
+resolution of a cloud property value until subnet definitions are processed.
+The ref is resolved against the BOSH director network data. All C<@args> are
+passed directly to C<Genesis::Hook::CloudConfig::LookupNetworkRef->new>.
+
+See L<Genesis::Hook::CloudConfig::LookupNetworkRef> for the accepted
+argument format.
+
+B<Returns:> A C<Genesis::Hook::CloudConfig::LookupNetworkRef> object.
+
+B<Examples:>
+
+    my $ref = $self->network_reference('sgs', sub {
+        my ($self, $data, $ref) = @_;
+        return $data->{sgs}{'default'}{id};
+    });
+    # Returns: a LookupNetworkRef that resolves to the default SG id
+
+=head2 subnet_reference
+
+    my $ref = $self->subnet_reference();
+
+Creates a L<Genesis::Hook::CloudConfig::LookupSubnetRef> that defers
+resolution of a cloud property to per-subnet OCFP config data. Only
+supported for OCFP network strategies. All C<@args> are passed directly to
+C<Genesis::Hook::CloudConfig::LookupSubnetRef->new>.
+
+See L<Genesis::Hook::CloudConfig::LookupSubnetRef> for the accepted
+argument format.
+
+B<Returns:> A C<Genesis::Hook::CloudConfig::LookupSubnetRef> object.
+
+B<Examples:>
+
+    my $ref = $self->subnet_reference('subnet_id');
+    # Returns: a LookupSubnetRef for subnet-level property resolution
+
+=head2 build_cloud_config
+
+    my $config = $self->build_cloud_config(\%config);
+
+Applies any extended cloud config definitions from the environment file
+(from C<bosh-configs.cloud> in the env YAML) onto the given C<%config>
+hashref. Extended definitions may add new VM types, disk types, and VM
+extensions via C<<based-on>> inheritance.
+
+B<Parameters:>
+
+=over 4
+
+=item C<\%config>
+
+B<(required)> The partial cloud config hashref assembled by the kit's
+C<perform> method. Modified in-place by adding entries from the environment's
+extended cloud config.
+
+=back
+
+B<Returns:> The C<\%config> hashref, with any extended definitions merged in.
+
+B<Examples:>
+
+    my $config = { vm_types => [...], networks => [...] };
+    $self->build_cloud_config($config);
+    # Returns: $config with any env-defined vm_types/disk_types/vm_extensions added
+
+=head2 build_cpi_azs
+
+    my %az_block = $self->build_cpi_azs(%options);
+
+Builds CPI-specific shadow AZ definitions for environments with a custom CPI
+enabled. Returns an empty list if the environment does not have CPI enabled.
+
+Each AZ in the parent's available AZs gets a corresponding shadow AZ using
+the environment's AZ prefix plus the AZ index number. The network data is
+updated to record the CPI-specific AZ name for each base AZ.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%options>
+
+B<(optional)> Options passed through to C<_az_definition_for>. The
+C<virtual> option suppresses cloud properties from the AZ definition.
+
+=back
+
+B<Returns:> In list context, a two-element list C<(azs => \@azs)> suitable
+for direct inclusion in a cloud config hashref. Returns an empty list if CPI
+is not enabled.
+
+B<Examples:>
+
+    my %cpi_block = $self->build_cpi_azs;
+    # Returns: (azs => [{ name => 'my-env-z1', cloud_properties => {...}, cpi => '...' }])
+
+    push @{$config->{azs}}, $cpi_block{azs}->@* if %cpi_block;
+
+=head2 relinquish_networks
+
+    $self->relinquish_networks(@networks);
+
+Removes the claim records for the named network targets from all subnets in
+the network data. This allows previously allocated IP ranges to be freed and
+re-allocated to other networks.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@networks>
+
+One or more network target names (the target portion, not the fully qualified
+name). Each name is expanded via C<name_for('net', $_)> before the claim is
+removed.
+
+=back
+
+B<Returns:> Nothing.
+
+B<Examples:>
+
+    $self->relinquish_networks('deployment', 'compilation');
+    # Removes allocation claims for my-env.bosh.net-deployment and
+    # my-env.bosh.net-compilation from all subnet claim records
+
+=head2 network_definition
+
+    my $config = $self->network_definition($target, %rules);
+
+Builds and returns a BOSH network definition hashref for the named network
+target. The network strategy is selected via the C<strategy> key in C<%rules>
+and dispatched to the corresponding builder method.
+
+Supported strategies:
+
+=over 4
+
+=item C<'vip'>
+
+Returns a minimal VIP network config (name and type only).
+
+=item C<'ocfp'>
+
+Builds a full OCFP network definition using one of the OCFP network models
+(C<dynamic_subnets>, C<greedy_subnets>, or C<subnets>). The chosen model key
+must be present in C<%rules>.
+
+=item C<'generic'>
+
+Not yet implemented; calls C<bug()> if invoked.
+
+=back
+
+After building the definition, records subnet IP allocations via
+C<update_network>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$target>
+
+The network target name (e.g., C<'deployment'>, C<'compilation'>).
+
+=item C<%rules>
+
+Key-value options controlling network generation:
+
+=over 4
+
+=item C<strategy>
+
+B<(optional)> The network strategy. Defaults to C<'generic'>.
+
+=item C<name_prefix>
+
+B<(optional)> When set, the network name is C<name_prefix . target> rather
+than C<name_for('net', target)>.
+
+=item C<dynamic_subnets>, C<greedy_subnets>, C<subnets>
+
+For OCFP strategies, one of these keys must be present. Its value is a
+hashref describing the allocation model (subnets filter, allocation counts,
+cloud properties, etc.).
+
+=back
+
+=back
+
+B<Returns:> A network definition hashref (with at minimum C<name> and C<type>
+keys), or an empty list if the strategy/environment combination does not
+apply (e.g., OCFP strategy requested on a non-OCFP environment).
+
+B<Errors:>
+
+=over 4
+
+=item C<"Network definition strategy %s is not supported by the cloud config hook">
+
+Thrown when C<strategy> names a method that does not exist on the class.
+C<%s> is the unsupported strategy name.
+
+=back
+
+B<Examples:>
+
+    my $net = $self->network_definition('deployment',
+        strategy       => 'ocfp',
+        dynamic_subnets => {
+            subnets    => undef,
+            allocation => { size => 64, statics => 8 },
+            cloud_properties_for_iaas => { aws => { subnet => 'subnet-abc' } },
+        },
+    );
+    # Returns: { name => 'my-env.bosh.net-deployment', type => 'manual', subnets => [...] }
+
+=head2 network
+
+    my $network_data = $self->network;
+
+Returns the BOSH director network data hashref, loading it lazily from
+director exodus if not already cached on the object.
+
+B<Returns:> A hashref containing C<azs>, C<subnets>, and related BOSH
+director network information.
+
+B<Examples:>
+
+    my $net = $self->network;
+    # Returns: { azs => { z1 => {...} }, subnets => { 'ocfp-a' => {...} } }
+
+=head2 update_network
+
+    $self->update_network($target, \%config, %options);
+
+Updates the internal network data to record IP allocation claims made by
+C<$target>. Clears any pre-existing claims for the network before recording
+new ones. Skips claim recording for greedy networks (those with the
+C<greedy_subnets> option set).
+
+B<Parameters:>
+
+=over 4
+
+=item C<$target>
+
+The network target name. The fully qualified network name is derived via
+C<name_for('net', $target)>.
+
+=item C<\%config>
+
+The network definition hashref produced by C<network_definition>. Its
+C<subnets> array is iterated to extract subnet names, ranges, and reserved
+ranges for allocation tracking.
+
+=item C<%options>
+
+If the C<greedy_subnets> key is present, claim recording is skipped.
+
+=back
+
+B<Returns:> Nothing (or early-returns for greedy networks).
+
+B<Examples:>
+
+    $self->update_network('deployment', $config);
+    # Returns: nothing; records allocation claims for each subnet in $config->{subnets}
+
+=head2 get_allocated_networks
+
+    my $allocations = $self->get_allocated_networks;
+
+Returns a hashref summarizing all current network allocation claims across all
+subnets. The structure maps fully qualified network names to per-subnet
+records containing the allocated IP range and availability zone.
+
+B<Returns:> A hashref of the form:
+
+    {
+        'my-env.bosh.net-deployment' => {
+            'ocfp-a' => { allocated => '10.0.1.0-10.0.1.63', az => 'z1' },
+            'ocfp-b' => { allocated => '10.0.2.0-10.0.2.63', az => 'z2' },
+        },
+    }
+
+B<Examples:>
+
+    my $allocs = $self->get_allocated_networks;
+    # Returns: { 'env.bosh.net-deployment' => { 'subnet-a' => { allocated => '...', az => 'z1' } } }
+
+=head2 get_network_security_groups
+
+    my $sgs = $self->get_network_security_groups($type, @names);
+
+Returns a L<Genesis::Hook::CloudConfig::LookupNetworkRef> that resolves to
+an arrayref of security group values from the BOSH director network data.
+The resolver filters C<sgs> entries by name (if C<@names> is provided) and
+returns the requested field (C<id> by default).
+
+B<Parameters:>
+
+=over 4
+
+=item C<$type>
+
+B<(optional)> The SG field to return (e.g., C<'id'>, C<'name'>). Defaults to
+C<'id'>.
+
+=item C<@names>
+
+B<(optional)> Security group names to include. When empty, all SGs are
+returned.
+
+=back
+
+B<Returns:> A C<Genesis::Hook::CloudConfig::LookupNetworkRef> that resolves
+to an arrayref of security group values.
+
+B<Examples:>
+
+    my $sgs_ref = $self->get_network_security_groups('id', 'bosh-sg', 'director-sg');
+    # Returns: a LookupNetworkRef; resolves to ['sg-abc123', 'sg-def456']
+
+=head2 lookup_az
+
+    my $az_name = $self->lookup_az($az);
+
+Resolves an AZ identifier to the canonical AZ name used by BOSH. Searches by
+exact key, by the C<name> field in the AZ definition, and by the CPI-specific
+AZ mapping if CPI is enabled. Returns the CPI-specific name when CPI is
+enabled.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$az>
+
+The AZ identifier to resolve (e.g., C<'z1'>, C<'us-east-1a'>).
+
+=back
+
+B<Returns:> The canonical AZ name string for use in subnet definitions.
+
+B<Errors:>
+
+=over 4
+
+=item C<"No availability zones available; you may need to run a deploy on the %s BOSH director to update its network information.">
+
+Thrown when the network data contains no AZs at all. C<%s> is replaced with
+the BOSH director alias.
+
+=item C<"Availability zone %s not found in the available AZs for the network">
+
+Thrown when the given AZ identifier does not match any known AZ. C<%s> is
+replaced with the C<$az> argument.
+
+=back
+
+B<Examples:>
+
+    my $az_name = $self->lookup_az('z1');
+    # Returns: 'us-east-1a'  (the canonical AZ name from BOSH director data)
+
+=head2 get_available_azs
+
+    my $azs = $self->get_available_azs;
+
+Returns the full AZ hash from the BOSH director network data.
+
+B<Returns:> A hashref mapping AZ keys to AZ definition hashrefs (containing
+C<name>, C<cloud_properties>, and optionally C<for_cpi> entries).
+
+B<Examples:>
+
+    my $azs = $self->get_available_azs;
+    # Returns: { z1 => { name => 'us-east-1a', cloud_properties => {...} } }
+
+=head2 get_available_azs_in_network
+
+    my $azs = $self->get_available_azs_in_network($target);
+
+Returns an arrayref of AZ names that have allocated subnets for the named
+network target.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$target>
+
+The network target name (the target portion passed to C<network_definition>).
+
+=back
+
+B<Returns:> An arrayref of unique, sorted AZ name strings.
+
+B<Examples:>
+
+    my $azs = $self->get_available_azs_in_network('deployment');
+    # Returns: ['z1', 'z2', 'z3']
+
+=head2 get_network_size
+
+    my $count = $self->get_network_size($target, @az_filters);
+
+Returns the total number of allocated IPs for the named network across all
+subnets. When C<@az_filters> is provided, only subnets in the specified AZs
+are counted.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$target>
+
+The network target name.
+
+=item C<@az_filters>
+
+B<(optional)> AZ names to filter by. When empty, all AZs are included.
+
+=back
+
+B<Returns:> An integer count of allocated IPs.
+
+B<Examples:>
+
+    my $size = $self->get_network_size('deployment');
+    # Returns: 128  (total IPs across all subnets)
+
+    my $size = $self->get_network_size('deployment', 'z1');
+    # Returns: 64  (IPs in z1 only)
+
+=head2 subnets
+
+    my $subnets = $self->subnets;
+
+Returns the OCFP subnet definitions for the environment, loaded lazily from
+the OCFP config at the C<net.subnets> or C<vpc.subnets> path.
+
+B<Returns:> A hashref mapping subnet names to subnet definition hashrefs.
+
+B<Examples:>
+
+    my $subnets = $self->subnets;
+    # Returns: { 'ocfp-a' => { cidr_block => '10.0.1.0/24', az => 'z1', ... } }
+
+=head2 vm_type_definition
+
+    my $defn = $self->vm_type_definition();
+
+Builds a BOSH VM type definition hashref for the named VM type. Delegates
+to C<_config_definition> with the C<vm_type> type and the C<vm> prefix.
+Applies environment overrides from C<bosh-configs.cloud.vm_type_defaults>
+and C<bosh-configs.cloud.vm_types.$name>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The VM type target name (e.g., C<'default'>, C<'compilation'>).
+
+=item C<%maps>
+
+Key-value options with the following recognized keys:
+
+=over 4
+
+=item C<common>
+
+B<(optional)> A hashref of properties shared across all IaaSes.
+
+=item C<cloud_properties_for_iaas>
+
+B<(optional)> A hashref mapping IaaS names to cloud property hashrefs.
+
+=back
+
+=back
+
+B<Returns:> A VM type definition hashref with C<name> and optionally
+C<cloud_properties> keys, or an empty list if no properties apply.
+
+B<Examples:>
+
+    my $vm = $self->vm_type_definition('default',
+        common                  => { stemcell => { name => 'ubuntu-jammy', version => 'latest' } },
+        cloud_properties_for_iaas => {
+            aws     => { instance_type => 't3.medium' },
+            vsphere => { cpu => 2, ram => 4096 },
+        },
+    );
+    # Returns: { name => 'my-env.bosh.vm-default', cloud_properties => { instance_type => 't3.medium' } }
+
+=head2 vm_extension_definition
+
+    my $defn = $self->vm_extension_definition($name, \%data);
+
+Builds a BOSH VM extension definition hashref for the named extension.
+Unlike other definition methods, VM extensions do not use the C<name_for>
+prefix — the name is used as-is. Returns an empty list if no cloud properties
+exist for the current IaaS.
+
+Applies environment overrides from C<bosh-configs.cloud.vm_extension_defaults>
+and C<bosh-configs.cloud.vm_extensions.$name>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The VM extension name (used verbatim, not prefixed with basename).
+
+=item C<\%data>
+
+A hashref. If a C<cloud_properties_for_iaas> key is present, its value is
+used for IaaS lookup. Otherwise C<\%data> itself is treated as the IaaS map.
+
+=back
+
+B<Returns:> A VM extension definition hashref with C<name> and
+C<cloud_properties> keys, or an empty list if no cloud properties exist for
+the current IaaS.
+
+B<Examples:>
+
+    my $ext = $self->vm_extension_definition('100GB_ephemeral_disk', {
+        cloud_properties_for_iaas => {
+            aws => { ephemeral_disk => { size => 102400 } },
+        },
+    });
+    # Returns: { name => '100GB_ephemeral_disk', cloud_properties => { ephemeral_disk => { size => 102400 } } }
+
+=head2 disk_type_definition
+
+    my $defn = $self->disk_type_definition();
+
+Builds a BOSH disk type definition hashref for the named disk type. Delegates
+to C<_config_definition> with the C<disk_type> type and the C<disk> prefix.
+Applies environment overrides from C<bosh-configs.cloud.disk_type_defaults>
+and C<bosh-configs.cloud.disk_types.$name>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The disk type target name (e.g., C<'default'>, C<'large'>).
+
+=item C<%maps>
+
+Key-value options with the following recognized keys:
+
+=over 4
+
+=item C<common>
+
+B<(optional)> A hashref of properties shared across all IaaSes.
+
+=item C<cloud_properties_for_iaas>
+
+B<(optional)> A hashref mapping IaaS names to cloud property hashrefs.
+
+=back
+
+=back
+
+B<Returns:> A disk type definition hashref with C<name> and optionally
+C<cloud_properties> keys, or an empty list if no properties apply.
+
+B<Examples:>
+
+    my $disk = $self->disk_type_definition('default',
+        common                  => { disk_size => 51200 },
+        cloud_properties_for_iaas => {
+            aws => { type => 'gp3' },
+        },
+    );
+    # Returns: { name => 'my-env.bosh.disk-default', cloud_properties => { type => 'gp3' } }
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _can_build_cloud_config
+
+    my $bool = $class->_can_build_cloud_config($env);
+
+Returns true if the environment can have a cloud config built for it (i.e.,
+it does not use create-env mode).
+
+B<Parameters:>
+
+=over 4
+
+=item C<$env>
+
+A C<Genesis::Env> object.
+
+=back
+
+B<Returns:> A boolean — true if C<< $env->use_create_env >> is false.
+
+B<Examples:>
+
+    my $ok = Genesis::Hook::CloudConfig->_can_build_cloud_config($env);
+    # Returns: 1 (if not a create-env deployment)
+
+=head2 _add_cpi_to_network_az
+
+    $self->_add_cpi_to_network_az($az_name, $cpi_az_name);
+
+Records the CPI-specific AZ name for a base AZ in the network data, under
+C<< $network->{azs}{$az_name}{for_cpi}{$cpi_name} >>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$az_name>
+
+The base AZ key in the network data.
+
+=item C<$cpi_az_name>
+
+The CPI-specific AZ name to record.
+
+=back
+
+B<Returns:> Nothing meaningful.
+
+B<Examples:>
+
+    $self->_add_cpi_to_network_az('z1', 'my-env-z1');
+    # Returns: nothing; records that the CPI-specific name for AZ z1 is 'my-env-z1'
+
+=head2 _build_generic_network_definition
+
+    $self->_build_generic_network_definition($target, $config, %options);
+
+Stub for generic (non-OCFP) network definition building. Not yet
+implemented; always calls C<bug()>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$target>
+
+The network target name.
+
+=item C<$config>
+
+The partial network config hashref (modified in-place by the builder).
+
+=item C<%options>
+
+Additional options.
+
+=back
+
+B<Returns:> Does not return (calls C<bug()>).
+
+B<Errors:>
+
+=over 4
+
+=item C<"Generic network definition building is not yet implemented">
+
+Always thrown — this method is a stub.
+
+=back
+
+B<Examples:>
+
+    # Not intended for direct use; called internally by network_definition
+    $self->_build_generic_network_definition('deployment', $config);
+    # Returns: does not return; dies with "Generic network definition building is not yet implemented"
+
+=head2 _available_ocfp_network_models
+
+    my @models = $self->_available_ocfp_network_models;
+
+Returns the list of supported OCFP network model names. Overridable in kit
+hook subclasses to allow kits to provide custom network models.
+
+B<Returns:> A list: C<('dynamic_subnets', 'subnets', 'greedy_subnets')>.
+
+B<Examples:>
+
+    my @models = $self->_available_ocfp_network_models;
+    # Returns: ('dynamic_subnets', 'subnets', 'greedy_subnets')
+
+=head2 _build_ocfp_network_definition
+
+    $self->_build_ocfp_network_definition($target, $config, %options);
+
+Dispatches OCFP network definition building to the appropriate model builder
+based on which model key is present in C<%options>. Exactly one model key
+must be present; multiple or zero model keys are errors.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$target>
+
+The network target name.
+
+=item C<$config>
+
+The partial network config hashref.
+
+=item C<%options>
+
+Must contain exactly one key from C<_available_ocfp_network_models>.
+
+=back
+
+B<Returns:> The return value of the dispatched model builder.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Network definition for %s can only have one network model, but found %d: %s">
+
+Thrown when more than one model key is present. C<%s> are the target name,
+model count, and model names.
+
+=item C<"Network definition for %s must have one of the following network models: %s">
+
+Thrown when no model key is present. C<%s> are the target name and available
+model names.
+
+=item C<"Network model %s is not supported for OCFP network definitions">
+
+Thrown when the selected model builder method does not exist on the class.
+C<%s> is the model name.
+
+=back
+
+B<Examples:>
+
+    # Not intended for direct use; called internally by network_definition
+    $self->_build_ocfp_network_definition('deployment', $config,
+        dynamic_subnets => { allocation => { size => 64 } }
+    );
+    # Returns: result of _build_ocfp_network_model_dynamic_subnets
+
+=head2 _build_ocfp_network_model_greedy_subnets
+
+    $self->_build_ocfp_network_model_greedy_subnets($target, $config, %options);
+
+Builds an OCFP greedy network definition. Greedy networks consume all
+available IPs in the OCFP subnet CIDR ranges and do not allocate static IPs.
+Only OCFP-prefixed subnets are included.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$target>
+
+The network target name.
+
+=item C<$config>
+
+The partial network config hashref. Populated in-place with a C<subnets> array.
+
+=item C<%options>
+
+Must contain C<greedy_subnets>, a hashref with:
+
+=over 4
+
+=item C<subnets>
+
+B<(optional)> A subnet filter (name, arrayref, or regexp) passed to C<_filter_subnets>.
+
+=item C<cloud_properties_for_iaas>
+
+B<(optional)> A hashref mapping IaaS names to cloud property hashrefs for the subnets.
+
+=back
+
+=back
+
+B<Returns:> Nothing meaningful (modifies C<$config> in-place).
+
+B<Errors:>
+
+=over 4
+
+=item C<"No ocfp-* subnets found in the ocfp configuration for network %s">
+
+Thrown when no OCFP-prefixed subnets are found. C<%s> is the target name.
+
+=back
+
+B<Examples:>
+
+    # Not intended for direct use; called internally by _build_ocfp_network_definition
+    $self->_build_ocfp_network_model_greedy_subnets('deployment', $config,
+        greedy_subnets => { cloud_properties_for_iaas => { aws => { subnet => 'subnet-abc' } } }
+    );
+    # Returns: nothing; populates $config->{subnets} with greedy subnet definitions
+
+=head2 _build_ocfp_network_model_dynamic_subnets
+
+    $self->_build_ocfp_network_model_dynamic_subnets($target, $config, %options);
+
+Builds an OCFP dynamic subnet network definition. Dynamically allocates IP
+ranges for each OCFP subnet based on existing claims, total VM counts, and
+static IP requirements. Supports Logical Subnet Amalgamation for subnets
+sharing the same CIDR.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$target>
+
+The network target name.
+
+=item C<$config>
+
+The partial network config hashref. Populated in-place with a C<subnets> array.
+
+=item C<%options>
+
+Must contain C<dynamic_subnets>, a hashref with:
+
+=over 4
+
+=item C<subnets>
+
+B<(optional)> A subnet filter passed to C<_filter_subnets>.
+
+=item C<allocation>
+
+A hashref specifying allocation sizes via one of:
+
+=over 4
+
+=item C<total_size>
+
+Total VM count distributed evenly across subnets.
+
+=item C<vms_per_subnet>
+
+A hashref mapping subnet names to individual counts.
+
+=item C<size>
+
+A fixed count per subnet (or a CIDR mask like C<'/26'>).
+
+=back
+
+=item C<statics>
+
+B<(optional)> Number of static IPs per subnet (or a CIDR mask). Defaults to 0.
+
+=item C<cloud_properties_for_iaas>
+
+B<(optional)> IaaS-specific cloud properties for subnets.
+
+=back
+
+=back
+
+B<Returns:> C<1> on success.
+
+B<Errors:>
+
+=over 4
+
+=item C<"No ocfp-* subnets found in the ocfp configuration for network %s">
+
+Thrown when no OCFP-prefixed subnets exist. C<%s> is the target name.
+
+=item C<"More static IPs requested (%d) than the allocation for the %s subnet for network %s allows (%d)">
+
+Thrown when static count exceeds subnet allocation.
+
+=back
+
+B<Examples:>
+
+    # Not intended for direct use; called internally by _build_ocfp_network_definition
+    $self->_build_ocfp_network_model_dynamic_subnets('deployment', $config,
+        dynamic_subnets => { allocation => { size => 64, statics => 8 } }
+    );
+    # Returns: 1; populates $config->{subnets} with dynamic subnet definitions
+
+=head2 _validate_override_schema
+
+    $self->_validate_override_schema;
+
+Validates the structure of the C<bosh-configs.cloud> section in the
+environment file. Checks that root keys are valid type plurals, type defaults,
+or matching rules; that defaults sections are hashrefs; that matching rules
+contain C<conditions> arrays and C<properties> hashrefs; and that no
+meta-keys (C<< <based-on> >>, C<< <explicit-name> >>) appear in defaults or
+rule properties.
+
+B<Returns:> C<1> if valid, or throws if errors are found.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Errors found in cloud config overrides:\n%s">
+
+Thrown when any validation error is detected. C<%s> is a newline-joined list
+of error messages.
+
+=back
+
+B<Examples:>
+
+    $self->_validate_override_schema;
+    # Returns: 1 if the bosh-configs.cloud section is valid
+
+=head2 _add_extended_cloud_config
+
+    $self->_add_extended_cloud_config(\%config);
+
+Reads the C<bosh-configs.cloud> environment overrides and appends any defined
+VM types, disk types, VM extensions, or network entries to C<%config>.
+Supports C<< <based-on> >> inheritance (deep-merging from an existing entry)
+and deferred processing to resolve ordering dependencies. Network additions
+are not currently supported and will throw.
+
+B<Parameters:>
+
+=over 4
+
+=item C<\%config>
+
+The cloud config hashref to extend. Modified in-place.
+
+=back
+
+B<Returns:> The modified C<\%config> hashref.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Invalid cloud config definition '#R{%s}' in #C{%s} environment file">
+
+Thrown when an override group key is not a recognized plural type name.
+C<%s> are the group key and environment name.
+
+=item C<"Extended cloud config network definitions are not supported yet: '%s' in #C{%s} environment file">
+
+Thrown when a network entry is found in the extended config. C<%s> are the
+target name and environment name.
+
+=item C<"Cyclic dependency detected for target '%s' in extended cloud config for type '%s'">
+
+Thrown when a C<< <based-on> >> chain creates a cycle. C<%s> are the target
+and type names.
+
+=item C<"The %s target '%s' depends on '%s' in environment #C{%s} %s definition, but it does not exist">
+
+Thrown when a C<< <based-on> >> source target cannot be found. C<%s> are
+type, target, source target, environment name, and the overrides base path.
+
+=back
+
+B<Examples:>
+
+    $self->_add_extended_cloud_config($config);
+    # Returns: $config with any env-extended vm_types/disk_types/vm_extensions merged in
+
+=head2 _config_definition
+
+    my $defn = $self->_config_definition($type, $prefix, $target, %maps);
+
+Builds a single BOSH resource definition (VM type or disk type) hashref.
+Validates C<%maps> keys, constructs the C<name> via C<name_for>, resolves
+IaaS-specific cloud properties, applies environment overrides via
+C<_process_config_overrides>, and removes empty C<cloud_properties> hashrefs.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$type>
+
+The resource type constant (e.g., C<VM_TYPE>, C<DISK_TYPE>).
+
+=item C<$prefix>
+
+The name prefix (e.g., C<'vm'>, C<'disk'>).
+
+=item C<$target>
+
+The resource target name.
+
+=item C<%maps>
+
+Recognized keys: C<common> (shared properties hashref) and
+C<cloud_properties_for_iaas> (IaaS-to-properties map).
+
+=back
+
+B<Returns:> A definition hashref, or an empty list if the result contains
+only a C<name> key.
+
+B<Examples:>
+
+    my $defn = $self->_config_definition('vm_type', 'vm', 'default',
+        common                  => { instance_type => 't3.medium' },
+        cloud_properties_for_iaas => { aws => { instance_type => 't3.medium' } },
+    );
+    # Returns: { name => 'my-env.bosh.vm-default', cloud_properties => { instance_type => 't3.medium' } }
+
+=head2 _subnet_definition
+
+    my $defn = $self->_subnet_definition($target, $subnet_id, \%fields, $strategy);
+
+Builds a single BOSH subnet definition hashref for the given subnet. Resolves
+range, reserved IPs, AZ(s), gateway, DNS, static IPs, and cloud properties
+from C<%fields>, resolving any C<LookupSubnetRef> or C<LookupNetworkRef>
+objects in cloud properties.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$target>
+
+The network target name.
+
+=item C<$subnet_id>
+
+The subnet identifier string.
+
+=item C<\%fields>
+
+A hashref containing subnet specification fields: C<range>, C<reserved>,
+C<az> or C<azs>, C<gateway>, C<dns>, and optionally C<static> and
+C<cloud_properties_for_iaas>.
+
+=item C<$strategy>
+
+The network strategy string (e.g., C<'ocfp:dynamic_subnets'>). Used to
+determine how C<LookupSubnetRef>/C<LookupNetworkRef> objects are resolved.
+
+=back
+
+B<Returns:> A subnet definition hashref.
+
+B<Errors:>
+
+=over 4
+
+=item C<"No availability zone(s) specified for network %s subnet %s">
+
+Thrown when neither C<az> nor C<azs> is present in C<%fields>. C<%s> are
+the target and subnet ID.
+
+=item C<"LookupSubnetRef not implemented for strategy $strategy">
+
+Thrown when a C<LookupSubnetRef> is encountered with a non-OCFP strategy.
+
+=item C<"LookupNetworkRef not implemented for strategy $strategy">
+
+Thrown when a C<LookupNetworkRef> is encountered with a non-OCFP strategy.
+
+=back
+
+B<Examples:>
+
+    my $subnet = $self->_subnet_definition('deployment', 'ocfp-a',
+        { az => 'z1', range => '10.0.1.0/24', gateway => '10.0.1.1',
+          dns => ['10.0.1.1'], reserved => ['10.0.1.0-10.0.1.4'] },
+        'ocfp:dynamic_subnets'
+    );
+    # Returns: { az => 'us-east-1a', range => '10.0.1.0/24', gateway => '10.0.1.1', ... }
+
+=head2 _get_network_subnet_property
+
+    my $value = $self->_get_network_subnet_property($target, $subnet_id, $fields, $property, %opts);
+
+Resolves a single subnet property by checking a priority-ordered list of
+sources: the cloud-config definition C<%fields>, environment network defaults,
+per-network subnet defaults, and per-subnet overrides. Returns the highest
+priority value found.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$target>
+
+Network target name.
+
+=item C<$subnet_id>
+
+Subnet identifier.
+
+=item C<\%fields>
+
+The baseline subnet field hashref (the cloud-config definition value).
+
+=item C<$property>
+
+The property name to resolve (e.g., C<'range'>, C<'gateway'>, C<'az'>).
+
+=item C<%opts>
+
+=over 4
+
+=item C<no_defaults>
+
+When true, skips the environment defaults lookup (used for C<reserved>).
+
+=item C<optional>
+
+When true, returns C<undef> instead of throwing when no value is found.
+
+=back
+
+=back
+
+B<Returns:> The resolved property value.
+
+B<Errors:>
+
+=over 4
+
+=item C<"No %s specified for network %s subnet %s (source: %s)">
+
+Thrown when the property is required but not found. C<%s> are the property
+name, target, subnet ID, and source description.
+
+=back
+
+B<Examples:>
+
+    my $range = $self->_get_network_subnet_property(
+        'deployment', 'ocfp-a', \%fields, 'range'
+    );
+    # Returns: '10.0.1.0/24'
+
+=head2 _network_cloud_properties_for_iaas
+
+    my $props = $self->_network_cloud_properties_for_iaas(
+        $target, $subnet_id, \%fields, %map
+    );
+
+Resolves and merges cloud properties for a subnet, applying network-level
+and subnet-level overrides on top of the IaaS-matched base from C<%map>.
+Removes undefined values from the merged result.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$target>
+
+Network target name.
+
+=item C<$subnet_id>
+
+Subnet identifier.
+
+=item C<\%fields>
+
+Subnet field hashref (used for matching-rule evaluation context).
+
+=item C<%map>
+
+IaaS-to-properties map passed to C<_cloud_properties_for_iaas>.
+
+=back
+
+B<Returns:> A merged cloud properties hashref.
+
+B<Examples:>
+
+    my $props = $self->_network_cloud_properties_for_iaas(
+        'deployment', 'ocfp-a', \%fields, aws => { subnet => 'subnet-abc' }
+    );
+    # Returns: { subnet => 'subnet-abc' }
+
+=head2 _cloud_properties_for_iaas
+
+    my $props = $self->_cloud_properties_for_iaas(%map);
+    my ($props, $found) = $self->_cloud_properties_for_iaas(%map);
+
+Selects cloud properties from C<%map> for the current IaaS. Tries an exact
+match on the IaaS name, then a pipe-delimited multi-IaaS key match (e.g.,
+C<'aws|azure'>), then falls back to the C<'*'> wildcard key.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%map>
+
+A hash mapping IaaS names (or C<'*'>) to cloud properties hashrefs.
+
+=back
+
+B<Returns:>
+
+In scalar context, returns the matched cloud properties hashref (or C<{}> if
+no match). In list context, returns C<($hashref, $found)> where C<$found> is
+true when a key was explicitly matched.
+
+B<Examples:>
+
+    my $props = $self->_cloud_properties_for_iaas(
+        aws   => { instance_type => 't3.medium' },
+        '*'   => { instance_type => 't2.micro' },
+    );
+    # Returns: { instance_type => 't3.medium' }  (if IaaS is 'aws')
+
+    my ($props, $found) = $self->_cloud_properties_for_iaas(aws => { instance_type => 't3.medium' });
+    # Returns: ({ instance_type => 't3.medium' }, 1)
+
+=head2 _process_config_overrides
+
+    my $config = $self->_process_config_overrides($type, $target, \%config);
+
+Evaluates deferred values (C<CODE> refs and C<LookupRef> objects) in the
+config, then applies environment defaults, conditional matching rules, and
+specific overrides from C<bosh-configs.cloud> in that order.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$type>
+
+The resource type (e.g., C<'vm_type'>, C<'disk_type'>).
+
+=item C<$target>
+
+The resource target name.
+
+=item C<\%config>
+
+The resource definition hashref to process.
+
+=back
+
+B<Returns:> The processed config as an unflattened hashref.
+
+B<Examples:>
+
+    my $config = $self->_process_config_overrides('vm_type', 'default', \%config);
+    # Returns: { instance_type => 't3.medium', ... }  (with env overrides applied)
+
+=head2 _evaluate_matching_rule
+
+    my $properties = $self->_evaluate_matching_rule($target, \%rule, $config);
+
+Evaluates a single conditional override rule against the current config.
+Conditions are evaluated as OR between condition sets and AND within each set.
+Patterns may be literal values, C<undef>, or regex strings in the form
+C<"/pattern/flags"> or C<"!~/pattern/flags">.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$target>
+
+The resource target name (used as context, not directly evaluated).
+
+=item C<\%rule>
+
+A hashref with a C<conditions> arrayref (sets of field-pattern maps) and a
+C<properties> hashref.
+
+=item C<$config>
+
+The flattened resource config hashref to evaluate against.
+
+=back
+
+B<Returns:> The rule's C<properties> hashref if conditions match, or C<{}>.
+
+B<Examples:>
+
+    my $props = $self->_evaluate_matching_rule('default', $rule, $config);
+    # Returns: { disk_size => 10240 }  (if the rule conditions matched)
+
+=head2 _validate_definition
+
+    $self->_validate_definition($type, $target, %maps);
+
+Validates that C<%maps> contains only the C<common> and
+C<cloud_properties_for_iaas> keys, that at least one of these keys is
+present, and that each present key is a hashref. Calls C<kit_bug> on the
+environment's kit for any violation.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$type>
+
+The resource type name.
+
+=item C<$target>
+
+The resource target name.
+
+=item C<%maps>
+
+The maps hashref to validate.
+
+=back
+
+B<Returns:> C<1> if valid.
+
+B<Examples:>
+
+    $self->_validate_definition('vm_type', 'default',
+        common => { instance_type => 't3.medium' }
+    );
+    # Returns: 1 if maps are valid
+
+=head2 _bosh_exodus_lookup
+
+    my $value = $self->_bosh_exodus_lookup($path);
+
+Returns the value at C<$path> in the deploying BOSH director's exodus data.
+Returns C<undef> immediately for create-env environments (which have no
+director exodus).
+
+B<Parameters:>
+
+=over 4
+
+=item C<$path>
+
+The exodus data path to look up (e.g., C<'/network'>).
+
+=back
+
+B<Returns:> The value at the exodus path, or C<undef> for create-env environments.
+
+B<Examples:>
+
+    my $data = $self->_bosh_exodus_lookup('/network');
+    # Returns: { azs => {...}, subnets => {...} }
+
+=head2 _get_subnet_ranges
+
+    my ($available, $reserved) = $self->_get_subnet_ranges(\%subnet);
+
+Computes the available and reserved IP ranges for a single OCFP subnet based
+on its C<cidr_block> and C<reserved-ips> entries. Returns two C<IPv4> range
+objects.
+
+B<Parameters:>
+
+=over 4
+
+=item C<\%subnet>
+
+A subnet definition hashref with C<cidr_block> and C<reserved-ips> entries.
+
+=back
+
+B<Returns:> A two-element list C<($available, $reserved)>, each an C<IPv4>
+range object.
+
+B<Examples:>
+
+    my ($available, $reserved) = $self->_get_subnet_ranges($subnet);
+    # Returns: (IPv4 range of available IPs, IPv4 range of reserved IPs)
+
+=head2 _get_existing_allocations
+
+    my $allocations = $self->_get_existing_allocations;
+
+Reads the current subnet claim records from the network data and returns them
+as a hashref mapping network names to per-subnet C<IPv4> range objects.
+
+B<Returns:> A hashref of the form
+C<{ $network => { $subnet => IPv4 object } }>.
+
+B<Examples:>
+
+    my $allocs = $self->_get_existing_allocations;
+    # Returns: { 'env.bosh.net-deployment' => { 'ocfp-a' => IPv4 object } }
+
+=head2 _calculate_subnet_allocation
+
+    my $range = $self->_calculate_subnet_allocation(
+        $target, $available, $existing, $count
+    );
+
+Calculates the new IP allocation range for a subnet, growing or shrinking
+the existing allocation to reach C<$count> IPs. Adds IPs from the available
+range when growing; removes from the high end of the existing range when
+shrinking.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$target>
+
+Network target name (used in error messages).
+
+=item C<$available>
+
+An C<IPv4> range object of IPs available for new allocation.
+
+=item C<$existing>
+
+An C<IPv4> range object of currently allocated IPs.
+
+=item C<$count>
+
+The desired total IP count.
+
+=back
+
+B<Returns:> A simplified C<IPv4> range object of the new allocation.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Negative IP allocation for network '%s' allocation - not enough allocated IPs to remove">
+
+Thrown when shrinking yields an impossible negative allocation. C<%s> is the
+target name.
+
+=item C<"Not enough available IPs in the subnet for the network '%s' allocation:  (has %d, needs %d)">
+
+Thrown when the available range cannot satisfy the growth request.
+
+=back
+
+B<Examples:>
+
+    my $range = $self->_calculate_subnet_allocation('deployment', $available, $existing, 64);
+    # Returns: IPv4 range object of 64 IPs
+
+=head2 _calculate_static_allocation
+
+    my $range = $self->_calculate_static_allocation($target, $allocated, $count);
+
+Calculates the static IP range by slicing the first C<$count> IPs from the
+allocated range. If C<$count> is a percentage string (e.g., C<'25%'>), the
+count is computed as that fraction of the allocated size.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$target>
+
+Network target name.
+
+=item C<$allocated>
+
+An C<IPv4> range object of the total allocated range.
+
+=item C<$count>
+
+An integer count, a CIDR mask string (e.g., C<'/26'>), or a percentage
+string (e.g., C<'25%'>).
+
+=back
+
+B<Returns:> A simplified C<IPv4> range object of static IPs.
+
+B<Examples:>
+
+    my $statics = $self->_calculate_static_allocation('deployment', $allocated, 8);
+    # Returns: IPv4 range object of the first 8 IPs in the allocated range
+
+=head2 _get_reserved_allocation
+
+    my ($allocation, $static) = $self->_get_reserved_allocation($target, \%subnet);
+
+Retrieves the pre-reserved IPs for a named network target within a subnet.
+Reserved ranges are read from C<< $subnet->{'reserved-ips'} >> keys matching
+C<< ${target}_a >>, C<< ${target}_b >>, etc. (as inclusive pairs) and
+C<< ${target}_ip* >> keys (individual IPs). Also returns the static flag
+C<< ${target}_static >> (defaults to C<1>).
+
+B<Parameters:>
+
+=over 4
+
+=item C<$target>
+
+Network target name.
+
+=item C<\%subnet>
+
+A subnet definition hashref with a C<reserved-ips> entry.
+
+=back
+
+B<Returns:> A two-element list C<($allocation, $static)> where C<$allocation>
+is a simplified C<IPv4> range object and C<$static> is the static flag value.
+
+B<Examples:>
+
+    my ($reserved_ips, $is_static) = $self->_get_reserved_allocation('bosh', $subnet);
+    # Returns: (IPv4 range of bosh-reserved IPs, 1)
+
+=head2 _get_bosh_network_data
+
+    my $data = $self->_get_bosh_network_data;
+
+Fetches the BOSH director network data from the C</network> path in the
+director's exodus.
+
+B<Returns:> The network data hashref from director exodus.
+
+B<Examples:>
+
+    my $data = $self->_get_bosh_network_data;
+    # Returns: { azs => { z1 => {...} }, subnets => { 'ocfp-a' => {...} } }
+
+=head2 _filter_subnets
+
+    my $subnets = $self->_filter_subnets($subnet_filter);
+
+Filters the available subnets from C<$self->subnets> using the given filter.
+The filter may be a subnet name string, an arrayref of names/regexps, or
+a compiled C<Regexp>. Returns all subnets when C<$subnet_filter> is
+C<undef>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$subnet_filter>
+
+B<(optional)> A subnet name string, C<Regexp>, or arrayref of names/regexps.
+When C<undef>, all subnets are returned.
+
+=back
+
+B<Returns:> A hashref of matching subnet name to subnet definition entries.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Invalid subnet filter type: %s">
+
+Thrown when a filter entry is a reference type other than C<Regexp>. C<%s>
+is the ref type.
+
+=back
+
+B<Examples:>
+
+    my $subnets = $self->_filter_subnets('ocfp-a');
+    # Returns: { 'ocfp-a' => { cidr_block => '10.0.1.0/24', ... } }
+
+    my $subnets = $self->_filter_subnets(qr/^ocfp-/);
+    # Returns: { 'ocfp-a' => {...}, 'ocfp-b' => {...} }
+
+=head2 _az_definition_for
+
+    my $config = $self->_az_definition_for(\%az, %options);
+
+Builds a single AZ definition hashref from the given AZ data. When
+C<< $options{virtual} >> is true, C<cloud_properties> is omitted. When CPI
+is enabled, adds a C<cpi> field.
+
+B<Parameters:>
+
+=over 4
+
+=item C<\%az>
+
+An AZ data hashref with C<name> and C<cloud_properties> (JSON-encoded string)
+fields.
+
+=item C<%options>
+
+=over 4
+
+=item C<name>
+
+B<(optional)> Override for the AZ name (supports CPI shadow naming).
+
+=item C<virtual>
+
+B<(optional)> When true, omits C<cloud_properties> from the definition.
+
+=back
+
+=back
+
+B<Returns:> An AZ definition hashref.
+
+B<Examples:>
+
+    my $az = $self->_az_definition_for($az_data, name => 'my-env-z1');
+    # Returns: { name => 'my-env-z1', cloud_properties => { availability_zone => 'us-east-1a' } }
+
+=head2 _process_network_subnets
+
+    $self->_process_network_subnets(\@networks);
+
+Processes the C<subnets> arrays in a BOSH networks definition to make them
+compatible with BOSH expectations: removes per-subnet C<name> fields and
+converts subnets sharing the same CIDR range into Logical Subnet
+Amalgamations (LSAs) via C<_build_logical_subnet_amalgamation>.
+
+VIP networks are skipped. Returns early if C<\@networks> is not an arrayref.
+
+B<Parameters:>
+
+=over 4
+
+=item C<\@networks>
+
+The C<networks> array from a cloud config hashref.
+
+=back
+
+B<Returns:> C<1> on success.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Network definition is not a hashref: %s">
+
+Thrown when a network entry is not a hashref or lacks a C<subnets> key.
+C<%s> is the network value.
+
+=back
+
+B<Examples:>
+
+    $self->_process_network_subnets($config->{networks});
+    # Returns: 1; converts shared-CIDR subnets to LSAs in-place
+
+=head2 _build_logical_subnet_amalgamation
+
+    my $lsa = $self->_build_logical_subnet_amalgamation($target, \@subnet_configs);
+
+Merges multiple subnet definitions sharing the same CIDR range into a single
+Logical Subnet Amalgamation (LSA) hashref. Validates that all subnets have
+the same range and gateway, deduplicates AZs and DNS servers, and calculates
+merged reserved and static ranges. Returns C<undef> if all IPs in the range
+are reserved.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$target>
+
+Network name (used in error context).
+
+=item C<\@subnet_configs>
+
+Arrayref of subnet hashrefs, each with C<name>, C<range>, C<gateway>,
+C<az>/C<azs>, C<dns>, C<reserved>, and optionally C<static> and
+C<cloud_properties>.
+
+=back
+
+B<Returns:> An LSA hashref, or the single input subnet if only one is given,
+or C<undef> if the range is fully reserved.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Cannot create LSA for subnets with different ranges:\n%s">
+
+Thrown when input subnets have different CIDR ranges.
+
+=item C<"Cannot create LSA for subnets with different gateways:\n%s">
+
+Thrown when input subnets have different gateways.
+
+=back
+
+B<Examples:>
+
+    my $lsa = $self->_build_logical_subnet_amalgamation('deployment', \@subnet_configs);
+    # Returns: { range => '10.0.1.0/24', azs => ['z1','z2'], reserved => [...], ... }
+
+=head2 _get_subnet_ref
+
+    my $ref = $self->_get_subnet_ref($name, \@all_subnets);
+
+Resolves a subnet name to either the direct subnet key or the LSA key that
+contains it. Checks exact match first, then searches LSA keys
+(C<"LSA|subnet1|subnet2|..."> format).
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+The subnet name to look up.
+
+=item C<\@all_subnets>
+
+B<(optional)> The list of available subnet keys. Defaults to the keys of
+C<< $self->network->{subnets} >>.
+
+=back
+
+B<Returns:> The matching subnet key or LSA key string.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Subnet %s not found in the available subnets: %s">
+
+Thrown when neither the exact name nor any LSA containing it is found.
+C<%s> are the name and the comma-joined available subnet list.
+
+=back
+
+B<Examples:>
+
+    my $ref = $self->_get_subnet_ref('ocfp-a');
+    # Returns: 'ocfp-a'  (if ocfp-a is a direct subnet key)
+
+    my $ref = $self->_get_subnet_ref('ocfp-a', ['LSA|ocfp-a|ocfp-b', 'ocfp-c']);
+    # Returns: 'LSA|ocfp-a|ocfp-b'
+
+=head2 _standardized_subnet_cidr
+
+    my $cidr = $self->_standardized_subnet_cidr(\%subnet, $name, $target);
+
+Validates that a subnet's C<cidr_block> represents a single contiguous CIDR
+block and returns the standardized CIDR string.
+
+B<Parameters:>
+
+=over 4
+
+=item C<\%subnet>
+
+A subnet hashref with a C<cidr_block> field.
+
+=item C<$name>
+
+The subnet name (used in error messages).
+
+=item C<$target>
+
+The network target name (used in error messages).
+
+=back
+
+B<Returns:> A standardized CIDR string (e.g., C<'10.0.1.0/24'>).
+
+B<Errors:>
+
+=over 4
+
+=item C<"Subnet %s for network %s is not a single CIDR block, but has multiple ranges: %s">
+
+Thrown when the CIDR block spans multiple ranges. C<%s> are the subnet name,
+target name, and the ranges found.
+
+=item C<"Subnet %s for network %s is not a single CIDR block, but has multiple CIDRs: %s">
+
+Thrown when the CIDR block contains multiple CIDR expressions. C<%s> are
+the subnet name, target name, and the CIDRs found.
+
+=back
+
+B<Examples:>
+
+    my $cidr = $self->_standardized_subnet_cidr($subnet, 'ocfp-a', 'deployment');
+    # Returns: '10.0.1.0/24'
+
+=head2 _plural_of
+
+    my $plural = _plural_of($word);
+
+Returns the plural form of C<$word> using C<count_nouns> (with count C<2>
+and the C<suppress_count> option). Used to map singular type names (e.g.,
+C<'vm_type'>) to their plural config keys (e.g., C<'vm_types'>).
+
+B<Parameters:>
+
+=over 4
+
+=item C<$word>
+
+The singular noun to pluralize.
+
+=back
+
+B<Returns:> The pluralized string.
+
+B<Examples:>
+
+    my $plural = _plural_of('vm_type');
+    # Returns: 'vm_types'
+
+    my $plural = _plural_of('network');
+    # Returns: 'networks'
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Hook/CloudConfig/Director.pod
+++ b/lib/Genesis/Hook/CloudConfig/Director.pod
@@ -1,0 +1,420 @@
+=encoding UTF-8
+
+=head1 NAME
+
+Genesis::Hook::CloudConfig::Director - Director-specific cloud-config hook for OCFP-managed BOSH environments
+
+=head1 SYNOPSIS
+
+    package Genesis::Hook::CloudConfig::Director;
+    use parent 'Genesis::Hook::CloudConfig';
+
+    # Instantiate via the parent factory; purpose must be 'director'
+    my $hook = Genesis::Hook::CloudConfig::Director->init(
+        env     => $env,
+        purpose => 'director',
+    );
+
+    # Build AZ definitions for inclusion in a cloud config
+    my @azs = $hook->build_az_definitions(prefix => 'z');
+
+    # Get the compilation block
+    my %compilation = $hook->compilation_definition(strategy => 'ocfp');
+
+    # Retrieve the env-level override base key
+    my $base = $hook->overrides_base;
+    # Returns: 'bosh-configs.director_cloud'
+
+=head1 DESCRIPTION
+
+C<Genesis::Hook::CloudConfig::Director> is the director-level cloud-config
+hook. It extends C<Genesis::Hook::CloudConfig> with the behavior needed to
+generate availability-zone and subnet definitions specifically for a BOSH
+director deployment, driven entirely by OCFP configuration stored in Vault.
+
+On initialization the hook:
+
+=over 4
+
+=item *
+
+Enforces that C<purpose> is exactly C<'director'>.
+
+=item *
+
+Delegates to the parent C<init> to set up the shared
+cloud-config infrastructure, including the AZ prefix derived from the
+environment name.
+
+=item *
+
+Loads AZ definitions from the OCFP Vault config mount
+(C<net.azs> or C<vpc.azs>) and populates C<< $self->{network}{azs} >>.
+
+=item *
+
+Loads subnet definitions from the OCFP Vault config mount
+(C<net.subnets> or C<vpc.subnets>), filtering to subnets whose names
+start with C<ocfp->, and populates C<< $self->{network}{subnets} >>.
+
+=back
+
+Existing exodus network data (C</network:.>) is consulted during both steps
+so that CPI-specific AZ data (C<for_cpi>) and subnet allocation data
+(C<claims>) added outside the director hook are preserved across
+re-initializations.
+
+Only OCFP-managed environments (C<< $env->is_ocfp >> returns true) are
+supported. Non-OCFP environments trigger a C<bug()> call at initialization
+time.
+
+See also:
+
+=over 4
+
+=item L<Genesis::Hook::CloudConfig>
+
+=item L<Genesis::Hook>
+
+=back
+
+=head1 METHODS
+
+=head2 init
+
+    my $hook = Genesis::Hook::CloudConfig::Director->init(%opts);
+
+Constructs and returns a director cloud-config hook object. Enforces that
+C<< $opts{purpose} >> is exactly C<'director'>, then delegates to the parent
+C<init> with C<< network => {} >> added to C<%opts>. After the parent object
+is built, calls C<_set_network_azs> and C<_set_network_subnets> to populate
+the in-memory network data from the OCFP Vault config.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+Key-value pairs forwarded to the parent C<init>. The
+following key is required by this subclass:
+
+=over 4
+
+=item C<purpose>
+
+B<(required)> Must be the string C<'director'>. Any other value (or absence)
+causes the method to bail with an error.
+
+=back
+
+All other keys (C<env>, C<basename>, etc.) are passed through to the parent
+unchanged.
+
+=back
+
+B<Returns:> A blessed C<Genesis::Hook::CloudConfig::Director> object.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Purpose must be 'director' - %s"> -- raised via C<bail()> if C<purpose>
+is absent or not equal to C<'director'>. C<%s> is replaced with
+C<"got '$opts{purpose}'"> when a wrong value was supplied, or
+C<"no purpose provided"> when the key was absent.
+
+=back
+
+B<Examples:>
+
+    my $hook = Genesis::Hook::CloudConfig::Director->init(
+        env     => $env,
+        purpose => 'director',
+    );
+    # Returns: a blessed Genesis::Hook::CloudConfig::Director object
+
+    # Wrong purpose
+    Genesis::Hook::CloudConfig::Director->init(env => $env, purpose => 'runtime');
+    # Dies: "Purpose must be 'director' - got 'runtime'"
+
+=head2 build_az_definitions
+
+    my @azs     = $hook->build_az_definitions(%options);
+    my $azs_ref = $hook->build_az_definitions(%options);
+
+Builds and returns the availability-zone definitions for all AZs known to
+this director. For each AZ stored in C<< $self->{network}{azs} >> (populated
+during C<init>), calls C<_az_definition_for> to produce the BOSH-compatible
+AZ definition hash. The results are deduplicated and sorted by name.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%options>
+
+Key-value options forwarded to C<_az_definition_for> for each AZ, with the
+following key consumed by this method before forwarding:
+
+=over 4
+
+=item C<prefix>
+
+B<(optional)> A string prepended to each AZ name. Defaults to C<''> (empty
+string).
+
+=back
+
+Other keys in C<%options> (e.g., C<strategy>) are passed through to
+C<_az_definition_for> unchanged.
+
+=back
+
+B<Returns:>
+
+In list context, returns a list of AZ definition hash references, each
+suitable for use as an entry in the BOSH cloud config C<azs> array.
+
+In scalar context, returns an array reference of the same hashes.
+
+Each AZ definition hash contains at least a C<name> key; additional keys
+depend on the C<_az_definition_for> implementation.
+
+B<Examples:>
+
+    # List context
+    my @azs = $hook->build_az_definitions(prefix => 'z');
+    # Returns: ({ name => 'z1', ... }, { name => 'z2', ... }, ...)
+
+    # Scalar context
+    my $azs_ref = $hook->build_az_definitions;
+    # Returns: [{ name => '1', ... }, { name => '2', ... }, ...]
+
+=head2 compilation_definition
+
+    my %compilation = $hook->compilation_definition(%options);
+
+Returns the BOSH compilation block definition for this director environment.
+Resolves the compilation network name, VM type, availability zones, worker
+count, and VM reuse setting, then returns them as a flat hash.
+
+The compilation network name and VM type are resolved via C<name_for>. The
+first AZ available in the compilation network (from
+C<get_available_azs_in_network('compilation')>) is used. The worker count
+is the size of the compilation network in that AZ
+(C<get_network_size('compilation', $az)>). The C<reuse_compilation_vms>
+flag is read from the environment's manifest key
+C<bosh-configs.director_cloud.compilation.reuse_vms>, defaulting to
+C<$self-E<gt>TRUE> (the JSON boolean true value) if not set.
+
+Currently only the C<'ocfp'> strategy is supported.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%options>
+
+=over 4
+
+=item C<strategy>
+
+B<(optional)> The build strategy. Only C<'ocfp'> is currently accepted.
+Defaults to C<'generic'>, but any value other than C<'ocfp'> causes the
+method to bail with an error.
+
+=back
+
+=back
+
+B<Returns:> A flat hash with the following keys:
+
+=over 4
+
+=item C<network>
+
+The resolved compilation network name (e.g., C<'my-env.bosh.net.compilation'>).
+
+=item C<vm_type>
+
+The resolved compilation VM type name.
+
+=item C<az>
+
+The name of the first available AZ in the compilation network.
+
+=item C<workers>
+
+The number of compilation workers derived from the compilation network size.
+
+=item C<reuse_compilation_vms>
+
+A JSON boolean value (C<$self-E<gt>TRUE> by default, or the value from
+C<bosh-configs.director_cloud.compilation.reuse_vms>).
+
+=back
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Unsupported strategy for building compilation definitions: %s"> -- raised
+via C<bail()> if C<strategy> is any value other than C<'ocfp'>. C<%s> is
+replaced with the supplied strategy string.
+
+=back
+
+B<Examples:>
+
+    my %comp = $hook->compilation_definition(strategy => 'ocfp');
+    # Returns: (
+    #   network              => 'my-env.bosh.net.compilation',
+    #   vm_type              => 'my-env.bosh.vm.compilation',
+    #   az                   => 'z1',
+    #   workers              => 4,
+    #   reuse_compilation_vms => JSON::PP::true,
+    # )
+
+    $hook->compilation_definition(strategy => 'generic');
+    # Dies: "Unsupported strategy for building compilation definitions: generic"
+
+=head2 overrides_base
+
+    my $base = $hook->overrides_base;
+
+Returns the environment manifest key path under which director cloud-config
+overrides are looked up. This is used by the inherited override-application
+machinery to locate user-supplied overrides.
+
+B<Returns:> The string C<'bosh-configs.director_cloud'>.
+
+B<Examples:>
+
+    my $base = $hook->overrides_base;
+    # Returns: 'bosh-configs.director_cloud'
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _can_build_cloud_config
+
+    $class->_can_build_cloud_config($env)
+
+Override of the parent abstract method. Always returns C<1> because the
+director cloud config can always be built, regardless of the environment
+state.
+
+B<Returns:> C<1>.
+
+B<Examples:>
+
+    my $ok = Genesis::Hook::CloudConfig::Director->_can_build_cloud_config($env);
+    # Returns: 1
+
+=head2 _set_network_azs
+
+    $self->_set_network_azs(%opts)
+
+Populates C<< $self->{network}{azs} >> from the OCFP Vault config. Looks up
+AZ data from C<net.azs> or C<vpc.azs> via
+C<< $self->env->ocfp_config_lookup >>. For each AZ, the index is taken from
+the C<index> field in Vault data or extracted from trailing digits of the AZ
+name. Cloud properties (JSON-encoded) are validated by JSON decoding;
+an empty JSON object (C<'{}'>) is used when none are stored.
+
+If existing exodus network data contains AZ entries with a C<for_cpi> field,
+those values are preserved in the newly built C<%azs> hash before it is
+stored on the object, so CPI-specific AZ data added externally is not lost.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+Currently unused; reserved for future use.
+
+=back
+
+B<Returns:> Nothing. Modifies C<< $self->{network}{azs} >> in-place.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Invalid json in cloud properties for AZ %s: %s"> -- raised via C<bug()>
+if the stored cloud properties string is not valid JSON. The first C<%s> is
+the AZ name and the second is the JSON parse error.
+
+=item *
+
+C<"NYI: Unsupported environment for setting AZs: only environments using ocfp feature is supported at this time"> -- raised via C<bug()> if the
+environment is not an OCFP environment.
+
+=back
+
+B<Examples:>
+
+    $hook->_set_network_azs;
+    # Returns: nothing; $hook->{network}{azs} is now populated
+
+=head2 _set_network_subnets
+
+    $self->_set_network_subnets
+
+Populates C<< $self->{network}{subnets} >> from the OCFP Vault config. Looks
+up subnet data from C<net.subnets> or C<vpc.subnets> via
+C<< $self->env->ocfp_config_lookup >>, filtering to subnet names that match
+the C</^ocfp-/> prefix. For each subnet, stores the IPv4 range (parsed from
+C<cidr_block>) and the resolved AZ name (via C<lookup_az>).
+
+If existing exodus network data contains subnet entries with a C<claims>
+field, those values are preserved in the newly built C<%subnets> hash so
+that subnet allocation data added outside the director hook is not lost.
+
+B<Returns:> Nothing. Modifies C<< $self->{network}{subnets} >> in-place.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"NYI: Unsupported environment for setting subnets: only environments using ocfp feature is supported at this time"> -- raised via C<bug()> if the
+environment is not an OCFP environment.
+
+=back
+
+B<Examples:>
+
+    $hook->_set_network_subnets;
+    # Returns: nothing; $hook->{network}{subnets} is now populated
+
+=head2 _get_bosh_network_data
+
+    my $data = $self->_get_bosh_network_data;
+
+Returns the stored network data hash for this BOSH director by calling
+C<< $self->env->exodus_lookup('/network:.') >>. Returns C<undef> if no
+exodus network data exists yet.
+
+B<Returns:> A hash reference of exodus network data, or C<undef>.
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Hook/CloudConfig/Helpers.pod
+++ b/lib/Genesis/Hook/CloudConfig/Helpers.pod
@@ -1,0 +1,91 @@
+=encoding UTF-8
+
+=head1 NAME
+
+Genesis::Hook::CloudConfig::Helpers - Exported size-conversion utilities for CloudConfig hooks
+
+=head1 SYNOPSIS
+
+    use Genesis::Hook::CloudConfig::Helpers;
+
+    # Specify disk sizes in readable units — all values are returned in megabytes
+    my $disk_mb = gigabytes(50);   # Returns: 51200
+    my $ram_mb  = megabytes(4096); # Returns: 4096
+
+=head1 DESCRIPTION
+
+C<Genesis::Hook::CloudConfig::Helpers> provides two exported helper functions,
+C<megabytes> and C<gigabytes>, for use in CloudConfig hook implementations.
+Both functions return a size expressed in megabytes, allowing hook authors to
+write capacity values in natural units while keeping the output consistent.
+
+The module exports both functions automatically via C<Exporter>; no import
+list is required.
+
+=head1 FUNCTIONS
+
+=over 4
+
+=item B<megabytes($n)>
+
+    my $mb = megabytes($n);
+
+Returns C<$n> unchanged. This function exists purely for readability and
+uniformity alongside C<gigabytes>: writing C<megabytes(4096)> makes the
+intended unit explicit in the calling code.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$n>
+
+A numeric value representing a size already expressed in megabytes.
+
+=back
+
+B<Returns:> The value of C<$n> unchanged.
+
+B<Examples:>
+
+    my $mb = megabytes(4096);
+    # Returns: 4096
+
+=item B<gigabytes($n)>
+
+    my $mb = gigabytes($n);
+
+Converts C<$n> gigabytes to megabytes by multiplying by 1024. Use this when
+specifying disk or memory capacities in gigabyte units in a CloudConfig hook.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$n>
+
+A numeric value representing a size in gigabytes.
+
+=back
+
+B<Returns:> C<$n> multiplied by 1024, expressed in megabytes.
+
+B<Examples:>
+
+    my $mb = gigabytes(50);
+    # Returns: 51200
+
+    my $mb = gigabytes(1);
+    # Returns: 1024
+
+=back
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Hook/CloudConfig/LookupNetworkRef.pod
+++ b/lib/Genesis/Hook/CloudConfig/LookupNetworkRef.pod
@@ -1,0 +1,188 @@
+=encoding UTF-8
+
+=head1 NAME
+
+Genesis::Hook::CloudConfig::LookupNetworkRef - Network reference resolver for cloud-config lookups
+
+=head1 SYNOPSIS
+
+    use Genesis::Hook::CloudConfig::LookupNetworkRef;
+
+    # Direct hash lookup — resolve 'default' from network data
+    my $ref = Genesis::Hook::CloudConfig::LookupNetworkRef->new('default');
+    my $value = $ref->resolve($config, $network_data);
+
+    # Delegate to a named method on $config
+    my $ref = Genesis::Hook::CloudConfig::LookupNetworkRef->new(
+        'primary', 'lookup_network', 'extra_arg'
+    );
+    my $value = $ref->resolve($config, $network_data);
+
+    # Delegate to a code reference
+    my $ref = Genesis::Hook::CloudConfig::LookupNetworkRef->new(
+        'primary',
+        sub {
+            my ($config, $network_data, $ref_name, @args) = @_;
+            return $network_data->{$ref_name};
+        }
+    );
+    my $value = $ref->resolve($config, $network_data);
+
+=head1 DESCRIPTION
+
+C<Genesis::Hook::CloudConfig::LookupNetworkRef> encapsulates a deferred
+network reference lookup for use in cloud-config generation. An instance
+records the reference name (C<$ref>), an optional resolution strategy
+(C<$lookup_method>), and any additional arguments needed by that strategy.
+The actual lookup is deferred until C<resolve()> is called.
+
+Three resolution strategies are supported, tried in priority order:
+
+=over 4
+
+=item 1.
+
+B<Code reference> — if C<$lookup_method> is a code reference, it is called
+directly with C<($config, $network_data, $ref, @lookup_args)>.
+
+=item 2.
+
+B<Named method> — if C<$lookup_method> is a non-empty string and
+C<$config-E<gt>can($lookup_method)> returns true, the method is invoked as
+C<$config-E<gt>$lookup_method($network_data, $ref, @lookup_args)>.
+
+=item 3.
+
+B<Direct hash lookup> — if C<$ref> exists as a key in C<$network_data>, its
+value is returned directly.
+
+=back
+
+If none of the strategies succeeds, C<resolve()> dies with an informative
+error message.
+
+See also L<Genesis::Hook::CloudConfig::LookupSubnetRef> for the analogous
+class that operates on subnet data.
+
+=head1 METHODS
+
+=head2 new
+
+    my $lookup_ref = Genesis::Hook::CloudConfig::LookupNetworkRef->new($ref, $lookup_method, @lookup_args);
+
+Creates a new C<LookupNetworkRef> object encapsulating a deferred network
+reference lookup.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$ref>
+
+The name of the reference to resolve. Used as a hash key when performing a
+direct lookup in C<$network_data>, and passed as an argument to code-ref and
+method-based resolution strategies.
+
+=item C<$lookup_method>
+
+B<(optional)> The resolution strategy. May be a code reference or a method
+name (string). When omitted or C<undef>, resolution falls back to a direct
+hash lookup in C<$network_data>.
+
+=item C<@lookup_args>
+
+B<(optional)> Additional arguments forwarded to C<$lookup_method> when it is
+a code reference or a named method on C<$config>.
+
+=back
+
+B<Returns:> A new C<Genesis::Hook::CloudConfig::LookupNetworkRef> object.
+
+B<Examples:>
+
+    # No strategy -- direct hash lookup
+    my $ref = Genesis::Hook::CloudConfig::LookupNetworkRef->new('default');
+    # Returns: a LookupNetworkRef object that will look up 'default' in network data
+
+    # Named method strategy with extra args
+    my $ref = Genesis::Hook::CloudConfig::LookupNetworkRef->new('primary', 'resolve_network', 'az1');
+    # Returns: a LookupNetworkRef object that will call $config->resolve_network(...)
+
+    # Code reference strategy
+    my $ref = Genesis::Hook::CloudConfig::LookupNetworkRef->new('mgmt', sub {
+        my ($config, $net, $name) = @_;
+        return $net->{$name}{cidr};
+    });
+    # Returns: a LookupNetworkRef object that will invoke the code reference
+
+=head2 resolve
+
+    my $value = $ref->resolve($config, $network_data);
+
+Resolves the reference against C<$network_data> using the strategy recorded
+at construction time. The three strategies are tried in order: code reference,
+named method on C<$config>, then direct hash lookup in C<$network_data>. If
+none succeeds, the method dies.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$config>
+
+The cloud-config object. Must support C<can()>. Used to dispatch named-method
+lookups when C<$lookup_method> is a string.
+
+=item C<$network_data>
+
+A hash reference containing the network data to search. Used both as the
+direct lookup target and as an argument passed to code-ref and method-based
+strategies.
+
+=back
+
+B<Returns:> The resolved value. The type and structure depend on the
+resolution strategy and the contents of C<$network_data>.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Could not resolve reference '$ref' in network data. Please ensure the reference exists and is spelled correctly.">
+
+Thrown via C<bail()> when none of the three resolution strategies succeeds.
+C<$ref> is the reference name passed to C<new()>.
+
+=back
+
+B<Examples:>
+
+    my $net_data = { default => '10.0.0.0/24', mgmt => '192.168.1.0/24' };
+
+    # Direct hash lookup
+    my $ref = Genesis::Hook::CloudConfig::LookupNetworkRef->new('default');
+    my $cidr = $ref->resolve($config, $net_data);
+    # Returns: '10.0.0.0/24'
+
+    # Named method dispatch
+    my $ref = Genesis::Hook::CloudConfig::LookupNetworkRef->new(
+        'mgmt', 'get_network_cidr'
+    );
+    my $cidr = $ref->resolve($config, $net_data);
+    # Returns: value from $config->get_network_cidr($net_data, 'mgmt')
+
+    # Unknown reference — dies
+    my $ref = Genesis::Hook::CloudConfig::LookupNetworkRef->new('missing');
+    $ref->resolve($config, $net_data);
+    # Dies: Could not resolve reference 'missing' in network data.
+    #       Please ensure the reference exists and is spelled correctly.
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Hook/CloudConfig/LookupRef.pod
+++ b/lib/Genesis/Hook/CloudConfig/LookupRef.pod
@@ -1,0 +1,156 @@
+=encoding UTF-8
+
+=head1 NAME
+
+Genesis::Hook::CloudConfig::LookupRef - Base class for cloud config value lookup references
+
+=head1 SYNOPSIS
+
+    use Genesis::Hook::CloudConfig::LookupRef;
+
+    # Create a lookup reference for a single path with a default
+    my $ref = Genesis::Hook::CloudConfig::LookupRef->new(
+        'meta.network',
+        'default-network',
+    );
+
+    # Create a lookup reference that searches multiple paths
+    my $ref = Genesis::Hook::CloudConfig::LookupRef->new(
+        ['meta.network', 'params.network'],
+        undef,
+    );
+
+    # Resolve the reference against a config data structure
+    my $value = $ref->resolve($config);
+    # Returns: the first matching value found, or the default
+
+=head1 DESCRIPTION
+
+C<Genesis::Hook::CloudConfig::LookupRef> is the base class for deferred value
+lookup references used in cloud config generation. A lookup reference
+encapsulates one or more dot-notation paths and an optional default value.
+When resolved, it walks the paths in order against a provided config data
+structure and returns the first value found, or the default if none match.
+
+Lookup references are created by cloud config hooks to represent values that
+should be drawn from the environment's manifest or params at resolution time,
+rather than being fixed at construction time. The subclasses
+C<Genesis::Hook::CloudConfig::LookupNetworkRef> and
+C<Genesis::Hook::CloudConfig::LookupSubnetRef> extend this base class with
+network- and subnet-specific resolution logic.
+
+=head1 METHODS
+
+=head2 new
+
+    my $ref = Genesis::Hook::CloudConfig::LookupRef->new($paths, $default);
+
+Constructs a new lookup reference. If C<$paths> is a plain string, it is
+wrapped in an array reference automatically.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$paths>
+
+A dot-notation path string (e.g., C<'meta.network'>) or an array reference
+of path strings to search in order. If a plain string is given, it is
+stored as a single-element array.
+
+=item C<$default>
+
+B<(optional)> The value to return from C<resolve> if none of the paths
+match in the config data structure. May be C<undef>.
+
+=back
+
+B<Returns:> A blessed C<Genesis::Hook::CloudConfig::LookupRef> object.
+
+B<Examples:>
+
+    # Single path with a default
+    my $ref = Genesis::Hook::CloudConfig::LookupRef->new('meta.network', 'default-net');
+    # Returns: a LookupRef object
+
+    # Multiple paths, no default
+    my $ref = Genesis::Hook::CloudConfig::LookupRef->new(
+        ['meta.network', 'params.network'],
+        undef,
+    );
+    # Returns: a LookupRef object
+
+=head2 paths
+
+    my @paths = $ref->paths;
+
+Returns the list of dot-notation lookup paths stored on this reference.
+
+B<Returns:> A list of path strings.
+
+B<Examples:>
+
+    my $ref = Genesis::Hook::CloudConfig::LookupRef->new(
+        ['meta.network', 'params.network'],
+        undef,
+    );
+    my @paths = $ref->paths;
+    # Returns: ('meta.network', 'params.network')
+
+=head2 default
+
+    my $default = $ref->default;
+
+Returns the default value stored on this reference. This value is passed to
+C<struct_lookup> as the fallback when none of the paths match.
+
+B<Returns:> The default value, or C<undef> if none was given to C<new>.
+
+B<Examples:>
+
+    my $ref = Genesis::Hook::CloudConfig::LookupRef->new('meta.network', 'default-net');
+    my $d = $ref->default;
+    # Returns: 'default-net'
+
+=head2 resolve
+
+    my $value = $ref->resolve($config);
+
+Resolves the lookup reference against C<$config> by calling C<struct_lookup>
+with the stored paths and default. Returns the first matching value found
+in C<$config>, or the default value if none of the paths match.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$config>
+
+A hash reference (or nested data structure) representing the config to
+search. Typically the environment's manifest params or a similar structured
+data source.
+
+=back
+
+B<Returns:> The resolved value from C<$config>, or the default value passed
+to C<new> if no path matched.
+
+B<Examples:>
+
+    my $ref = Genesis::Hook::CloudConfig::LookupRef->new('meta.network', 'default-net');
+
+    my $value = $ref->resolve({ meta => { network => 'prod-net' } });
+    # Returns: 'prod-net'
+
+    my $value = $ref->resolve({});
+    # Returns: 'default-net'
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Hook/CloudConfig/LookupSubnetRef.pod
+++ b/lib/Genesis/Hook/CloudConfig/LookupSubnetRef.pod
@@ -1,0 +1,167 @@
+=encoding UTF-8
+
+=head1 NAME
+
+Genesis::Hook::CloudConfig::LookupSubnetRef - Deferred reference resolver for cloud-config subnet data
+
+=head1 SYNOPSIS
+
+    use Genesis::Hook::CloudConfig::LookupSubnetRef;
+
+    # Direct key lookup in subnet data
+    my $ref = Genesis::Hook::CloudConfig::LookupSubnetRef->new('gateway');
+
+    # Method-dispatched lookup with extra arguments
+    my $ref = Genesis::Hook::CloudConfig::LookupSubnetRef->new(
+        'cidr',
+        'lookup_subnet_cidr',
+        $extra_arg,
+    );
+
+    # Resolve the reference against a config object and subnet data hash
+    my $value = $ref->resolve($config, $subnet_data);
+
+=head1 DESCRIPTION
+
+C<Genesis::Hook::CloudConfig::LookupSubnetRef> represents a pending reference
+into a subnet data hash that is resolved at a later point when the target
+cloud-config object and subnet data are available.
+
+An instance captures three pieces of information at construction time: the
+name of the key to look up (C<$ref>), an optional method name to dispatch on
+the config object for custom resolution (C<$lookup_method>), and any
+additional arguments to forward to that method (C<@lookup_args>). Resolution
+is deferred until C<resolve()> is called with a live config object and the
+relevant subnet data hash.
+
+This class is a sibling to
+C<Genesis::Hook::CloudConfig::LookupNetworkRef>, which performs the same
+role for network-level data rather than subnet-level data. Both classes are
+used by cloud-config hook implementations to build up a set of lazy
+references that are evaluated once all data is loaded.
+
+=head1 METHODS
+
+=head2 new
+
+    my $ref_obj = Genesis::Hook::CloudConfig::LookupSubnetRef->new($ref, $lookup_method, @lookup_args);
+
+Creates a new lookup reference object that records a subnet data key and an
+optional resolution strategy for later evaluation by C<resolve()>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$ref>
+
+B<(required)> The key name to look up in the subnet data hash when
+C<resolve()> is called.
+
+=item C<$lookup_method>
+
+B<(optional)> The name of a method to call on the config object for custom
+resolution. When provided and the config object supports this method (via
+C<can()>), that method is called instead of performing a direct hash lookup.
+Pass C<undef> to use direct key lookup only.
+
+=item C<@lookup_args>
+
+B<(optional)> Zero or more additional arguments forwarded to C<$lookup_method>
+when the method-dispatch path is taken.
+
+=back
+
+B<Returns:> A new blessed C<Genesis::Hook::CloudConfig::LookupSubnetRef>
+object.
+
+B<Examples:>
+
+    # Simple key lookup -- resolves $subnet_data->{gateway} at resolve time
+    my $gw_ref = Genesis::Hook::CloudConfig::LookupSubnetRef->new('gateway');
+    # Returns: a LookupSubnetRef object with ref='gateway'
+
+    # Custom method dispatch with extra arguments
+    my $cidr_ref = Genesis::Hook::CloudConfig::LookupSubnetRef->new('cidr', 'lookup_subnet_cidr', $zone);
+    # Returns: a LookupSubnetRef object with ref='cidr', lookup_method='lookup_subnet_cidr'
+
+=head2 resolve
+
+    my $value = $ref_obj->resolve($config, $subnet_data);
+
+Resolves the reference against C<$config> and C<$subnet_data> using the
+strategy recorded at construction time. Three resolution paths are attempted
+in order:
+
+=over 4
+
+=item 1.
+
+If a C<$lookup_method> was provided and the config object supports that method
+(C<$config-E<gt>can($lookup_method)> is true), the method is called as
+C<$config-E<gt>$lookup_method($subnet_data, $ref, @lookup_args)> and its
+return value is returned.
+
+=item 2.
+
+If the key C<$ref> exists directly in C<$subnet_data>, C<$subnet_data-E<gt>{$ref}>
+is returned.
+
+=item 3.
+
+If neither path succeeds, C<bail()> is called with an error message.
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item C<$config>
+
+B<(required)> The cloud-config object against which to dispatch the optional
+lookup method. Must support C<can()>.
+
+=item C<$subnet_data>
+
+B<(required)> A hash reference containing the subnet data fields to search.
+Typically one entry from the subnet list in a cloud-config network stanza.
+
+=back
+
+B<Returns:> The resolved value from the config method or the subnet data hash.
+
+B<Errors:>
+
+=over 4
+
+=item C<"Could not resolve reference '$ref' in subnet data. Please ensure the reference exists and is spelled correctly.">
+
+Raised via C<bail()> when neither the method-dispatch path nor the direct key
+lookup finds a value. C<$ref> is replaced with the key name passed to C<new()>.
+
+=back
+
+B<Examples:>
+
+    my $ref_obj = Genesis::Hook::CloudConfig::LookupSubnetRef->new('gateway');
+    my $gateway = $ref_obj->resolve($config, { gateway => '10.0.0.1', cidr => '10.0.0.0/24' });
+    # Returns: '10.0.0.1'
+
+    my $cidr_ref = Genesis::Hook::CloudConfig::LookupSubnetRef->new(
+        'cidr',
+        'lookup_subnet_cidr',
+        $zone,
+    );
+    my $cidr = $cidr_ref->resolve($config, $subnet_data);
+    # Returns: result of $config->lookup_subnet_cidr($subnet_data, 'cidr', $zone)
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Hook/CpiConfig.pod
+++ b/lib/Genesis/Hook/CpiConfig.pod
@@ -1,0 +1,372 @@
+=encoding UTF-8
+
+=head1 NAME
+
+Genesis::Hook::CpiConfig - Hook implementation for generating BOSH CPI configs
+
+=head1 SYNOPSIS
+
+    package Genesis::Hook::CpiConfig::my_kit;
+    use parent 'Genesis::Hook::CpiConfig';
+
+    sub perform {
+        my ($self) = @_;
+
+        my $properties = $self->gather_properties(
+            'datacenter',
+            'datastore',
+            '!password@credentials.vcenter_password',
+        );
+
+        my $config = $self->build_cpi_config_for_iaas(
+            vsphere => $properties,
+        );
+
+        $self->done($config);
+    }
+
+    1;
+
+=head1 DESCRIPTION
+
+C<Genesis::Hook::CpiConfig> is the base class for Genesis kit hooks that
+generate BOSH CPI (Cloud Provider Interface) configurations. It extends
+C<Genesis::Hook> with infrastructure specific to CPI config generation:
+property lookup and resolution from environment manifests and OCFP
+configuration, secret entombment into CredHub, and construction of the CPI
+config data structure.
+
+Kit authors subclass this class and implement C<perform>. The C<perform>
+method should call C<gather_properties> to resolve CPI property values,
+C<build_cpi_config_for_iaas> to assemble the BOSH CPI config structure, and
+finally C<done> to signal completion and deliver the result to Genesis.
+
+The hook lifecycle follows the standard C<Genesis::Hook> pattern. See
+L<Genesis::Hook> for inherited methods including C<init>, C<perform>,
+C<completed>, C<env>, C<iaas>, C<features>, C<want_feature>, and BOSH
+integration helpers.
+
+=head1 METHODS
+
+=head2 init
+
+    my $hook = Genesis::Hook::CpiConfig->init(%opts);
+
+Constructs and returns a new C<Genesis::Hook::CpiConfig> object. Delegates
+to the parent class for base initialization, then initializes two internal
+stores: C<cpi_config> (empty hashref) and C<credhub_secrets> (empty
+hashref).
+
+B<Parameters:>
+
+=over 4
+
+=item C<%ops>
+
+Key-value pairs passed through to C<Genesis::Hook>'s C<init>. The C<env> key
+is required. See L<Genesis::Hook/init> for the full list of accepted options.
+
+=back
+
+B<Returns:> A blessed C<Genesis::Hook::CpiConfig> object (or subclass).
+
+B<Examples:>
+
+    my $hook = Genesis::Hook::CpiConfig->init(env => $env);
+    # Returns: a blessed Genesis::Hook::CpiConfig object
+
+=head2 done
+
+    $hook->done($config, $error);
+    $hook->done(undef, $error_message);
+    $hook->done($config);
+
+Signals that CPI config generation is complete. When C<$config> is a
+defined, truthy value, it is serialized to a temporary YAML file and the
+YAML string is stored as the hook's content. When C<$config> is false or
+undefined, the content is set to C<undef>. An optional C<$error> string
+records any error that occurred during generation. Sets the internal
+C<complete> flag to C<1>.
+
+Modifies the object in-place.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$config>
+
+A data structure (hashref) representing the CPI config to serialize to YAML,
+or C<undef> / a false value to indicate that no config was produced.
+
+=item C<$error>
+
+B<(optional)> An error message string to record. Stored as C<undef> if not
+provided.
+
+=back
+
+B<Returns:> C<1> (the value of the C<complete> flag after being set).
+
+B<Examples:>
+
+    # Signal success with a config structure
+    $self->done($cpi_config_hashref);
+    # Returns: 1
+
+    # Signal that generation produced no config
+    $self->done(undef, "IaaS not supported for this environment");
+    # Returns: 1
+
+=head2 results
+
+    my $hashref          = $hook->results;
+    my ($content, $secrets, $error) = $hook->results;
+
+Returns the results of CPI config generation after C<done> has been called.
+Returns early with an empty/undefined value if the hook has not yet
+completed.
+
+In scalar context, returns a hashref with three keys: C<content> (the
+generated YAML string, or C<undef>), C<credhub_secrets> (a hashref mapping
+CredHub credential names to their values), and C<error> (an error message
+string, or C<undef>).
+
+In list context, returns the three values directly in the order
+C<(content, credhub_secrets, error)>.
+
+B<Returns:>
+
+In scalar context: a hashref with keys C<content>, C<credhub_secrets>, and
+C<error>, or C<undef> if the hook has not completed.
+
+In list context: C<($content, $credhub_secrets, $error)>, or an empty list
+if the hook has not completed.
+
+B<Examples:>
+
+    $hook->done($config);
+
+    # Scalar context
+    my $r = $hook->results;
+    print $r->{content};
+    # Returns: { content => '...yaml...', credhub_secrets => {...}, error => undef }
+
+    # List context
+    my ($yaml, $secrets, $err) = $hook->results;
+    # Returns: ('...yaml...', { '/path/cred--key--abc1234' => 'value' }, undef)
+
+    # Before done() is called
+    my $r = $hook->results;
+    # Returns: undef (scalar context) or () (list context)
+
+=head2 build_cpi_config_for_iaas
+
+    my $config = $hook->build_cpi_config_for_iaas(%configs);
+
+Builds a BOSH CPI config data structure for the environment's IaaS type.
+C<%configs> is a dispatch table mapping IaaS type strings (e.g., C<'aws'>,
+C<'vsphere'>) to either a properties hashref or a code reference that
+returns one. Only the entry matching the environment's current IaaS is used.
+If the current IaaS is not present in C<%configs>, the method terminates
+with an error.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%configs>
+
+A hash mapping IaaS type strings to CPI properties. Values may be either a
+hashref of CPI properties or a C<CODE> reference that, when called with no
+arguments, returns a hashref of CPI properties.
+
+=back
+
+B<Returns:> A hashref suitable for passing to C<done>, structured as:
+
+    {
+        cpis => [
+            {
+                name       => $env->cpi_name,
+                type       => $iaas,
+                properties => \%properties,
+            }
+        ],
+    }
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Unsupported IaaS: %s"> -- raised via C<bail()> if the environment's IaaS
+type is not a key in C<%configs>. C<%s> is replaced with the IaaS type
+string.
+
+=back
+
+B<Examples:>
+
+    my $config = $hook->build_cpi_config_for_iaas(
+        aws     => { region => 'us-east-1', default_key_name => 'bosh' },
+        vsphere => sub { { datacenter => $hook->env->lookup('params.datacenter') } },
+    );
+    # Returns: { cpis => [{ name => 'aws_cpi', type => 'aws', properties => {...} }] }
+
+    $self->done($config);
+    # Returns: 1
+
+=head2 gather_properties
+
+    my $properties = $hook->gather_properties(@properties);
+
+Resolves a list of CPI property descriptors into a flat hashref of values
+suitable for use as the C<properties> key in a CPI config structure. Each
+descriptor is a string in a mini-language that controls where to look up the
+value, what default to use, and where to place it in the output.
+
+B<Property descriptor syntax:>
+
+    [!]property_name[@alt1,alt2][:default_value|?][>config_path]
+
+=over 4
+
+=item C<property_name>
+
+The primary lookup key. Used to search C<bosh-configs.cpi.E<lt>keyE<gt>> in
+the environment manifest, and C<cpi.E<lt>iaasE<gt>.E<lt>keyE<gt>> in the
+OCFP configuration. Also used as the output key in the returned hashref
+unless C<< > >> is specified.
+
+=item C<!>
+
+Marks the property as a secret. The resolved value is entombed in CredHub
+via C<cpi_entombment_path_for>, the original value is stored in the hook's
+C<credhub_secrets> store, and the property's value in the output is replaced
+with the CredHub reference C<(( path ))>.
+
+=item C<@alt1,alt2,...>
+
+Alternative lookup keys tried in order if C<property_name> is not found.
+Multiple alternatives are comma-separated.
+
+=item C<:default_value>
+
+A default value to use if the property is not found via any lookup. The
+default is parsed as JSON if possible; otherwise used verbatim. Use C<true>,
+C<false>, and C<null> for their JSON/YAML equivalents. Quoted strings are
+parsed as JSON strings.
+
+=item C<?>
+
+Makes the property optional. If not found via any lookup, the property is
+omitted from the output entirely (no error, no default).
+
+=item C<< >config_path >>
+
+Overrides the output key in the returned hashref. Useful for nested
+properties using dot-notation (e.g., C<< connection_options.connect_timeout >>).
+
+=back
+
+Values are resolved in this priority order: C<bosh-configs.cpi.*> in the
+environment manifest, then C<cpi.E<lt>iaasE<gt>.*> in the OCFP
+configuration, then the descriptor's default. After the declared properties
+are resolved, any additional keys present in C<bosh-configs.cpi> that were
+not already resolved are merged in as overrides. Vault references in
+override values are entombed in CredHub automatically.
+
+The resulting flat hash is passed through C<unflatten> to produce a nested
+structure when dot-notation config paths are used.
+
+B<Parameters:>
+
+=over 4
+
+=item C<@properties>
+
+A list of property descriptor strings as described above.
+
+=back
+
+B<Returns:> A hashref of resolved CPI property values, unflattened into a
+nested structure.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Missing default for CPI config value for %s, and none found in environment">
+-- raised via C<bail()> when a non-optional property has no value in the
+manifest, no value in the OCFP configuration, and no default in its
+descriptor. C<%s> is replaced with the property name.
+
+=back
+
+B<Examples:>
+
+    my $props = $hook->gather_properties(
+        'datacenter',                        # required, from env or OCFP
+        'datastore:default-datastore',       # optional with default
+        'timeout?',                          # omitted if not set
+        '!vcenter_password',                 # secret: entombed in CredHub
+        'clusters@vsphere_clusters:[]',      # alternate lookup with default
+        'ntp>global.ntp',                    # placed at properties.global.ntp
+    );
+    # Returns: { datacenter => '...', datastore => '...', global => { ntp => [...] }, ... }
+
+=head2 cpi_entombment_path_for
+
+    my $path = $hook->cpi_entombment_path_for($key, $value);
+
+Computes a deterministic CredHub credential path for a CPI config property
+value. The path is of the form:
+
+    $prefix . 'cpi-config-property--' . $key . '--' . $sha1
+
+where C<$prefix> is taken from C<< $self->{credhub_prefix} >> if set,
+otherwise from C<< $env->cpi_credhub_base >>, and C<$sha1> is the first 8
+hex characters of the SHA-1 digest of the string
+C<"cpi-config-property--$key--$value">.
+
+This method is used internally by C<gather_properties> to generate stable,
+unique CredHub paths for secret values. The path is the same for a given
+combination of key and value, making it safe to call idempotently.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$key>
+
+The property name or config path for which a CredHub credential is being
+created.
+
+=item C<$value>
+
+The secret value. Incorporated into the SHA-1 hash to produce a unique path
+per distinct value.
+
+=back
+
+B<Returns:> A CredHub credential path string of the form
+C<"$prefix cpi-config-property--$key--$sha1">.
+
+B<Examples:>
+
+    my $path = $hook->cpi_entombment_path_for('vcenter_password', 's3cr3t');
+    # Returns: '/bosh/cpi-config-property--vcenter_password--a1b2c3d4'
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Hook/CpiConfig.pod
+++ b/lib/Genesis/Hook/CpiConfig.pod
@@ -354,7 +354,7 @@ per distinct value.
 =back
 
 B<Returns:> A CredHub credential path string of the form
-C<"$prefix cpi-config-property--$key--$sha1">.
+C<"${prefix}cpi-config-property--$key--$sha1">.
 
 B<Examples:>
 

--- a/lib/Genesis/Hook/Features.pod
+++ b/lib/Genesis/Hook/Features.pod
@@ -1,0 +1,371 @@
+=encoding UTF-8
+
+=head1 NAME
+
+Genesis::Hook::Features - Hook for resolving and communicating feature flags to Genesis
+
+=head1 SYNOPSIS
+
+    package Genesis::Hook::Features::my_kit;
+    use parent 'Genesis::Hook::Features';
+
+    sub perform {
+        my ($self) = @_;
+
+        # Add features unconditionally
+        $self->add_feature('ha');
+        $self->add_feature('mtls');
+
+        # Conditionally suppress a feature
+        $self->delete_feature('ha') unless $self->want_feature('ha');
+
+        # Signal completion — done() will call build_features_list() automatically
+        $self->done;
+    }
+
+    1;
+
+=head1 DESCRIPTION
+
+C<Genesis::Hook::Features> is the concrete hook class that kit authors subclass
+when they need to report the resolved feature set for a deployment environment.
+It extends L<Genesis::Hook> with a mutable feature registry and a
+C<build_features_list> method that produces an ordered list of active features
+for Genesis to consume.
+
+The features hook lifecycle:
+
+=over 4
+
+=item 1.
+
+Genesis instantiates the hook via C<init>, which calls the parent
+L<Genesis::Hook> C<init> method and then initialises an empty C<all_features>
+list and C<has_feature> lookup map. The C<env>, C<kit>, and C<features>
+constructor arguments are all required.
+
+=item 2.
+
+Genesis calls C<perform> on the hook. Kit authors implement this method, using
+C<add_feature>, C<has_feature>, and C<delete_feature> to build up the desired
+feature set.
+
+=item 3.
+
+Kit authors call C<done> (with or without an explicit list) to signal
+completion and hand the resolved feature array reference back to Genesis.
+
+=back
+
+See L<Genesis::Hook> for the full set of inherited methods including
+C<want_feature>, C<env>, C<kit>, and C<spruce_merge>.
+
+=head1 METHODS
+
+=head2 init
+
+    my $hook = Genesis::Hook::Features->init;
+
+Constructs and returns a new features hook object. Calls the parent
+L<Genesis::Hook> C<init> after validating required arguments, then initialises
+two internal data structures:
+an ordered C<all_features> list (used to preserve insertion order when building
+the final feature list) and a C<has_feature> lookup hash.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+Key-value pairs forwarded to the parent L<Genesis::Hook> C<init>. The
+following keys are required:
+
+=over 4
+
+=item C<env>
+
+B<(required)> A C<Genesis::Env> object for the deployment environment.
+
+=item C<kit>
+
+B<(required)> A C<Genesis::Kit> object for the kit being run.
+
+=item C<features>
+
+B<(required)> The initial feature list for the environment (typically the
+list declared in the environment YAML file).
+
+=back
+
+=back
+
+B<Returns:> A blessed C<Genesis::Hook::Features> object.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Missing required arguments for a perl-based kit hook call: %s"> -- raised
+via C<bug()> if any of C<env>, C<kit>, or C<features> are absent from
+C<%opts>. C<%s> is replaced with the comma-separated list of missing argument
+names.
+
+=back
+
+B<Examples:>
+
+    # Genesis calls this internally; kit authors do not call init() directly.
+    # Genesis::Hook::Features->init is invoked with env, kit, and features args.
+    # Returns: a blessed Genesis::Hook::Features object
+
+=head2 add_feature
+
+    $hook->add_feature($feature, $set);
+
+Registers C<$feature> in the hook's feature registry. The feature name is
+appended to the ordered C<all_features> list (which governs output order in
+C<build_features_list>) and its value is recorded in the C<has_feature> lookup
+map.
+
+When C<$set> is omitted, the feature is registered with the value C<1>
+(active). Passing an explicit C<$set> value allows a feature to be registered
+with a different truthy or falsy value.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$feature>
+
+The feature name string to register.
+
+=item C<$set>
+
+B<(optional)> The value to store for this feature in the lookup map. Defaults
+to C<1> when fewer than three arguments are passed.
+
+=back
+
+B<Returns:> Nothing.
+
+B<Examples:>
+
+    $hook->add_feature('ha');
+    # Returns: nothing (registers 'ha' with value 1)
+
+    $hook->add_feature('debug', 0);
+    # Returns: nothing (registers 'debug' with value 0)
+
+=head2 has_feature
+
+    my $value = $hook->has_feature($feature);
+
+Returns the value stored for C<$feature> in the hook's feature lookup map, or
+C<undef> if the feature was never registered. A true return value means the
+feature is active; C<undef> or a false value means it is not.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$feature>
+
+The feature name string to look up.
+
+=back
+
+B<Returns:> The value stored by C<add_feature> for this feature, or C<undef>
+if the feature is not registered.
+
+B<Examples:>
+
+    $hook->add_feature('ha');
+    my $val = $hook->has_feature('ha');
+    # Returns: 1
+
+    my $val = $hook->has_feature('nonexistent');
+    # Returns: undef
+
+=head2 delete_feature
+
+    my $value = $hook->delete_feature($feature);
+
+Removes C<$feature> from the hook's feature lookup map and returns the value
+that was stored there. After this call, C<has_feature($feature)> will return
+C<undef>. The feature name remains in the C<all_features> ordered list, but
+C<build_features_list> will skip it because the lookup entry is gone.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$feature>
+
+The feature name string to remove.
+
+=back
+
+B<Returns:> The value that was stored for C<$feature>, or C<undef> if it was
+not registered.
+
+B<Examples:>
+
+    $hook->add_feature('ha');
+    my $old = $hook->delete_feature('ha');
+    # Returns: 1
+
+    my $old = $hook->delete_feature('nonexistent');
+    # Returns: undef
+
+=head2 build_features_list
+
+    my @features = $hook->build_features_list(%opts);
+
+Iterates over the ordered C<all_features> list and returns those features that
+are currently active in the lookup map. For each feature in insertion order:
+
+=over 4
+
+=item *
+
+If the feature name appears in C<virtual_features>, the method checks for an
+entry under C<"+$feature"> (the virtual variant). If that entry is active, the
+C<"+$feature"> string is included in the result and removed from the lookup map.
+If not active, the feature is skipped entirely.
+
+=item *
+
+Otherwise, if the feature is active in the lookup map (i.e., C<has_feature>
+returns a true value), the plain feature name is included in the result and
+removed from the lookup map.
+
+=back
+
+Each included feature is deleted from the lookup map as it is emitted, so
+repeated calls to C<build_features_list> produce an empty list after the first
+call.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+=over 4
+
+=item C<virtual_features>
+
+B<(optional)> An array reference of feature names that should be promoted to
+their virtual (C<+>-prefixed) variants when present. Defaults to an empty
+list.
+
+=back
+
+=back
+
+B<Returns:> A list of active feature name strings, in the order they were
+added via C<add_feature>.
+
+B<Examples:>
+
+    $hook->add_feature('ha');
+    $hook->add_feature('mtls');
+    my @list = $hook->build_features_list;
+    # Returns: ('ha', 'mtls')
+
+    # With virtual features
+    $hook->add_feature('+internal-blobstore');
+    $hook->add_feature('ocfp');
+    my @list = $hook->build_features_list(
+        virtual_features => ['internal-blobstore'],
+    );
+    # Returns: ('+internal-blobstore', 'ocfp')
+
+=head2 done
+
+    $hook->done;
+
+Marks the hook as complete and records the resolved feature list. This is the
+primary way to signal to Genesis that the features hook has finished its work.
+
+The argument handling is:
+
+=over 4
+
+=item *
+
+B<No arguments> -- calls C<build_features_list()> with no options to produce
+the feature list automatically, wraps it in an array reference, and passes it
+to the parent L<Genesis::Hook> C<done>.
+
+=item *
+
+B<A single array reference> -- passed directly to the parent L<Genesis::Hook> C<done> as the
+result.
+
+=item *
+
+B<One or more plain strings> -- collected into a new array reference and passed
+to the parent L<Genesis::Hook> C<done>.
+
+=item *
+
+B<A single falsy value> (e.g., C<undef> or C<0>) -- delegated directly to
+the parent C<done($value)>, which marks the hook as I<not> complete.
+
+=back
+
+B<Parameters:>
+
+=over 4
+
+=item C<@features> or C<\@features>
+
+B<(optional)> An explicit list of feature name strings, or a single array
+reference of feature names. When omitted, C<build_features_list()> is called
+to generate the list automatically. Pass C<undef> to mark the hook as
+incomplete.
+
+=back
+
+B<Returns:> The feature array reference passed to the parent L<Genesis::Hook> C<done>, or the falsy
+value if a single falsy argument was given.
+
+B<Examples:>
+
+    # Automatic: build_features_list() is called; result passed to Genesis
+    $self->done;
+    # Returns: an array reference of the active features
+
+    # See the perform() examples in ABSTRACT METHODS for complete usage
+
+=head1 ABSTRACT METHODS
+
+The following method must be implemented by every concrete C<Genesis::Hook::Features>
+subclass. The base class implementation in L<Genesis::Hook> calls C<kit_bug>
+and terminates with an error.
+
+=head2 perform
+
+    $hook->perform;
+
+Carries out the features hook's work. The implementation should use
+C<add_feature>, C<has_feature>, and C<delete_feature> to build up the desired
+feature set, then call C<$self->done> to signal completion and pass the
+resolved feature list to Genesis.
+
+B<Returns:> Whatever value was passed to C<done>, made available via
+C<results>. The return value of C<perform> itself is not used by Genesis.
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Hook/PostDeploy.pod
+++ b/lib/Genesis/Hook/PostDeploy.pod
@@ -1,0 +1,505 @@
+=encoding UTF-8
+
+=head1 NAME
+
+Genesis::Hook::PostDeploy - Post-deploy hook for Genesis kit deployments
+
+=head1 SYNOPSIS
+
+    package Genesis::Hook::PostDeploy::my_kit;
+    use parent 'Genesis::Hook::PostDeploy';
+
+    sub perform {
+        my ($self) = @_;
+
+        if ($self->deploy_successful) {
+            $self->update_director_network_config;
+            $self->upload_director_cpi_config;
+            $self->upload_stemcells;
+            $self->upload_runtime_configs;
+        }
+
+        $self->done(1);
+    }
+
+    1;
+
+=head1 DESCRIPTION
+
+C<Genesis::Hook::PostDeploy> is the base class for post-deploy kit hooks.
+It extends C<Genesis::Hook> with post-deploy-specific behavior: inspecting the
+deployment result code, managing director-level configurations (cloud config,
+CPI config, runtime configs), uploading stemcells, and storing CredHub secrets.
+
+The hook is instantiated by Genesis after a C<bosh deploy> completes, with the
+exit code passed as C<rc>. Kit authors subclass this class and implement the
+C<perform> method to carry out any required post-deploy work.
+
+The standard usage pattern is:
+
+=over 4
+
+=item 1.
+
+Genesis calls C<init> with C<env> and C<rc> (the deployment exit code).
+
+=item 2.
+
+Genesis calls C<perform>. Kit authors implement this to call the appropriate
+post-deploy helpers (C<update_director_network_config>,
+C<upload_director_cpi_config>, C<upload_stemcells>,
+C<upload_runtime_configs>) based on what the kit requires.
+
+=item 3.
+
+The hook calls C<done> to signal completion.
+
+=back
+
+See L<Genesis::Hook> for the full base class interface, including environment
+access, feature detection, BOSH/CredHub integration, and YAML merging utilities.
+
+=head1 METHODS
+
+=head2 init
+
+    my $hook = Genesis::Hook::PostDeploy->init(%ops);
+
+Constructs and returns a new post-deploy hook object. Both C<env> and C<rc>
+are required keys in C<%ops>. Delegates to the parent class C<Genesis::Hook> C<init> after
+validating that both required arguments are present.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%ops>
+
+Key-value pairs stored on the hook object. The following keys are required:
+
+=over 4
+
+=item C<env>
+
+B<(required)> A C<Genesis::Env> object representing the deployment environment.
+
+=item C<rc>
+
+B<(required)> The integer exit code from the C<bosh deploy> command. A value
+of C<0> indicates a successful deployment.
+
+=back
+
+=back
+
+B<Returns:> A blessed C<Genesis::Hook::PostDeploy> object (or subclass thereof).
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Missing required arguments for a perl-based kit hook call: %s"> -- raised
+via C<bug()> if either C<env> or C<rc> is absent from C<%opts>. C<%s> is
+replaced with the comma-separated list of missing argument names.
+
+=back
+
+B<Examples:>
+
+    my $hook = Genesis::Hook::PostDeploy->init(env => $env, rc => 0);
+    # Returns: a blessed Genesis::Hook::PostDeploy object
+
+
+
+=head2 deploy_successful
+
+    my $bool = $hook->deploy_successful;
+
+Returns true if the deployment completed successfully (i.e., the C<rc> value
+passed to C<init> was C<0>).
+
+B<Returns:> C<1> if C<rc> equals C<0>, or an empty string (false) otherwise.
+
+B<Examples:>
+
+    if ($hook->deploy_successful) {
+        $hook->upload_stemcells;
+    }
+    # Returns: 1 if the deploy exited with rc=0, '' otherwise
+
+=head2 data
+
+    my $hashref = $hook->data;
+
+Returns the hook's mutable data hash reference. The hash is initialized to an
+empty hash on first access and can be used by kit authors to store arbitrary
+values during C<perform>.
+
+B<Returns:> A hash reference (never C<undef>).
+
+B<Examples:>
+
+    my $data = $hook->data;
+    $data->{custom_key} = 'custom_value';
+    # Returns: {} on first call, then the same hash reference on subsequent calls
+
+=head2 update_director_network_config
+
+    $hook->update_director_network_config;
+
+Generates and uploads the director cloud-config for the BOSH director, then
+stores the resulting network details in the environment's exodus vault path.
+Does nothing and returns immediately if the environment cannot build cloud
+configs (C<< $env->can_build_cloud_configs >> is false).
+
+The method:
+
+=over 4
+
+=item 1.
+
+Runs the C<cloud-config> hook with C<purpose =E<gt> 'director'> to produce
+a config YAML document and a network hash.
+
+=item 2.
+
+Uploads the cloud config to the BOSH director under the name
+C<$env_name.$env_type.director>.
+
+=item 3.
+
+Stores the network hash in the environment's exodus vault path under
+C</network>.
+
+=back
+
+B<Returns:> Nothing. Returns immediately (without completing the upload) if
+the environment does not support building cloud configs.
+
+B<Examples:>
+
+    $hook->update_director_network_config;
+    # Returns: nothing; uploads config and stores network details in exodus
+
+=head2 command
+
+    my $cmd = $hook->command();
+
+Constructs a shell command string using the genesis invocation path from the
+environment (C<GENESIS_CALL_ENV> or C<GENESIS_CALL>) as the base command,
+followed by any additional arguments passed to the method. Arguments
+containing spaces, parentheses, exclamation marks, asterisks, or question
+marks are single-quoted.
+
+B<Returns:> A string containing the full shell command.
+
+B<Examples:>
+
+    my $cmd = $hook->command('do', 'upload-stemcells');
+    # Returns: 'genesis my-env do upload-stemcells'
+
+    my $cmd = $hook->command('deploy', '--dry-run');
+    # Returns: 'genesis my-env deploy --dry-run'
+
+=head2 help
+
+    $hook->help(%addons);
+
+Displays help information for the hook or for the kit's available addons.
+
+If the hook object has a C<cmd_details> method (i.e., the subclass implements
+it), the method displays the hook's own command details using the hook's
+label and returns C<1>.
+
+Otherwise, the method collects C<cmd_details> from all C<addon-*.pm> files in
+the kit's C<hooks/> directory, merges them with any entries in C<%addons>,
+and prints a formatted listing. Returns C<0> if no addons are found.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%addons>
+
+B<(optional)> A hash mapping addon command names to their help text strings.
+Addon names may include a C<~> separator to specify a short alias (e.g.,
+C<"upload-stemcells~us">).
+
+=back
+
+B<Returns:> C<1> if the hook provides its own C<cmd_details>, C<0> if no
+addons are found, or nothing if addons are displayed.
+
+B<Examples:>
+
+    $hook->help;
+    # Returns: 1 if cmd_details is defined, 0 if no addons exist
+
+    $hook->help('upload-stemcells' => "Upload stemcells to the BOSH director");
+    # Returns: nothing (prints the addon listing)
+
+=head2 upload_director_cpi_config
+
+    $hook->upload_director_cpi_config;
+
+Uploads a custom CPI config to the BOSH director if the environment's CPI is
+enabled and the kit provides a C<cpi-config> hook. After a successful upload,
+any CredHub secrets produced by the CPI config hook are committed to the
+director's CredHub via C<_commit_config_credhub_secrets>.
+
+The method:
+
+=over 4
+
+=item 1.
+
+Does nothing if C<< $self->cpi_enabled >> is false or the kit has no
+C<cpi-config> hook.
+
+=item 2.
+
+Runs the C<cpi-config> hook with a CredHub prefix of
+C</cpi-config/properties/> to produce a config document, a secrets hash, and
+an errors string.
+
+=item 3.
+
+Returns C<0> and logs an error if the hook returned errors.
+
+=item 4.
+
+Uploads the config to the BOSH director under the name
+C<$cpi_name.director>.
+
+=item 5.
+
+Returns C<0> and logs an error if the upload fails.
+
+=item 6.
+
+Calls C<_commit_config_credhub_secrets> with the secrets hash.
+
+=back
+
+B<Returns:> C<0> on error (CPI config errors or upload failure), or nothing
+on success or when CPI config is not applicable.
+
+B<Examples:>
+
+    $hook->upload_director_cpi_config;
+    # Returns: 0 on error, nothing on success or when not applicable
+
+=head2 upload_stemcells
+
+    $hook->upload_stemcells;
+
+Checks for existing stemcells on the BOSH director and, if none are found,
+offers to upload one. Returns immediately without action if the deployment
+was not successful (C<deploy_successful> is false).
+
+The method:
+
+=over 4
+
+=item 1.
+
+Returns immediately (without uploading) if the deploy was not successful.
+
+=item 2.
+
+Returns C<1> if the director already has stemcells.
+
+=item 3.
+
+In interactive mode on a controlling terminal, prompts the user whether to
+upload a stemcell. Returns without uploading if the user declines.
+
+=item 4.
+
+Queries available stemcells, optionally filtered by the
+C<bosh-configs.stemcells.type> setting in the environment manifest.
+
+=item 5.
+
+Returns C<0> and logs an error if no available stemcells are found.
+
+=item 6.
+
+In interactive mode, prompts the user to select a stemcell. In
+non-interactive mode, selects the latest available stemcell automatically.
+
+=item 7.
+
+Uploads the selected stemcell and returns C<1> on success, or C<0> on
+upload failure.
+
+=back
+
+B<Returns:>
+
+=over 4
+
+=item *
+
+Nothing (returns early) if the deploy was not successful or if the user
+declined the upload prompt.
+
+=item *
+
+C<1> if stemcells already exist on the director or the upload succeeded.
+
+=item *
+
+C<0> if no available stemcells were found for the IaaS or the upload failed.
+
+=back
+
+B<Examples:>
+
+    $hook->upload_stemcells;
+    # Returns: 1 if stemcells are present or uploaded successfully
+
+    # After a failed deploy, does nothing:
+    # ($hook->deploy_successful is false -- rc != 0)
+    $hook->upload_stemcells;
+    # Returns: nothing
+
+=head2 upload_runtime_configs
+
+    $hook->upload_runtime_configs;
+
+Reads the C<bosh-configs.runtime> setting from the environment manifest and
+uploads the specified runtime configs to the BOSH director by running the
+kit's C<runtime-config> hook.
+
+Returns immediately without action if C<bosh-configs.runtime> is not set, or
+if the hash has no keys.
+
+B<Returns:>
+
+=over 4
+
+=item *
+
+Nothing if C<bosh-configs.runtime> is not configured or is empty.
+
+=item *
+
+C<0> and logs an error if the C<runtime-config> hook fails.
+
+=item *
+
+The result of C<$self->done(1)> on success.
+
+=back
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Runtime configs must be a hash reference, got %s.  Please check the 'bosh-configs.runtime' setting in the #C{%s} environment.">
+-- raised via C<bail()> if C<bosh-configs.runtime> is set but is not a hash
+reference. The first C<%s> is the ref type (or the stringified value if not
+a reference), and the second C<%s> is the environment name.
+
+=item *
+
+C<"The #M{%s} kit does not provide any runtime configs.  Please check the 'bosh-configs.runtime' setting in the #C{%s} environment.">
+-- raised via C<bail()> if runtime configs are configured but the kit does
+not provide a C<runtime-config> hook. The first C<%s> is the kit identifier
+and the second is the environment name.
+
+=item *
+
+C<"Runtime config options must be a hash reference or 'true', but:\n%s\n">
+-- raised via C<bail()> if any entry in the C<bosh-configs.runtime> hash is
+neither a hash reference nor a JSON boolean true value. C<%s> is replaced
+with a formatted list of the invalid entries.
+
+=back
+
+B<Examples:>
+
+    $hook->upload_runtime_configs;
+    # Returns: result of done(1) on success, 0 on hook failure, nothing if unconfigured
+
+=head2 results
+
+    my $result = $hook->results;
+
+Returns C<1> unconditionally, overriding the C<Genesis::Hook> base class
+implementation. Post-deploy hooks always report a successful result
+regardless of the operations performed.
+
+B<Returns:> C<1>
+
+B<Examples:>
+
+    my $r = $hook->results;
+    # Returns: 1
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _commit_config_credhub_secrets
+
+    $hook->_commit_config_credhub_secrets(\%secrets);
+
+Writes each entry in C<%secrets> to the BOSH director's CredHub instance.
+Returns immediately if C<%secrets> is empty or C<undef>. The CredHub client
+is obtained via C<< Service::Credhub->from_bosh >> using the environment's
+target BOSH director.
+
+B<Parameters:>
+
+=over 4
+
+=item C<\%secrets>
+
+B<(optional)> A hash reference mapping CredHub paths to secret values. If
+C<undef> or empty, the method returns C<1> immediately.
+
+=back
+
+B<Returns:> C<1> on success, or C<1> immediately if there are no secrets to
+commit.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"No value specified for the secret %s"> -- raised via C<bail()> if a path
+key exists in C<%secrets> but its value is false. C<%s> is the CredHub path.
+
+=item *
+
+C<"Failed to entomb the secret %s: %s"> -- raised via C<bail()> if the
+CredHub C<set> call throws an exception. The first C<%s> is the CredHub path
+and the second is the exception message.
+
+=back
+
+B<Examples:>
+
+    $hook->_commit_config_credhub_secrets({
+        '/bosh/certs/ca' => $ca_pem,
+    });
+    # Returns: 1 on success
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Hook/PostDeploy.pod
+++ b/lib/Genesis/Hook/PostDeploy.pod
@@ -101,7 +101,7 @@ B<Errors:>
 =item *
 
 C<"Missing required arguments for a perl-based kit hook call: %s"> -- raised
-via C<bug()> if either C<env> or C<rc> is absent from C<%opts>. C<%s> is
+via C<bug()> if either C<env> or C<rc> is absent from C<%ops>. C<%s> is
 replaced with the comma-separated list of missing argument names.
 
 =back

--- a/lib/Genesis/Hook/RuntimeConfig.pod
+++ b/lib/Genesis/Hook/RuntimeConfig.pod
@@ -1,0 +1,960 @@
+=encoding UTF-8
+
+=head1 NAME
+
+Genesis::Hook::RuntimeConfig - Hook base class for generating and uploading BOSH runtime configs
+
+=head1 SYNOPSIS
+
+    package Genesis::Hook::RuntimeConfig::my_kit;
+    use parent 'Genesis::Hook::RuntimeConfig';
+
+    sub init {
+        my ($class, %opts) = @_;
+        my $self = $class->SUPER::init(%opts);
+        $self->register_runtime_config_builds(
+            'dns',
+            ['logging', 'Logging'],
+        );
+        return $self;
+    }
+
+    sub build_dns_runtime {
+        my ($self) = @_;
+        my $data = {
+            releases => [...],
+            addons   => [...],
+        };
+        return ($data, undef, undef);
+    }
+
+    sub build_logging_runtime {
+        my ($self) = @_;
+        # Return ($data, 'skipped', 'reason') to skip
+        # Return ($data, 'failed', 'reason') to report failure
+        my $yaml = "releases:\n- name: loggregator\n  version: 1.0\n";
+        return ($yaml, undef, undef);
+    }
+
+    1;
+
+=head1 DESCRIPTION
+
+C<Genesis::Hook::RuntimeConfig> is the base class for kit hooks that generate
+and upload BOSH runtime configs. Kits subclass this module, call
+C<register_runtime_config_builds> in their C<init> method to declare which
+runtime configs they provide, and implement a C<build_E<lt>nameE<gt>_runtime>
+method for each registered config.
+
+The standard lifecycle for a runtime config hook is:
+
+=over 4
+
+=item 1.
+
+Genesis instantiates the hook via C<init>, passing C<env> and C<kit> options.
+The subclass C<init> calls the parent class C<init> via C<SUPER> and then calls
+C<register_runtime_config_builds> to declare available config types.
+
+=item 2.
+
+Before C<perform> is called, the caller invokes
+C<validate_runtime_config_requests> to normalize the requested config names
+from C<< $self->{args} >> into C<< $self->{requests} >> and
+C<< $self->{request_options} >>.
+
+=item 3.
+
+C<perform> orchestrates the build-compare-upload cycle (or removal cycle
+when C<remove> is set). For each requested config, C<build> invokes the
+subclass's C<build_E<lt>nameE<gt>_runtime> method, then
+C<compare_configs> diffs against the existing BOSH director config, and
+C<upload_runtime_config> pushes the new config unless a dry run is in effect.
+
+=item 4.
+
+After all configs are processed, C<store_secrets> entombs any Vault secrets
+that were fetched during the build into CredHub (when CredHub entombment is
+enabled and Genesis compatibility is at least C<3.0.0-rc.1>).
+
+=back
+
+Subclass C<build_E<lt>nameE<gt>_runtime> methods must return a three-element
+list: C<($config_data, $status, $message)>. C<$config_data> is a YAML string
+or a hash/array reference (automatically converted to YAML). C<$status> may
+be C<undef> for success, C<'skipped'> to silently skip this config, or
+C<'failed'> to log an error and skip. C<$message> is a human-readable detail
+string used when C<$status> is C<'skipped'> or C<'failed'>.
+
+This class inherits from L<Genesis::Hook>. See that module for the full set
+of inherited methods including C<done>, C<env>, C<kit>, C<want_feature>,
+C<spruce_merge>, C<get_credhub_variable>, and others.
+
+=head1 METHODS
+
+=head2 init
+
+    my $hook = Genesis::Hook::RuntimeConfig->init(%opts);
+
+Constructs and returns a new runtime config hook object. Validates required
+and optional options, then delegates to L<Genesis::Hook/init> before initializing
+runtime-config-specific state. Resolves the BOSH director object (using
+C<get_target_bosh> when the environment is itself a BOSH director, otherwise
+C<< $env->bosh >>), initializes a C<Service::Credhub> object from the BOSH
+director, and sets up empty builds and secrets registries.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%opts>
+
+Key-value pairs that configure the hook. The following keys are recognized:
+
+=over 4
+
+=item C<env>
+
+B<(required)> A C<Genesis::Env> object for the deployment environment.
+
+=item C<kit>
+
+B<(required)> A C<Genesis::Kit> object for the kit being executed.
+
+=item C<interactive>
+
+B<(optional)> When true, the hook prompts for confirmation before uploading
+each config. Defaults to C<0>.
+
+=item C<dryrun>
+
+B<(optional)> When true, the hook builds and compares configs but does not
+upload or remove them. Defaults to C<0>.
+
+=item C<print>
+
+B<(optional)> When true, the hook prints generated config content to the
+terminal instead of uploading it. Cannot be combined with C<remove>.
+Defaults to C<0>.
+
+=item C<remove>
+
+B<(optional)> When true, the hook removes the requested runtime configs from
+the BOSH director instead of generating and uploading them. Cannot be
+combined with C<print>. Defaults to C<0>.
+
+=item C<args>
+
+B<(optional)> Runtime config request arguments. May be a boolean true value,
+a config name string, a comma-separated list of names, an array of names and
+option hashes, or a hash mapping config names to option hashes. Defaults to
+an empty array reference, which requests all registered configs.
+
+=item C<file>
+
+B<(optional)> Path to an associated file. Stored on the object for use by
+subclasses.
+
+=item C<label>
+
+B<(optional)> A human-readable label for display. Stored on the object for
+use by subclasses.
+
+=back
+
+=back
+
+B<Returns:> A blessed runtime config hook object.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Missing required arguments for a perl-based runtime-config hook call: %s">
+-- raised via C<bug()> if C<env> or C<kit> is absent from C<%opts>. C<%s>
+is replaced with the comma-separated list of missing argument names.
+
+=item *
+
+C<"Invalid optional arguments for a perl-based runtime-config hook call: %s">
+-- raised via C<bug()> if any unrecognized keys appear in C<%opts>. C<%s>
+is replaced with the comma-separated list of invalid argument names.
+
+=item *
+
+C<"Cannot specify both 'print' and 'remove' options."> -- raised via
+C<bail()> if both C<print> and C<remove> are set to true values.
+
+=back
+
+B<Examples:>
+
+    my $hook = Genesis::Hook::RuntimeConfig::my_kit->init(
+        env => $env,
+        kit => $kit,
+    );
+    # Returns: a blessed Genesis::Hook::RuntimeConfig::my_kit object
+
+    my $hook = Genesis::Hook::RuntimeConfig::my_kit->init(
+        env         => $env,
+        kit         => $kit,
+        dryrun      => 1,
+        interactive => 0,
+        args        => 'dns',
+    );
+    # Returns: a blessed hook configured for a dry-run of the 'dns' config
+
+=head2 dryrun
+
+    my $bool     = $hook->dryrun;
+    my $bool     = $hook->interactive;
+    my $bool     = $hook->print;
+    my $bool     = $hook->remove;
+    my $bosh     = $hook->bosh;
+    my $credhub  = $hook->credhub;
+    my $base     = $hook->credhub_base;
+
+Accessor methods for the hook's configuration state.
+
+B<dryrun> -- Returns the dry-run flag. When true, the hook builds and
+compares configs but does not upload or remove anything. Defaults to C<0>.
+
+B<interactive> -- Returns the interactive flag. When true, the hook prompts
+for confirmation before each config upload. Defaults to C<0>.
+
+B<print> -- Returns the print flag. When true, the hook prints generated
+runtime config content to the terminal rather than uploading it. Defaults
+to C<0>.
+
+B<remove> -- Returns the remove flag. When true, the hook removes the
+requested runtime configs from the BOSH director rather than generating and
+uploading them. Defaults to C<0>.
+
+B<bosh> -- Returns the BOSH client object initialized during C<init>. When
+the environment is a BOSH director, returns the self-referencing target BOSH
+object; otherwise returns the environment's associated BOSH director client.
+
+B<credhub> -- Returns the C<Service::Credhub> object initialized from the
+BOSH director during C<init>. May be C<undef> if the BOSH director has no
+associated CredHub.
+
+B<credhub_base> -- Returns the CredHub base path for secret entombment, or
+C<undef> if CredHub entombment is not enabled for this environment.
+Entombment requires Genesis feature compatibility of at least C<3.0.0-rc.1>,
+the C<genesis.entomb> manifest key set to a true value, and a CredHub object
+with a base path available.
+
+B<Returns:>
+
+C<dryrun>, C<interactive>, C<print>, and C<remove> return C<1> if the
+corresponding flag is active, C<0> otherwise.
+
+C<bosh> returns the BOSH client object.
+
+C<credhub> returns a C<Service::Credhub> object, or C<undef>.
+
+C<credhub_base> returns the CredHub base path string, or C<undef>.
+
+B<Examples:>
+
+    if ($hook->dryrun) {
+        print "Would upload config (dry-run mode)\n";
+    }
+    # Returns: 1 if dry-run mode is active, 0 otherwise
+
+    my $bosh = $hook->bosh;
+    my $configs = $bosh->get_config('runtime', 'my-env.dns');
+    # Returns: the BOSH client object
+
+    if (my $base = $hook->credhub_base) {
+        print "Entombing secrets under: $base\n";
+    }
+    # Returns: '/bosh-genesis-kit/bosh-us-east-1/' or undef
+
+=head2 config_name_for
+
+    my $name = $hook->config_name_for($build);
+
+Returns the fully-qualified BOSH runtime config name for the given build
+identifier. The name is formed by joining the environment's BOSH config name
+with the build identifier using a period.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$build>
+
+The build identifier string (e.g., C<'dns'>, C<'logging'>).
+
+=back
+
+B<Returns:> A string of the form C<"E<lt>bosh_config_nameE<gt>.E<lt>buildE<gt>">.
+
+B<Examples:>
+
+    my $name = $hook->config_name_for('dns');
+    # Returns: 'us-east-1-bosh.dns'
+
+    my $name = $hook->config_name_for('logging');
+    # Returns: 'us-east-1-bosh.logging'
+
+=head2 perform
+
+    $hook->perform;
+
+Executes the runtime config hook. Notifies the operator of the action being
+taken, then either removes or generates-and-uploads the requested runtime
+configs depending on the hook's flags.
+
+When removal is requested (C<remove> is true), delegates entirely to
+C<remove_configs> and returns its result.
+
+Otherwise, for each config name in C<< $self->{requests} >>:
+
+=over 4
+
+=item 1.
+
+Calls C<build> to invoke the subclass's C<build_E<lt>nameE<gt>_runtime>
+method. Skips configs that return C<undef>.
+
+=item 2.
+
+If C<print> is set, calls C<print_config> and skips to the next config.
+
+=item 3.
+
+Calls C<compare_configs> to diff against the existing BOSH director config.
+Skips if the config is already up to date (C<compare_configs> returns
+C<undef>).
+
+=item 4.
+
+Skips the upload step if dry-run mode is active.
+
+=item 5.
+
+Otherwise calls C<upload_runtime_config> to push the new config.
+
+=back
+
+After the loop, calls C<store_secrets> to entomb any Vault secrets fetched
+during the build into CredHub.
+
+B<Returns:> The result of C<$self->done()>, or the result of C<remove_configs>
+if removal was requested.
+
+B<Examples:>
+
+    $hook->validate_runtime_config_requests;
+    $hook->perform;
+    # Returns: the result of $self->done()
+
+=head2 register_runtime_config_builds
+
+    $hook->register_runtime_config_builds(@names);
+
+Declares the set of runtime configs this hook can build. Each entry in
+C<@names> is either a plain string build name or a two-element array
+reference C<[$name, $description]>. For plain strings, the description is
+derived automatically by splitting the name on hyphens and underscores and
+title-casing each word.
+
+For each name, a corresponding C<build_E<lt>nameE<gt>_runtime> method must
+exist on the hook object (hyphens in the name are converted to underscores
+when forming the method name). If the method cannot be found, C<kit_bug> is
+called.
+
+Modifies the object in-place (replaces any previously registered builds).
+
+B<Parameters:>
+
+=over 4
+
+=item C<@names>
+
+One or more build descriptors. Each element is either:
+
+=over 4
+
+=item *
+
+A string -- the build name. Must match C</^[a-z0-9\-_]+$/i>. The description
+is auto-derived from the name.
+
+=item *
+
+An array reference C<[$name, $description]> -- the build name and an explicit
+human-readable description string.
+
+=back
+
+=back
+
+B<Returns:> C<$self>, for method chaining.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"No builds specified for registration"> -- raised via C<bail()> if
+C<@names> is empty.
+
+=item *
+
+C<"Invalid runtime config name '%s' specified"> -- raised via C<bail()> if a
+name contains characters other than alphanumerics, hyphens, or underscores.
+C<%s> is replaced with the offending name.
+
+=back
+
+B<Examples:>
+
+    $self->register_runtime_config_builds(
+        'dns',
+        ['logging', 'Log Aggregation'],
+    );
+    # Returns: $self
+
+    # Requires these methods to exist on the object:
+    #   build_dns_runtime
+    #   build_logging_runtime
+
+=head2 validate_runtime_config_requests
+
+    $hook->validate_runtime_config_requests;
+
+Normalizes and validates the runtime config requests stored in
+C<< $self->{args} >>. On success, populates C<< $self->{requests} >> with a
+deduplicated list of requested build names and C<< $self->{request_options} >>
+with a hash of per-build option hashes.
+
+Accepts C<< $self->{args} >> in several formats:
+
+=over 4
+
+=item *
+
+C<undef>, an empty value, or a JSON boolean true -- requests all registered
+configs with default options.
+
+=item *
+
+A plain string or comma-separated list of names -- requests the named configs
+with no options.
+
+=item *
+
+An array reference -- each element may be a string (build name), a hash
+reference (options merged across all preceding names), or a JSON boolean
+(true to include, false to exclude).
+
+=item *
+
+A hash reference mapping build names (or C<'*'> or C<'all'>) to option
+hashes or JSON booleans.
+
+=back
+
+Boolean false values in hash or array arguments exclude those configs from
+the request list. When all configs are excluded, the requests list is empty.
+
+Modifies the object in-place (sets C<< $self->{requests} >> and
+C<< $self->{request_options} >>).
+
+B<Returns:> C<1> on success.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Invalid runtime config request argument type: expecting a string, a boolean, or hash of options, got %s">
+-- raised via C<bail()> if an array element is an unrecognized reference
+type. C<%s> is replaced with the reference type.
+
+=item *
+
+C<"Invalid runtime config request arguments: expecting a #C{true}, a ">
+-- raised via C<bail()> if C<< $self->{args} >> is not a recognized type
+(not a string, array, or hash). The message continues with a description of
+the expected types and the actual value received.
+
+=item *
+
+C<"Invalid runtime config request options for '%s': expecting a hash or boolean, got %s">
+-- raised via C<bail()> if a request's options value is neither a hash
+reference nor a JSON boolean. The first C<%s> is the request identifier and
+the second is the type or value encountered.
+
+=item *
+
+C<"Invalid runtime config requests: %s\n\nExpecting one or more of the following:\n%s\n\n">
+-- raised via C<bail()> if any requested build names are not in the
+registered builds list. The first C<%s> is the comma-separated list of
+invalid names and the second is a formatted list of the valid registered
+names with their descriptions.
+
+=back
+
+B<Examples:>
+
+    # Request all configs (args is undef or true)
+    $hook->{args} = undef;
+    $hook->validate_runtime_config_requests;
+    # Returns: 1
+    # $hook->{requests} = ['dns', 'logging', ...]
+
+    # Request a specific config by name
+    $hook->{args} = 'dns';
+    $hook->validate_runtime_config_requests;
+    # Returns: 1
+    # $hook->{requests} = ['dns']
+
+    # Request with options
+    $hook->{args} = { dns => { ttl => 300 }, logging => {} };
+    $hook->validate_runtime_config_requests;
+    # Returns: 1
+    # $hook->{request_options} = { dns => { ttl => 300 }, logging => {} }
+
+=head2 action
+
+    my $description = $hook->action;
+
+Returns a human-readable description of the action the hook will perform,
+based on the current flag state.
+
+B<Returns:> One of the strings C<"remove">, C<"generate">, or
+C<"generate and upload">, depending on whether the C<remove> or C<dryrun>
+flags are set.
+
+B<Examples:>
+
+    my $action = $hook->action;
+    # Returns: 'generate and upload' (normal mode)
+    # Returns: 'generate' (dry-run mode)
+    # Returns: 'remove' (remove mode)
+
+=head2 build
+
+    my $config_data = $hook->build($build);
+
+Invokes the registered C<build_E<lt>nameE<gt>_runtime> method for the named
+build and returns the resulting YAML string. If the build method returns a
+hash or array reference, it is converted to YAML automatically.
+
+If the build method returns a status of C<'failed'>, logs the error and
+returns C<undef>. If the build method returns a status of C<'skipped'>, logs
+a warning and returns C<undef>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$build>
+
+The build identifier string. Must match a name previously registered via
+C<register_runtime_config_builds>.
+
+=back
+
+B<Returns:> A YAML string on success, or C<undef> if the build failed or was
+skipped.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"No runtime config name specified"> -- raised via C<bail()> if C<$build>
+is undefined or empty.
+
+=item *
+
+C<"Invalid runtime config name '%s' specified"> -- raised via C<bail()> if
+C<$build> is not in the registered builds list. C<%s> is replaced with
+the build name.
+
+=back
+
+B<Examples:>
+
+    my $yaml = $hook->build('dns');
+    # Returns: a YAML string, or undef if failed/skipped
+
+=head2 print_config
+
+    $hook->print_config($config_data, $config_name);
+
+Prints the given runtime config YAML to the terminal in a formatted code
+block, using the terminal's configured code color scheme. The output includes
+a header bar with the config name.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$config_data>
+
+The YAML string content of the runtime config to display.
+
+=item C<$config_name>
+
+The fully-qualified BOSH runtime config name (e.g., C<'us-east-1-bosh.dns'>),
+displayed in the header bar.
+
+=back
+
+B<Returns:> C<1>.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"No runtime config contents given"> -- raised via C<bail()> if
+C<$config_data> is undefined or empty.
+
+=back
+
+B<Examples:>
+
+    $hook->print_config($yaml, 'us-east-1-bosh.dns');
+    # prints the YAML content with a formatted header to the terminal
+    # Returns: 1
+
+=head2 compare_configs
+
+    my $needs_upload = $hook->compare_configs($build, $config_data, $config_name);
+
+Compares the generated runtime config against the config currently on the
+BOSH director.
+
+If the named config does not yet exist on the director, logs its content and
+returns C<1> (indicating an upload is needed).
+
+If the config already exists, uses C<spruce_diff> to compare the existing
+and generated YAML. If there are differences, logs the diff and returns C<1>.
+If there are no differences, logs that the config is up to date and returns
+C<undef> (indicating no upload is needed).
+
+B<Parameters:>
+
+=over 4
+
+=item C<$build>
+
+The build identifier string, used to look up the human-readable description
+for log messages.
+
+=item C<$config_data>
+
+The generated YAML string to compare against the existing config.
+
+=item C<$config_name>
+
+The fully-qualified BOSH runtime config name to look up on the director.
+
+=back
+
+B<Returns:> C<1> if an upload is needed (new config or differences found),
+C<undef> if the config is already up to date.
+
+B<Examples:>
+
+    my $needs_upload = $hook->compare_configs('dns', $yaml, 'us-east-1-bosh.dns');
+    if ($needs_upload) {
+        $hook->upload_runtime_config('dns', $yaml, 'us-east-1-bosh.dns');
+    }
+    # Returns: 1 if upload is needed, undef if already up to date
+
+=head2 upload_runtime_config
+
+    $hook->upload_runtime_config($build, $config_data, $config_name);
+
+Uploads the generated runtime config to the BOSH director.
+
+In interactive mode, first checks that a controlling terminal is available,
+then prompts the operator for confirmation. If the operator declines, returns
+C<undef> without uploading.
+
+Otherwise, calls the BOSH client's C<upload_config> method. On failure, logs
+the error, discards any secrets registered for this build, and returns
+C<undef>. On success, returns C<1>.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$build>
+
+The build identifier string, used to look up the description and to clean up
+secrets on failure.
+
+=item C<$config_data>
+
+The YAML string content of the runtime config to upload.
+
+=item C<$config_name>
+
+The fully-qualified BOSH runtime config name to pass to the director.
+
+=back
+
+B<Returns:> C<1> on success, C<undef> if the upload was skipped or failed.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Not in a controlling terminal, cannot prompt for confirmation to upload ">
+-- raised via C<bail()> in interactive mode when no controlling terminal is
+available. The message continues with C<"runtime config. Please use #y{%s}
+to skip the confirmation prompt.">, where C<%s> is replaced with the
+applicable yes-flag string (defaulting to C<'--yes'>).
+
+=back
+
+B<Examples:>
+
+    my $ok = $hook->upload_runtime_config('dns', $yaml, 'us-east-1-bosh.dns');
+    # Returns: 1 on success, undef if skipped or failed
+
+=head2 remove_configs
+
+    $hook->remove_configs;
+
+Removes the requested runtime configs from the BOSH director. Fetches the
+current list of runtime configs from the director, then for each requested
+config:
+
+=over 4
+
+=item *
+
+If the config does not exist on the director, logs a notice and skips.
+
+=item *
+
+In dry-run mode, logs what would be removed (including config ID and creation
+date) but takes no action.
+
+=item *
+
+With the C<yes> flag set, removes the config without prompting.
+
+=item *
+
+Otherwise, prompts the operator for confirmation. If the operator declines,
+skips that config.
+
+=back
+
+B<Returns:> The result of C<$self->done(1)>.
+
+B<Examples:>
+
+    $hook->{args} = 'dns';
+    $hook->validate_runtime_config_requests;
+    $hook->remove_configs;
+    # Returns: the result of done(1)
+
+=head2 store_secrets
+
+    $hook->store_secrets;
+
+Entombs all Vault secrets fetched during the runtime config build phase into
+CredHub. Collects secrets from all builds' secret registries, then either
+lists what would be entombed (dry-run mode) or iterates over each secret and
+calls C<< $self->credhub->set >> to store the value.
+
+Does nothing if no secrets were collected during the build phase.
+
+B<Returns:> Nothing.
+
+B<Examples:>
+
+    $hook->store_secrets;
+    # Entombs any pending Vault secrets into CredHub, or lists them in dry-run mode
+    # Returns: nothing
+
+=head1 INTERNAL METHODS
+
+These methods are internal to the implementation. They may change without
+notice and should not be called directly.
+
+=head2 _get_secret
+
+    $obj->_get_secret($secret)
+
+Retrieves a secret from Vault and, if CredHub entombment is enabled, registers
+it for later entombment and returns a CredHub interpolation reference
+C<"(($credhub_var))"> instead of the raw value.
+
+C<$secret> is a string of the form C<"path:key"> (relative to the
+environment's secrets store base path, unless the path begins with C</>).
+When C<credhub_base> returns a defined value, the raw Vault value is stored
+under C<< $self->{secrets}{$config}{$credhub_var} >> and the CredHub
+reference string is returned. Otherwise, the raw Vault value is returned
+directly.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$secret>
+
+A string of the form C<"path:key"> identifying the Vault secret to retrieve.
+
+=back
+
+B<Returns:> The raw secret value if CredHub entombment is not active, or a
+CredHub interpolation string C<"(($credhub_var))"> if entombment is enabled.
+
+B<Examples:>
+
+    my $val = $self->_get_secret('certs/server:certificate');
+    # Returns: '-----BEGIN CERTIFICATE-----...' (raw value, no CredHub)
+    # Returns: '((//bosh/.../certs--server--certificate--a1b2c3d4))' (with CredHub entombment)
+
+=head2 _get_exodus_secret
+
+    $obj->_get_exodus_secret($key, $default, $deployment_slug)
+
+Retrieves a value from the environment's exodus data and, if CredHub
+entombment is enabled, registers it for entombment and returns a CredHub
+interpolation reference.
+
+Uses C<exodus_lookup> for the value retrieval. When C<credhub_base> is
+defined, derives the entombment path from C<$deployment_slug> (defaulting to
+C<< $env->exodus_slug >> if not provided), and stores the value under
+C<< $self->{secrets}{$config}{$credhub_var} >>. Returns the CredHub reference
+string C<"(($credhub_var))"> when entombment is active.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$key>
+
+The exodus data key to retrieve.
+
+=item C<$default>
+
+B<(optional)> Default value if the key is not found in exodus data.
+
+=item C<$deployment_slug>
+
+B<(optional)> The deployment slug used to scope the entombment path.
+Defaults to C<< $env->exodus_slug >>.
+
+=back
+
+B<Returns:> The raw exodus value if CredHub entombment is not active, or a
+CredHub interpolation string C<"(($credhub_var))"> if entombment is enabled.
+
+B<Examples:>
+
+    my $url = $self->_get_exodus_secret('director_url');
+    # Returns: 'https://bosh.example.com' (raw value, no CredHub)
+    # Returns: '((//bosh/.../exodus--director_url--a1b2c3d4))' (with CredHub entombment)
+
+    my $url = $self->_get_exodus_secret('director_url', 'https://default', 'bosh/us-east-1');
+    # Returns: the exodus value for 'bosh/us-east-1', or 'https://default' if absent
+
+=head2 _get_runtime_configs
+
+    $obj->_get_runtime_configs
+    $obj->_get_runtime_configs($name)
+
+Fetches runtime config metadata from the BOSH director via
+C<bosh configs --type=runtime --json>. When C<$name> is provided, appends
+C<--name=$name> to filter results to that config name.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$name>
+
+B<(optional)> The config name to filter by. When omitted, all runtime configs
+are returned.
+
+=back
+
+B<Returns:> An array reference of row hash references from the first table
+in the BOSH JSON response. Each row contains C<name>, C<id>, and
+C<created_at> fields.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Failed to get runtime configs: %s"> -- raised via C<bail()> if the BOSH
+command fails. C<%s> is replaced with the error output.
+
+=back
+
+B<Examples:>
+
+    my $rows = $self->_get_runtime_configs;
+    # Returns: [{ name => 'us-east-1-bosh.dns', id => '3', created_at => '...' }, ...]
+
+    my $rows = $self->_get_runtime_configs('us-east-1-bosh.dns');
+    # Returns: [{ name => 'us-east-1-bosh.dns', id => '3', created_at => '...' }]
+
+=head2 _get_req_names
+
+    $obj->_get_req_names($req_id)
+
+Resolves a request identifier to a list of registered build names.
+
+If C<$req_id> is C<'*'> or C<'all'>, returns all registered build names
+sorted by their registration order. Otherwise, splits C<$req_id> on commas
+and returns the resulting list.
+
+B<Parameters:>
+
+=over 4
+
+=item C<$req_id>
+
+A build name string, a comma-separated list of build names, or the wildcard
+C<'*'> or C<'all'> to select all registered builds.
+
+=back
+
+B<Returns:> A list of build name strings.
+
+B<Examples:>
+
+    my @names = $self->_get_req_names('*');
+    # Returns: ('dns', 'logging', ...) sorted by registration order
+
+    my @names = $self->_get_req_names('dns,logging');
+    # Returns: ('dns', 'logging')
+
+    my @names = $self->_get_req_names('dns');
+    # Returns: ('dns')
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut

--- a/lib/Genesis/Hook/RuntimeConfig.pod
+++ b/lib/Genesis/Hook/RuntimeConfig.pod
@@ -147,8 +147,9 @@ combined with C<print>. Defaults to C<0>.
 
 B<(optional)> Runtime config request arguments. May be a boolean true value,
 a config name string, a comma-separated list of names, an array of names and
-option hashes, or a hash mapping config names to option hashes. Defaults to
-an empty array reference, which requests all registered configs.
+option hashes, or a hash mapping config names to option hashes. When
+C<undef>, an empty array reference, or a JSON boolean true value, all
+registered configs are requested with default options.
 
 =item C<file>
 
@@ -481,10 +482,10 @@ type. C<%s> is replaced with the reference type.
 
 =item *
 
-C<"Invalid runtime config request arguments: expecting a #C{true}, a ">
+C<"Invalid runtime config request arguments: expecting a #C{true}, a string, array of strings or build =E<gt> option hash, or a hash of runtime build with options or boolean, but got %s">
 -- raised via C<bail()> if C<< $self->{args} >> is not a recognized type
-(not a string, array, or hash). The message continues with a description of
-the expected types and the actual value received.
+(not a string, array, or hash). C<%s> is replaced with a description of the
+actual value received (e.g., C<"a CODE value"> or C<"'some_value'">).
 
 =item *
 

--- a/lib/Genesis/Hook/Terminate.pod
+++ b/lib/Genesis/Hook/Terminate.pod
@@ -1,0 +1,237 @@
+=encoding UTF-8
+
+=head1 NAME
+
+Genesis::Hook::Terminate - Hook class for kit termination lifecycle callbacks
+
+=head1 SYNOPSIS
+
+    package Genesis::Hook::Terminate::my_kit;
+    use parent 'Genesis::Hook::Terminate';
+
+    sub before_terminate {
+        my ($self) = @_;
+        # Runs before the environment is torn down
+        return 1;
+    }
+
+    sub after_terminate {
+        my ($self) = @_;
+        # Runs after the environment has been torn down
+        return 1;
+    }
+
+    sub failed_terminate {
+        my ($self) = @_;
+        # Runs when termination fails
+        return 1;
+    }
+
+    1;
+
+=head1 DESCRIPTION
+
+C<Genesis::Hook::Terminate> is the base class for kit-provided terminate hooks.
+It extends L<Genesis::Hook> and implements the lifecycle for cleaning up or
+reacting to environment teardown operations.
+
+When Genesis terminates (removes or destroys) an environment, it invokes the
+terminate hook at up to three points depending on outcome:
+
+=over 4
+
+=item *
+
+C<before> -- called before the termination begins, allowing the kit to prepare
+or verify preconditions.
+
+=item *
+
+C<after> -- called after successful termination, allowing the kit to perform
+final cleanup.
+
+=item *
+
+C<failed> -- called when termination fails, allowing the kit to handle error
+conditions.
+
+=back
+
+Kit authors subclass C<Genesis::Hook::Terminate> and implement one or more of
+the mode-specific methods (C<before_terminate>, C<after_terminate>,
+C<failed_terminate>). The C<perform> method dispatches to the correct one
+based on the C<mode> set at construction time.
+
+=head1 METHODS
+
+=head2 init
+
+    my $hook = Genesis::Hook::Terminate->init(%args);
+
+Constructs and returns a new C<Genesis::Hook::Terminate> object. Validates that
+all required arguments are present, normalizes the C<dry_run> argument key to
+C<dryrun> if needed, and validates that the C<mode> is one of the three
+recognized values.
+
+B<Parameters:>
+
+=over 4
+
+=item C<%args>
+
+Key-value pairs stored on the hook object. The following keys are required:
+
+=over 4
+
+=item C<env>
+
+B<(required)> A C<Genesis::Env> object representing the deployment environment.
+
+=item C<kit>
+
+B<(required)> A C<Genesis::Kit> object for the kit being executed.
+
+=item C<mode>
+
+B<(required)> The termination phase. Must be one of C<'before'>, C<'after'>,
+or C<'failed'>.
+
+=item C<dryrun>
+
+B<(required)> Boolean. When true, the hook should simulate actions without
+making real changes. May also be passed as C<dry_run>, which is automatically
+renamed to C<dryrun>.
+
+=item C<force>
+
+B<(required)> Boolean. When true, the hook should proceed without safety
+checks.
+
+=item C<noprompt>
+
+B<(required)> Boolean. When true, the hook should not prompt the user for
+confirmation.
+
+=back
+
+=back
+
+B<Returns:> A blessed C<Genesis::Hook::Terminate> object.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+C<"Missing required arguments for a perl-based kit hook call: %s"> -- raised
+via C<bug()> if any of the required arguments (C<env>, C<kit>, C<mode>,
+C<dryrun>, C<force>, C<noprompt>) are absent. C<%s> is replaced with the
+comma-separated list of missing argument names.
+
+=item *
+
+C<"Unknown termination mode '%s'; expected 'before', 'after', or 'failed'">
+-- raised via C<bug()> if C<mode> is not one of the three valid values. C<%s>
+is replaced with the provided mode string.
+
+=back
+
+B<Examples:>
+
+    my $hook = Genesis::Hook::Terminate->init(
+        env      => $env,
+        kit      => $kit,
+        mode     => 'before',
+        dryrun   => 0,
+        force    => 0,
+        noprompt => 0,
+    );
+    # Returns: a blessed Genesis::Hook::Terminate object
+
+    # dry_run is accepted and renamed to dryrun automatically
+    my $hook = Genesis::Hook::Terminate->init(
+        env      => $env,
+        kit      => $kit,
+        mode     => 'after',
+        dry_run  => 1,
+        force    => 0,
+        noprompt => 1,
+    );
+    # Returns: a blessed Genesis::Hook::Terminate object with dryrun => 1
+
+=head2 perform
+
+    $hook->perform;
+
+Dispatches to the mode-specific terminate method on the hook object. The method
+name is derived from the C<mode> set at construction time: for example, mode
+C<'before'> dispatches to C<before_terminate>, mode C<'after'> dispatches to
+C<after_terminate>, and mode C<'failed'> dispatches to C<failed_terminate>.
+
+Kit authors implement these methods in their subclass. If the derived method
+is not present on the object, a kit bug error is raised.
+
+After calling the mode-specific method, calls C<$self->done($result)> to
+record the result and mark the hook complete.
+
+B<Returns:> The return value of C<< $self->done($result) >>, where C<$result>
+is whatever the mode-specific method returned.
+
+B<Errors:>
+
+=over 4
+
+=item *
+
+Kit bug raised via C<< $self->kit->kit_bug >> if the mode-specific method
+(e.g., C<before_terminate>) is not implemented on the hook object. The error
+message identifies the missing method name and the kit name.
+
+=back
+
+B<Examples:>
+
+    package Genesis::Hook::Terminate::my_kit;
+    use parent 'Genesis::Hook::Terminate';
+
+    sub before_terminate {
+        my ($self) = @_;
+        # Pre-teardown logic here
+        return 1;
+    }
+
+    1;
+
+    # Genesis calls:
+    $hook->perform;
+    # Dispatches to before_terminate() and calls done(1)
+
+=head2 is_dryrun
+
+    my $bool = $hook->is_dryrun;
+
+Returns the value of the C<dryrun> flag set at construction time.
+
+B<Returns:> The boolean value of C<< $self->{dryrun} >>. True if the hook was
+constructed with C<dryrun> (or C<dry_run>) set to a true value, false otherwise.
+
+B<Examples:>
+
+    if ($hook->is_dryrun) {
+        # Simulate actions without making real changes
+        say "Would terminate environment: " . $hook->env->name;
+    } else {
+        # Proceed with actual termination
+    }
+    # Returns: 1 or 0 (or undef) depending on the dryrun flag
+
+=head1 AUTHORS
+
+Written by the Genesis team.
+
+=head1 COPYRIGHT
+
+This module is free software, distributed under the same terms as Perl itself.
+
+=cut


### PR DESCRIPTION
## Summary

- Add companion `.pod` documentation for all 15 modules in the `Genesis::Hook` hierarchy
- Covers the base class inheritance contract, all hook subclasses (Addon, Blueprint, Check, CloudConfig, CpiConfig, Features, PostDeploy, RuntimeConfig, Terminate), and the CloudConfig sub-hierarchy (Director, Helpers, LookupRef, LookupNetworkRef, LookupSubnetRef)
- 8,227 lines of documentation across 15 new `.pod` files

## Details

Documents the full hook lifecycle (`init`/`perform`/`done` pattern), all public and internal methods with parameter lists, return values, error conditions, and usage examples. Follows the existing companion-POD convention established by `Genesis::Base.pod` and `Genesis::Config.pod`.

**Validation:** 1,446 mechanical checks pass with 0 failures across all 15 modules.

**Demerits:** 22 subjective quality demerits noted (mostly method-grouping patterns from one-liner accessor bundling). Documented in FWT-584 Jira comment.

**Code defects:** 17 source code defects discovered during documentation work (8 critical bugs). Tracked separately in [FWT-751](https://fivetwenty.atlassian.net/browse/FWT-751).

Resolves [FWT-584](https://fivetwenty.atlassian.net/browse/FWT-584). Unblocks FWT-560 (Genesis::Hook Tests) and FWT-561 (Genesis::Hook::CloudConfig Tests).

## Test plan

- [ ] Verify all 15 `.pod` files render correctly with `perldoc`
- [ ] Spot-check cross-references between base class and subclass docs
- [ ] Confirm no `.pm` files were modified (documentation-only change)