### PR TITLE
Add Genesis::Log unit test suite

### DIFF
--- a/t/test-manifest.txt
+++ b/t/test-manifest.txt
@@ -45,6 +45,12 @@ unit-tests/genesis_env-manifest_helpers.t
 unit-tests/genesis_env_secrets_parser_fromkit-core.t  # FromKit parser defect regression tests
 unit-tests/genesis_env_secrets_store_vault-core.t  # Store::Vault code defect regression tests
 unit-tests/genesis_log-get_scope.t
+unit-tests/genesis_log-core.t
+unit-tests/genesis_log-levels.t
+unit-tests/genesis_log-styles.t
+unit-tests/genesis_log-stack.t
+unit-tests/genesis_log-routing.t
+unit-tests/genesis_log-convenience.t
 unit-tests/genesis_secret-base.t
 unit-tests/genesis_secret_dhparams-core.t
 unit-tests/genesis_secret_invalid-core.t

--- a/t/unit-tests/genesis_log-convenience.t
+++ b/t/unit-tests/genesis_log-convenience.t
@@ -1,0 +1,288 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use lib 't';
+use helper;
+use File::Temp qw/tempfile/;
+
+use_ok 'Genesis::Log';
+
+# ---------------------------------------------------------------------------
+# Helper: create a fresh logger isolated to a single temp file.
+# Resetting the singleton ensures each subtest starts from a clean state.
+# ---------------------------------------------------------------------------
+sub make_logger_with_file {
+	my (%opts) = @_;
+	$Genesis::Log::Logger = undef;
+	my $logger = Genesis::Log->new();
+	my ($fh, $filename) = tempfile(UNLINK => 1, SUFFIX => '.log');
+	close $fh;
+	$logger->configure_log($filename, %opts);
+	return ($logger, $filename);
+}
+
+# ---------------------------------------------------------------------------
+# AC2: All 9 convenience methods can be called without dying
+# ---------------------------------------------------------------------------
+subtest 'all 9 convenience methods live_ok on a configured logger' => sub {
+	my ($logger, $file) = make_logger_with_file(level => 'TRACE');
+
+	quietly {
+		lives_ok { $logger->output("output message") }  'output() does not die';
+		lives_ok { $logger->info("info message") }      'info() does not die';
+		lives_ok { $logger->debug("debug message") }    'debug() does not die';
+		lives_ok { $logger->notice("notice message") }  'notice() does not die';
+		lives_ok { $logger->warning("warning message") }'warning() does not die';
+		lives_ok { $logger->error("error message") }    'error() does not die';
+		lives_ok { $logger->fatal("fatal message") }    'fatal() does not die';
+		lives_ok { $logger->trace("trace message") }    'trace() does not die';
+		lives_ok { $logger->qtrace("qtrace message") }  'qtrace() does not die';
+	};
+};
+
+# ---------------------------------------------------------------------------
+# AC2 + AC3: fatal does NOT terminate the process
+# ---------------------------------------------------------------------------
+subtest 'fatal() does not terminate the process' => sub {
+	my ($logger, $file) = make_logger_with_file(level => 'TRACE');
+
+	quietly {
+		lives_ok { $logger->fatal("this should not die") }
+			'fatal() logs without calling exit or die';
+	};
+
+	# Process is still running — confirm we can read back the log file
+	my $contents = get_file($file);
+	ok defined($contents), 'process still alive: log file is readable after fatal()';
+};
+
+# ---------------------------------------------------------------------------
+# AC3: Output routing — file receives content at the correct level
+# ---------------------------------------------------------------------------
+subtest 'file target at TRACE level captures all convenience method output' => sub {
+	my ($logger, $file) = make_logger_with_file(
+		level     => 'TRACE',
+		style     => 'plain',
+		no_color  => 1,
+		no_utf8   => 1,
+		timestamp => 0,
+	);
+
+	quietly {
+		$logger->output("output-payload");
+		$logger->info("info-payload");
+		$logger->debug("debug-payload");
+		$logger->notice("notice-payload");
+		$logger->warning("warning-payload");
+		$logger->error("error-payload");
+		$logger->fatal("fatal-payload");
+		$logger->trace("trace-payload");
+		$logger->qtrace("qtrace-payload");
+	};
+
+	my $contents = get_file($file);
+
+	like $contents, qr/output-payload/,  'output() written to file';
+	like $contents, qr/info-payload/,    'info() written to file';
+	like $contents, qr/debug-payload/,   'debug() written to file';
+	like $contents, qr/notice-payload/,  'notice() written to file';
+	like $contents, qr/warning-payload/, 'warning() written to file';
+	like $contents, qr/error-payload/,   'error() written to file';
+	like $contents, qr/fatal-payload/,   'fatal() written to file';
+	like $contents, qr/trace-payload/,   'trace() written to file';
+	like $contents, qr/qtrace-payload/,  'qtrace() written to file';
+};
+
+# ---------------------------------------------------------------------------
+# AC2 + AC3: Level filtering — configured at WARNING
+#
+# Level ordinals (from _log_item_level_map):
+#   NONE=0, OUTPUT=1, FATAL=2, ERROR=2, WARNING=3, NOTICE=3,
+#   INFO=4, DEBUG=5, VALUE=6, TRACE=6
+#
+# meets_level(configured, message) = configured_ord >= message_ord
+#   WARNING(3) >= ERROR(2)   => true  — error messages appear
+#   WARNING(3) >= WARNING(3) => true  — warning messages appear
+#   WARNING(3) >= NOTICE(3)  => true  — notice messages appear
+#   WARNING(3) >= INFO(4)    => false — info messages suppressed
+#   WARNING(3) >= DEBUG(5)   => false — debug messages suppressed
+#   WARNING(3) >= TRACE(6)   => false — trace messages suppressed
+# ---------------------------------------------------------------------------
+subtest 'level filtering: configured at WARNING filters lower-priority messages' => sub {
+	my ($logger, $file) = make_logger_with_file(
+		level     => 'WARNING',
+		style     => 'plain',
+		no_color  => 1,
+		no_utf8   => 1,
+		timestamp => 0,
+	);
+
+	quietly {
+		$logger->error("should-appear-error");
+		$logger->warning("should-appear-warning");
+		$logger->notice("should-appear-notice");
+		$logger->info("should-not-appear-info");
+		$logger->debug("should-not-appear-debug");
+		$logger->trace("should-not-appear-trace");
+		$logger->qtrace("should-not-appear-qtrace");
+	};
+
+	my $contents = get_file($file);
+
+	# Messages that meet the WARNING threshold
+	like   $contents, qr/should-appear-error/,
+		'error() appears when configured at WARNING (ERROR ord=2 <= WARNING ord=3)';
+	like   $contents, qr/should-appear-warning/,
+		'warning() appears when configured at WARNING (exact match)';
+	like   $contents, qr/should-appear-notice/,
+		'notice() appears when configured at WARNING (NOTICE ord=3 == WARNING ord=3)';
+
+	# Messages below the WARNING threshold
+	unlike $contents, qr/should-not-appear-info/,
+		'info() suppressed when configured at WARNING (INFO ord=4 > WARNING ord=3)';
+	unlike $contents, qr/should-not-appear-debug/,
+		'debug() suppressed when configured at WARNING (DEBUG ord=5 > WARNING ord=3)';
+	unlike $contents, qr/should-not-appear-trace/,
+		'trace() suppressed when configured at WARNING (TRACE ord=6 > WARNING ord=3)';
+	unlike $contents, qr/should-not-appear-qtrace/,
+		'qtrace() suppressed when configured at WARNING (TRACE ord=6 > WARNING ord=3)';
+};
+
+# ---------------------------------------------------------------------------
+# AC2: dump_var can be called without dying
+# ---------------------------------------------------------------------------
+subtest 'dump_var() can be called without dying' => sub {
+	my ($logger, $file) = make_logger_with_file(level => 'TRACE');
+
+	quietly {
+		lives_ok { $logger->dump_var(foo => 'bar') }
+			'dump_var(foo => bar) does not die';
+
+		lives_ok { $logger->dump_var(count => 42, name => 'test') }
+			'dump_var with multiple name/value pairs does not die';
+
+		lives_ok { $logger->dump_var(nested => { a => 1, b => [2, 3] }) }
+			'dump_var with nested reference does not die';
+	};
+};
+
+# ---------------------------------------------------------------------------
+# AC2 + AC3: dump_var writes Data::Dumper output to the file
+# ---------------------------------------------------------------------------
+subtest 'dump_var() writes variable dump to file target' => sub {
+	my ($logger, $file) = make_logger_with_file(
+		level     => 'TRACE',
+		style     => 'plain',
+		no_color  => 1,
+		no_utf8   => 1,
+		timestamp => 0,
+	);
+
+	quietly {
+		$logger->dump_var(myvar => 'hello-dump');
+	};
+
+	my $contents = get_file($file);
+	like $contents, qr/myvar/, 'dump_var writes the variable name to the log';
+	like $contents, qr/hello-dump/, 'dump_var writes the variable value to the log';
+};
+
+# ---------------------------------------------------------------------------
+# AC2: trace vs qtrace — style distinction via log_styles
+# ---------------------------------------------------------------------------
+subtest 'trace and qtrace have distinct log_styles: show_stack present/absent' => sub {
+	my $trace_style  = log_styles('trace');
+	my $qtrace_style = log_styles('qtrace');
+
+	ok  exists($trace_style->{show_stack}),
+		"trace style has 'show_stack' key";
+	is  $trace_style->{show_stack}, 'current',
+		"trace style show_stack is 'current'";
+
+	ok !exists($qtrace_style->{show_stack}),
+		"qtrace style does not have 'show_stack' key";
+};
+
+# ---------------------------------------------------------------------------
+# AC3: trace writes stack annotation to file; qtrace does not
+#
+# When show_stack => 'current' is active and the file is at TRACE level,
+# flush_logs() appends a "#Ki{...}" stack line.  We verify the behavioural
+# difference by examining whether a file/line reference appears after each
+# call.  We use separate loggers so the buffer for each is independent.
+# ---------------------------------------------------------------------------
+subtest 'trace() writes stack annotation to file; qtrace() does not' => sub {
+	# --- trace: expect a stack annotation in the file ---
+	my ($trace_logger, $trace_file) = make_logger_with_file(
+		level     => 'TRACE',
+		style     => 'plain',
+		no_color  => 1,
+		no_utf8   => 1,
+		timestamp => 0,
+	);
+
+	quietly {
+		$trace_logger->trace("trace-stack-test");
+	};
+
+	my $trace_contents = get_file($trace_file);
+	like $trace_contents, qr/trace-stack-test/,
+		'trace() message body appears in file';
+	# The stack annotation written by flush_logs looks like " file:Lnnn"
+	like $trace_contents, qr/L\d+/,
+		'trace() appends a stack annotation (line reference) to file output';
+
+	# --- qtrace: expect NO stack annotation ---
+	my ($qtrace_logger, $qtrace_file) = make_logger_with_file(
+		level     => 'TRACE',
+		style     => 'plain',
+		no_color  => 1,
+		no_utf8   => 1,
+		timestamp => 0,
+	);
+
+	quietly {
+		$qtrace_logger->qtrace("qtrace-nostack-test");
+	};
+
+	my $qtrace_contents = get_file($qtrace_file);
+	like $qtrace_contents, qr/qtrace-nostack-test/,
+		'qtrace() message body appears in file';
+	unlike $qtrace_contents, qr/L\d+/,
+		'qtrace() does not append a stack annotation to file output';
+};
+
+# ---------------------------------------------------------------------------
+# AC3: is_logging reflects configured level correctly
+# ---------------------------------------------------------------------------
+subtest 'is_logging returns correct results for configured file level' => sub {
+	my ($logger, $file) = make_logger_with_file(level => 'WARNING');
+
+	ok  $logger->is_logging('ERROR',   $file), 'is_logging ERROR   at WARNING => true';
+	ok  $logger->is_logging('WARNING', $file), 'is_logging WARNING at WARNING => true';
+	ok  $logger->is_logging('NOTICE',  $file), 'is_logging NOTICE  at WARNING => true';
+	ok !$logger->is_logging('INFO',    $file), 'is_logging INFO    at WARNING => false';
+	ok !$logger->is_logging('DEBUG',   $file), 'is_logging DEBUG   at WARNING => false';
+	ok !$logger->is_logging('TRACE',   $file), 'is_logging TRACE   at WARNING => false';
+};
+
+# ---------------------------------------------------------------------------
+# Singleton management: resetting $Genesis::Log::Logger gives fresh object
+# ---------------------------------------------------------------------------
+subtest 'singleton can be reset for clean test isolation' => sub {
+	my $original = Genesis::Log->new();
+	$original->configure_log('<terminal>', level => 'INFO');
+
+	$Genesis::Log::Logger = undef;
+	my $fresh = Genesis::Log->new();
+
+	isnt $fresh, $original, 'after reset, new() returns a different object';
+	is scalar(keys %{$fresh->{logs}}), 0,
+		'fresh singleton has no configured logs';
+
+	# Restore a clean singleton for any subsequent tests
+	$Genesis::Log::Logger = undef;
+	Genesis::Log->new();
+};
+
+done_testing;

--- a/t/unit-tests/genesis_log-core.t
+++ b/t/unit-tests/genesis_log-core.t
@@ -1,0 +1,100 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use lib 't';
+use helper;
+
+our $Logger;
+use_ok 'Genesis::Log';
+
+subtest 'constructor returns a blessed Genesis::Log object' => sub {
+	my $log;
+	lives_ok { $log = Genesis::Log->new() } 'new() does not die';
+	isa_ok $log, 'Genesis::Log', 'new() returns a Genesis::Log object';
+};
+
+subtest 'singleton pattern' => sub {
+	my $first  = Genesis::Log->new();
+	my $second = Genesis::Log->new();
+	is $second, $first, 'repeated new() calls return the same reference';
+	no warnings 'once';
+	is $Genesis::Log::Logger, $first, 'package variable holds the same singleton';
+};
+
+subtest '$Logger export matches new()' => sub {
+	ok defined($Logger), '$Logger is defined after use Genesis::Log';
+	isa_ok $Logger, 'Genesis::Log', '$Logger is a Genesis::Log object';
+	is $Logger, Genesis::Log->new(), '$Logger matches Genesis::Log->new()';
+};
+
+subtest 'initial state - system identity fields' => sub {
+	my $log = Genesis::Log->new();
+
+	ok defined($log->{hostname}), 'hostname is defined';
+	ok length($log->{hostname}) > 0, 'hostname is non-empty';
+
+	ok defined($log->{user}), 'user is defined';
+	ok length($log->{user}) > 0, 'user is non-empty';
+
+	ok defined($log->{pid}), 'pid is defined';
+	ok length($log->{pid}) > 0, 'pid is non-empty';
+
+	# version is populated when $Genesis::VERSION is set and not "(development)"
+	ok exists($log->{version}), 'version key exists in object';
+};
+
+subtest 'version field reflects Genesis::VERSION at construction time' => sub {
+	my $log = Genesis::Log->new();
+	# The constructor assigns: ($Genesis::VERSION eq "(development)") ? "0.0.0-rc.0" : $Genesis::VERSION
+	# When $Genesis::VERSION is undef, eq warns and returns false, so version is also undef.
+	# When $Genesis::VERSION is "(development)", version is "0.0.0-rc.0".
+	# Otherwise version mirrors $Genesis::VERSION.
+	if (defined($Genesis::VERSION) && $Genesis::VERSION eq '(development)') {
+		is $log->{version}, '0.0.0-rc.0',
+			'version is 0.0.0-rc.0 when Genesis::VERSION is (development)';
+	} elsif (defined($Genesis::VERSION)) {
+		is $log->{version}, $Genesis::VERSION,
+			'version matches Genesis::VERSION when it is a release string';
+	} else {
+		ok !defined($log->{version}),
+			'version is undef when Genesis::VERSION is undef (test environment)';
+	}
+};
+
+subtest 'buffer initialized as empty arrayref' => sub {
+	my $log = Genesis::Log->new();
+	ok defined($log->{buffer}), 'buffer is defined';
+	is ref($log->{buffer}), 'ARRAY', 'buffer is an arrayref';
+	is scalar(@{$log->{buffer}}), 0, 'buffer is empty on initialization';
+};
+
+subtest 'logs initialized as empty hashref' => sub {
+	my $log = Genesis::Log->new();
+	ok defined($log->{logs}), 'logs is defined';
+	is ref($log->{logs}), 'HASH', 'logs is a hashref';
+	is scalar(keys %{$log->{logs}}), 0, 'logs is empty on initialization';
+};
+
+subtest 'internal tracking fields initialized as empty hashrefs' => sub {
+	my $log = Genesis::Log->new();
+
+	ok defined($log->{log_templates}), 'log_templates is defined';
+	is ref($log->{log_templates}), 'HASH', 'log_templates is a hashref';
+	is scalar(keys %{$log->{log_templates}}), 0, 'log_templates is empty on initialization';
+
+	ok defined($log->{realized_logs}), 'realized_logs is defined';
+	is ref($log->{realized_logs}), 'HASH', 'realized_logs is a hashref';
+	is scalar(keys %{$log->{realized_logs}}), 0, 'realized_logs is empty on initialization';
+
+	ok defined($log->{command_logged}), 'command_logged is defined';
+	is ref($log->{command_logged}), 'HASH', 'command_logged is a hashref';
+	is scalar(keys %{$log->{command_logged}}), 0, 'command_logged is empty on initialization';
+};
+
+subtest 'capture_stack_min_level defaults to 2' => sub {
+	my $log = Genesis::Log->new();
+	ok defined($log->{capture_stack_min_level}), 'capture_stack_min_level is defined';
+	is $log->{capture_stack_min_level}, 2, 'capture_stack_min_level is set to 2';
+};
+
+done_testing;

--- a/t/unit-tests/genesis_log-levels.t
+++ b/t/unit-tests/genesis_log-levels.t
@@ -5,7 +5,6 @@ use lib 't';
 use helper;
 
 use_ok 'Genesis::Log';
-use Genesis::Log; # use_ok does not run import; pull in exported symbols
 
 # level_ord is not in @EXPORT so we alias it for readability
 *level_ord = \&Genesis::Log::level_ord;

--- a/t/unit-tests/genesis_log-levels.t
+++ b/t/unit-tests/genesis_log-levels.t
@@ -1,0 +1,183 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use lib 't';
+use helper;
+
+use_ok 'Genesis::Log';
+use Genesis::Log; # use_ok does not run import; pull in exported symbols
+
+# level_ord is not in @EXPORT so we alias it for readability
+*level_ord = \&Genesis::Log::level_ord;
+
+# ── log_levels() ────────────────────────────────────────────────────────────
+
+subtest 'log_levels returns the seven user-facing level names' => sub {
+	my @levels = log_levels();
+
+	is scalar(@levels), 7, 'log_levels() returns exactly 7 names';
+
+	is_deeply \@levels,
+		[qw/NONE OUTPUT ERROR WARNING INFO DEBUG TRACE/],
+		'level names are in the correct order';
+};
+
+# ── level_ord() ─────────────────────────────────────────────────────────────
+
+subtest 'level_ord returns correct ordinals for every known level' => sub {
+	is level_ord('NONE'),    0, 'NONE    => 0';
+	is level_ord('OUTPUT'),  1, 'OUTPUT  => 1';
+	is level_ord('FATAL'),   2, 'FATAL   => 2';
+	is level_ord('ERROR'),   2, 'ERROR   => 2';
+	is level_ord('WARNING'), 3, 'WARNING => 3';
+	is level_ord('NOTICE'),  3, 'NOTICE  => 3';
+	is level_ord('INFO'),    4, 'INFO    => 4';
+	is level_ord('DEBUG'),   5, 'DEBUG   => 5';
+	is level_ord('VALUE'),   6, 'VALUE   => 6';
+	is level_ord('TRACE'),   6, 'TRACE   => 6';
+	is level_ord('STACK'),   6, 'STACK   => 6';
+};
+
+subtest 'level_ord returns undef for unknown level names' => sub {
+	is level_ord('BOGUS'),   undef, 'BOGUS returns undef';
+	is level_ord(''),        undef, 'empty string returns undef';
+	is level_ord('verbose'), undef, 'lowercase unknown returns undef';
+};
+
+subtest 'level_ord applies uc() to its argument' => sub {
+	# level_ord calls uc() internally, so lower-case known names resolve
+	is level_ord('debug'),   5, 'debug (lowercase) => 5';
+	is level_ord('trace'),   6, 'trace (lowercase) => 6';
+	is level_ord('warning'), 3, 'warning (lowercase) => 3';
+};
+
+# ── find_log_level() ─────────────────────────────────────────────────────────
+
+subtest 'find_log_level - full name lookup (uppercase)' => sub {
+	is find_log_level('DEBUG'),   'DEBUG',   'DEBUG   => DEBUG';
+	is find_log_level('ERROR'),   'ERROR',   'ERROR   => ERROR';
+	is find_log_level('INFO'),    'INFO',    'INFO    => INFO';
+	is find_log_level('TRACE'),   'TRACE',   'TRACE   => TRACE';
+	is find_log_level('OUTPUT'),  'OUTPUT',  'OUTPUT  => OUTPUT';
+	is find_log_level('WARNING'), 'WARNING', 'WARNING => WARNING';
+};
+
+subtest 'find_log_level - case-insensitive full name lookup' => sub {
+	is find_log_level('debug'),   'DEBUG',   'debug   => DEBUG';
+	is find_log_level('trace'),   'TRACE',   'trace   => TRACE';
+	is find_log_level('info'),    'INFO',    'info    => INFO';
+	is find_log_level('error'),   'ERROR',   'error   => ERROR';
+	is find_log_level('warning'), 'WARNING', 'warning => WARNING';
+	is find_log_level('output'),  'OUTPUT',  'output  => OUTPUT';
+};
+
+subtest 'find_log_level - NONE is handled via prefix matching (level_ord 0 is falsy)' => sub {
+	# level_ord('NONE') == 0, which is falsy, so find_log_level falls through
+	# to prefix matching. 'NONE' matches only 'NONE', so it resolves correctly.
+	is find_log_level('NONE'), 'NONE', 'NONE resolves to NONE via prefix path';
+	is find_log_level('none'), 'NONE', 'none resolves to NONE (case-insensitive prefix)';
+};
+
+subtest 'find_log_level - unambiguous prefix lookup' => sub {
+	is find_log_level('TRAC'),  'TRACE',   'TRAC   => TRACE';
+	is find_log_level('DEB'),   'DEBUG',   'DEB    => DEBUG';
+	is find_log_level('WAR'),   'WARNING', 'WAR    => WARNING';
+	is find_log_level('OUT'),   'OUTPUT',  'OUT    => OUTPUT';
+	is find_log_level('trac'),  'TRACE',   'trac   => TRACE (prefix, lowercase)';
+	is find_log_level('deb'),   'DEBUG',   'deb    => DEBUG (prefix, lowercase)';
+};
+
+subtest 'find_log_level - ambiguous prefix dies' => sub {
+	# 'T' matches both TRACE (and no others in the 7-level list since TRACE is
+	# the only T-prefixed level) — actually only TRACE starts with T, so 'T'
+	# is unambiguous.  Use a prefix that matches multiple levels.
+	# 'E' matches ERROR only (no other level starts with E), so also unambiguous.
+	# 'IN' matches INFO only.
+	# A genuinely ambiguous prefix across the 7 levels: none share a prefix
+	# letter uniquely causing ambiguity... let's verify: the 7 levels are:
+	#   NONE, OUTPUT, ERROR, WARNING, INFO, DEBUG, TRACE
+	# 'N'   => NONE only          (unambiguous)
+	# 'O'   => OUTPUT only        (unambiguous)
+	# 'E'   => ERROR only         (unambiguous)
+	# 'W'   => WARNING only       (unambiguous)
+	# 'I'   => INFO only          (unambiguous)
+	# 'D'   => DEBUG only         (unambiguous)
+	# 'T'   => TRACE only         (unambiguous)
+	# There is no single-character ambiguous prefix for these 7 levels.
+	# A multi-char prefix that doesn't match any level is the invalid case.
+	# The ambiguous case requires a prefix matching >1 level, which cannot
+	# occur with these 7 distinct first-letters.  We still test the code path
+	# by constructing a scenario: the test confirms die behavior for invalid.
+	# (Ambiguity coverage is structural; we document it here for clarity.)
+	pass 'no ambiguous prefix exists among the 7 user-facing levels (by design)';
+};
+
+subtest 'find_log_level - invalid level name dies' => sub {
+	quietly {
+		throws_ok { find_log_level('BOGUS') }
+			qr/Not a valid log level 'BOGUS'/,
+			'BOGUS dies with "Not a valid log level" message';
+
+		throws_ok { find_log_level('XYZ') }
+			qr/Not a valid log level 'XYZ'/,
+			'XYZ dies with "Not a valid log level" message';
+
+		throws_ok { find_log_level('verbose') }
+			qr/Not a valid log level 'VERBOSE'/,
+			'verbose (mapped to VERBOSE) dies with "Not a valid log level" message';
+	};
+};
+
+subtest 'find_log_level - invalid level error lists valid levels' => sub {
+	my $err;
+	quietly {
+		eval { find_log_level('BOGUS') };
+		$err = $@;
+	};
+	like $err, qr/NONE/,    'error message mentions NONE';
+	like $err, qr/OUTPUT/,  'error message mentions OUTPUT';
+	like $err, qr/ERROR/,   'error message mentions ERROR';
+	like $err, qr/WARNING/, 'error message mentions WARNING';
+	like $err, qr/INFO/,    'error message mentions INFO';
+	like $err, qr/DEBUG/,   'error message mentions DEBUG';
+	like $err, qr/TRACE/,   'error message mentions TRACE';
+};
+
+# ── meets_level() ────────────────────────────────────────────────────────────
+
+subtest 'meets_level - current level exceeds target (passes)' => sub {
+	ok  meets_level('DEBUG', 'INFO'),  'DEBUG(5) >= INFO(4)  => true';
+	ok  meets_level('TRACE', 'ERROR'), 'TRACE(6) >= ERROR(2) => true';
+	ok  meets_level('TRACE', 'NONE'),  'TRACE(6) >= NONE(0)  => true';
+	ok  meets_level('INFO',  'NONE'),  'INFO(4)  >= NONE(0)  => true';
+	ok  meets_level('DEBUG', 'OUTPUT'),'DEBUG(5) >= OUTPUT(1)=> true';
+};
+
+subtest 'meets_level - current level equals target (passes)' => sub {
+	ok  meets_level('INFO',    'INFO'),    'INFO(4)    >= INFO(4)    => true';
+	ok  meets_level('DEBUG',   'DEBUG'),   'DEBUG(5)   >= DEBUG(5)   => true';
+	ok  meets_level('TRACE',   'TRACE'),   'TRACE(6)   >= TRACE(6)   => true';
+	ok  meets_level('ERROR',   'ERROR'),   'ERROR(2)   >= ERROR(2)   => true';
+	ok  meets_level('WARNING', 'WARNING'), 'WARNING(3) >= WARNING(3) => true';
+	ok  meets_level('NONE',    'NONE'),    'NONE(0)    >= NONE(0)    => true';
+};
+
+subtest 'meets_level - current level below target (fails)' => sub {
+	ok !meets_level('INFO',  'DEBUG'),  'INFO(4)  >= DEBUG(5)  => false';
+	ok !meets_level('ERROR', 'TRACE'),  'ERROR(2) >= TRACE(6)  => false';
+	ok !meets_level('NONE',  'TRACE'),  'NONE(0)  >= TRACE(6)  => false';
+	ok !meets_level('NONE',  'INFO'),   'NONE(0)  >= INFO(4)   => false';
+	ok !meets_level('OUTPUT','WARNING'),'OUTPUT(1)>= WARNING(3)=> false';
+};
+
+subtest 'meets_level - accepts raw numeric ordinal values' => sub {
+	# meets_level checks values of _log_item_level_map(); numerics that appear
+	# as map values (0-6) skip the level_ord() conversion step.
+	ok  meets_level(5, 4), 'numeric 5 >= numeric 4 => true';
+	ok  meets_level(6, 0), 'numeric 6 >= numeric 0 => true';
+	ok  meets_level(4, 4), 'numeric 4 >= numeric 4 => true';
+	ok !meets_level(2, 6), 'numeric 2 >= numeric 6 => false';
+	ok !meets_level(0, 6), 'numeric 0 >= numeric 6 => false';
+};
+
+done_testing;

--- a/t/unit-tests/genesis_log-levels.t
+++ b/t/unit-tests/genesis_log-levels.t
@@ -87,30 +87,10 @@ subtest 'find_log_level - unambiguous prefix lookup' => sub {
 	is find_log_level('deb'),   'DEBUG',   'deb    => DEBUG (prefix, lowercase)';
 };
 
-subtest 'find_log_level - ambiguous prefix dies' => sub {
-	# 'T' matches both TRACE (and no others in the 7-level list since TRACE is
-	# the only T-prefixed level) — actually only TRACE starts with T, so 'T'
-	# is unambiguous.  Use a prefix that matches multiple levels.
-	# 'E' matches ERROR only (no other level starts with E), so also unambiguous.
-	# 'IN' matches INFO only.
-	# A genuinely ambiguous prefix across the 7 levels: none share a prefix
-	# letter uniquely causing ambiguity... let's verify: the 7 levels are:
-	#   NONE, OUTPUT, ERROR, WARNING, INFO, DEBUG, TRACE
-	# 'N'   => NONE only          (unambiguous)
-	# 'O'   => OUTPUT only        (unambiguous)
-	# 'E'   => ERROR only         (unambiguous)
-	# 'W'   => WARNING only       (unambiguous)
-	# 'I'   => INFO only          (unambiguous)
-	# 'D'   => DEBUG only         (unambiguous)
-	# 'T'   => TRACE only         (unambiguous)
-	# There is no single-character ambiguous prefix for these 7 levels.
-	# A multi-char prefix that doesn't match any level is the invalid case.
-	# The ambiguous case requires a prefix matching >1 level, which cannot
-	# occur with these 7 distinct first-letters.  We still test the code path
-	# by constructing a scenario: the test confirms die behavior for invalid.
-	# (Ambiguity coverage is structural; we document it here for clarity.)
-	pass 'no ambiguous prefix exists among the 7 user-facing levels (by design)';
-};
+# Note: No ambiguous prefix test — the 7 user-facing levels (NONE, OUTPUT,
+# ERROR, WARNING, INFO, DEBUG, TRACE) each have distinct first letters, so
+# no prefix can match more than one level.  The ambiguous code path in
+# find_log_level() is unreachable with the current level set.
 
 subtest 'find_log_level - invalid level name dies' => sub {
 	quietly {

--- a/t/unit-tests/genesis_log-routing.t
+++ b/t/unit-tests/genesis_log-routing.t
@@ -1,0 +1,472 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use lib 't';
+use helper;
+use File::Temp qw/tempdir/;
+
+use_ok 'Genesis::Log';
+Genesis::Log->import();
+
+# ---------------------------------------------------------------------------
+# Singleton reset helper
+# ---------------------------------------------------------------------------
+# Because Genesis::Log is a singleton, each subtest that needs a pristine
+# logger must reset $Genesis::Log::Logger before calling new().
+sub reset_logger {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    # Suppress any QUIET/DEBUG/TRACE env influence for clean defaults
+    local $ENV{QUIET}         = undef;
+    local $ENV{GENESIS_TRACE} = undef;
+    local $ENV{GENESIS_DEBUG} = undef;
+    return Genesis::Log->new();
+}
+
+# ---------------------------------------------------------------------------
+# configure_log() — terminal target (no path argument)
+# ---------------------------------------------------------------------------
+
+subtest 'configure_log() with no args configures terminal target and returns $self' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    my $ret;
+    lives_ok { $ret = $logger->configure_log() } 'configure_log() does not die';
+    is $ret, $logger, 'configure_log() returns $self for chaining';
+};
+
+subtest 'configure_log() creates <terminal> entry in logs hash' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+    $logger->configure_log();
+
+    ok exists($logger->{logs}{'<terminal>'}),
+        'logs hash contains <terminal> key after configure_log()';
+    is ref($logger->{logs}{'<terminal>'}), 'HASH',
+        '<terminal> value is a hashref';
+};
+
+subtest 'terminal target has expected default keys' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+    $logger->configure_log();
+
+    my $t = $logger->{logs}{'<terminal>'};
+
+    ok exists($t->{level}),      'terminal config has level key';
+    ok exists($t->{level_ord}),  'terminal config has level_ord key';
+    ok exists($t->{show_stack}), 'terminal config has show_stack key';
+    ok exists($t->{timestamp}),  'terminal config has timestamp key';
+    ok exists($t->{next_entry}), 'terminal config has next_entry key';
+    ok exists($t->{style}),      'terminal config has style key';
+};
+
+subtest 'terminal target defaults: timestamp => 0, show_stack => none, next_entry => 0' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    local $ENV{QUIET}         = undef;
+    local $ENV{GENESIS_TRACE} = undef;
+    local $ENV{GENESIS_DEBUG} = undef;
+    my $logger = Genesis::Log->new();
+    $logger->configure_log();
+
+    my $t = $logger->{logs}{'<terminal>'};
+
+    is $t->{timestamp},  0,      'terminal timestamp defaults to 0';
+    is $t->{show_stack}, 'none', 'terminal show_stack defaults to none';
+    is $t->{next_entry}, 0,      'terminal next_entry defaults to 0';
+};
+
+subtest 'configure_log(level => DEBUG) sets terminal level to DEBUG' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+    $logger->configure_log(level => 'DEBUG');
+
+    my $t = $logger->{logs}{'<terminal>'};
+
+    is $t->{level},     'DEBUG', 'level is DEBUG';
+    is $t->{level_ord}, Genesis::Log::level_ord('DEBUG'),
+        'level_ord matches DEBUG ordinal';
+};
+
+subtest 'configure_log chaining: configure_log()->configure_log() works' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    my $ret;
+    lives_ok {
+        $ret = $logger->configure_log(level => 'DEBUG')
+                      ->configure_log(level => 'TRACE');
+    } 'chained configure_log calls do not die';
+
+    is $ret, $logger, 'chain returns $self';
+    is $logger->{logs}{'<terminal>'}{level}, 'TRACE',
+        'second configure_log call overrides level to TRACE';
+};
+
+# ---------------------------------------------------------------------------
+# configure_log() — file target
+# ---------------------------------------------------------------------------
+
+subtest 'configure_log($path) creates a file target entry' => sub {
+    my $dir = tempdir(CLEANUP => 1);
+    my $path = "$dir/test.log";
+
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    lives_ok { $logger->configure_log($path) }
+        'configure_log(path) does not die';
+
+    ok exists($logger->{logs}{$path}),
+        "logs hash contains the file path key '$path'";
+};
+
+subtest 'file target has timestamp => 1 by default (unlike terminal)' => sub {
+    my $dir = tempdir(CLEANUP => 1);
+    my $path = "$dir/test-ts.log";
+
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+    $logger->configure_log($path);
+
+    is $logger->{logs}{$path}{timestamp}, 1,
+        'file target timestamp defaults to 1';
+};
+
+subtest 'configure_log($path, level => DEBUG) sets file target level' => sub {
+    my $dir = tempdir(CLEANUP => 1);
+    my $path = "$dir/test-level.log";
+
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+    $logger->configure_log($path, level => 'DEBUG');
+
+    is $logger->{logs}{$path}{level}, 'DEBUG',
+        'file target level set to DEBUG';
+};
+
+subtest 'configure_log returns $self for file target too' => sub {
+    my $dir = tempdir(CLEANUP => 1);
+    my $path = "$dir/test-chain.log";
+
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    my $ret;
+    lives_ok { $ret = $logger->configure_log($path, level => 'INFO') }
+        'configure_log with file path does not die';
+
+    is $ret, $logger, 'configure_log(path) returns $self';
+};
+
+# ---------------------------------------------------------------------------
+# is_logging()
+# ---------------------------------------------------------------------------
+
+subtest 'is_logging returns false for unconfigured target' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    # No configure_log called — terminal is not set up
+    my $result = $logger->is_logging('DEBUG');
+    is $result, 0, 'is_logging on unconfigured target returns 0';
+};
+
+subtest 'is_logging with terminal at DEBUG: DEBUG and INFO true, TRACE false' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+    $logger->configure_log(level => 'DEBUG');
+
+    ok  $logger->is_logging('DEBUG'),   'is_logging(DEBUG) true when level=DEBUG';
+    ok  $logger->is_logging('INFO'),    'is_logging(INFO) true when level=DEBUG';
+    ok  $logger->is_logging('WARNING'), 'is_logging(WARNING) true when level=DEBUG';
+    ok  $logger->is_logging('ERROR'),   'is_logging(ERROR) true when level=DEBUG';
+    ok !$logger->is_logging('TRACE'),   'is_logging(TRACE) false when level=DEBUG';
+};
+
+subtest 'is_logging for a specific file target' => sub {
+    my $dir = tempdir(CLEANUP => 1);
+    my $path = "$dir/specific.log";
+
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+    $logger->configure_log($path, level => 'DEBUG');
+
+    ok  $logger->is_logging('DEBUG', $path),
+        'is_logging(DEBUG, path) true when file level=DEBUG';
+    ok  $logger->is_logging('INFO', $path),
+        'is_logging(INFO, path) true when file level=DEBUG';
+    ok !$logger->is_logging('TRACE', $path),
+        'is_logging(TRACE, path) false when file level=DEBUG';
+};
+
+subtest 'is_logging returns 0 for unconfigured named target' => sub {
+    my $nonexistent = '/tmp/nonexistent-genesis-log-test.log';
+
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    my $result = $logger->is_logging('INFO', $nonexistent);
+    is $result, 0, 'is_logging returns 0 for unconfigured named path';
+};
+
+# ---------------------------------------------------------------------------
+# set_level()
+# ---------------------------------------------------------------------------
+
+subtest 'set_level returns $self for chaining' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+    $logger->configure_log(level => 'INFO');
+
+    my $ret;
+    lives_ok { $ret = $logger->set_level('WARNING') }
+        'set_level does not die on configured terminal';
+
+    is $ret, $logger, 'set_level returns $self';
+};
+
+subtest 'set_level changes the terminal threshold' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+    $logger->configure_log(level => 'INFO');
+
+    $logger->set_level('WARNING');
+
+    is $logger->{logs}{'<terminal>'}{level}, 'WARNING',
+        'level updated to WARNING after set_level';
+    is $logger->{logs}{'<terminal>'}{level_ord},
+        Genesis::Log::level_ord('WARNING'),
+        'level_ord updated to WARNING ordinal after set_level';
+};
+
+subtest 'set_level to WARNING: ERROR is logged, INFO is not' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+    $logger->configure_log(level => 'INFO');
+    $logger->set_level('WARNING');
+
+    ok  $logger->is_logging('ERROR'),   'ERROR is logged at WARNING threshold';
+    ok  $logger->is_logging('WARNING'), 'WARNING is logged at WARNING threshold';
+    ok !$logger->is_logging('INFO'),    'INFO is not logged at WARNING threshold';
+    ok !$logger->is_logging('DEBUG'),   'DEBUG is not logged at WARNING threshold';
+};
+
+subtest 'set_level dies with "invalid log" for unconfigured target' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    # Terminal is not configured — set_level must die
+    throws_ok { $logger->set_level('WARNING') }
+        qr/invalid log/,
+        'set_level dies with "invalid log" on unconfigured terminal';
+};
+
+subtest 'set_level dies with "invalid log" for unconfigured named path' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    throws_ok { $logger->set_level('DEBUG', '/tmp/no-such-log.log') }
+        qr/invalid log/,
+        'set_level dies with "invalid log" for unknown file target';
+};
+
+# ---------------------------------------------------------------------------
+# style()
+# ---------------------------------------------------------------------------
+
+subtest 'style() returns configured style string for terminal' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    local $ENV{GENESIS_LOG_STYLE} = undef;
+    my $logger = Genesis::Log->new();
+    $logger->configure_log();
+
+    my $s;
+    lives_ok { $s = $logger->style() } 'style() does not die on configured terminal';
+    ok defined($s), 'style() returns a defined value';
+    ok length($s) > 0, 'style() returns a non-empty string';
+};
+
+subtest 'style() returns explicitly set style' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+    $logger->configure_log(style => 'fun');
+
+    is $logger->style(), 'fun', 'style() returns explicitly configured style';
+};
+
+subtest 'style() dies with "invalid log" for unconfigured target' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    throws_ok { $logger->style() }
+        qr/invalid log/,
+        'style() dies with "invalid log" on unconfigured terminal';
+};
+
+subtest 'style() dies with "invalid log" for unknown named path' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    throws_ok { $logger->style('/tmp/no-such-log.log') }
+        qr/invalid log/,
+        'style(path) dies with "invalid log" for unconfigured path';
+};
+
+# ---------------------------------------------------------------------------
+# expand_log_template()
+# ---------------------------------------------------------------------------
+
+subtest 'expand_log_template expands {pid}' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    my $result = $logger->expand_log_template('/logs/{pid}/app.log');
+    is $result, "/logs/$$/app.log", '{pid} replaced with current process ID ($$)';
+};
+
+subtest 'expand_log_template expands {command} from GENESIS_COMMAND' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    local $ENV{GENESIS_COMMAND} = 'deploy';
+    my $result = $logger->expand_log_template('/logs/{command}/app.log');
+    is $result, '/logs/deploy/app.log', '{command} replaced with GENESIS_COMMAND value';
+};
+
+subtest 'expand_log_template expands {command} to "unknown" when GENESIS_COMMAND unset' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    local $ENV{GENESIS_COMMAND} = undef;
+    my $result = $logger->expand_log_template('/logs/{command}/app.log');
+    is $result, '/logs/unknown/app.log',
+        '{command} replaced with "unknown" when GENESIS_COMMAND not set';
+};
+
+subtest 'expand_log_template expands {date} to YYYYMMDD format' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    my $result = $logger->expand_log_template('/logs/{date}/app.log');
+    like $result, qr|/logs/\d{8}/app\.log|,
+        '{date} expands to an 8-digit date string (YYYYMMDD)';
+};
+
+subtest 'expand_log_template expands {time} to HHMMSS format' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    my $result = $logger->expand_log_template('/logs/{time}/app.log');
+    like $result, qr|/logs/\d{6}/app\.log|,
+        '{time} expands to a 6-digit time string (HHMMSS)';
+};
+
+subtest 'expand_log_template expands {timestamp} to ISO-like format' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    my $result = $logger->expand_log_template('/logs/{timestamp}/app.log');
+    # Expected pattern: YYYYMMDDTHHMMSSmmm.mmmZ
+    like $result, qr|/logs/\d{8}T\d{6}\.\d{3}Z/app\.log|,
+        '{timestamp} expands to compact ISO-like timestamp with milliseconds';
+};
+
+subtest 'expand_log_template removes {env}/ when GENESIS_ENVIRONMENT not set' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    local $ENV{GENESIS_ENVIRONMENT} = undef;
+    my $result = $logger->expand_log_template('/logs/{env}/app.log');
+    unlike $result, qr/\{env\}/, '{env} token is gone from result';
+    unlike $result, qr|//|,       'no double slashes in result';
+    is $result, '/logs/app.log',
+        '{env}/ removed cleanly when GENESIS_ENVIRONMENT is not set';
+};
+
+subtest 'expand_log_template substitutes {env} with GENESIS_ENVIRONMENT when set' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    local $ENV{GENESIS_ENVIRONMENT} = 'prod-us-east-1';
+    my $result = $logger->expand_log_template('/logs/{env}/app.log');
+    is $result, '/logs/prod-us-east-1/app.log',
+        '{env} replaced with GENESIS_ENVIRONMENT value';
+};
+
+subtest 'expand_log_template collapses double slashes' => sub {
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+
+    local $ENV{GENESIS_ENVIRONMENT} = undef;
+    # Template with leading slash + {env}/ which would otherwise produce //
+    my $result = $logger->expand_log_template('/base/{env}/sub/app.log');
+    unlike $result, qr|//|, 'no double slashes after expansion';
+};
+
+# ---------------------------------------------------------------------------
+# File output: configure a temp file target, log to it, verify content
+# ---------------------------------------------------------------------------
+
+subtest 'log message is written to configured file target' => sub {
+    my $dir  = tempdir(CLEANUP => 1);
+    my $path = "$dir/output.log";
+
+    no warnings 'once';
+    $Genesis::Log::Logger = undef;
+    my $logger = Genesis::Log->new();
+    $logger->configure_log($path, level => 'INFO', style => 'plain');
+
+    quietly {
+        $logger->info('routing test marker message');
+    };
+
+    ok -e $path, 'log file was created after info() call';
+
+    open my $fh, '<', $path
+        or fail "could not open log file for reading: $!";
+    my $content = do { local $/; <$fh> };
+    close $fh;
+
+    ok length($content) > 0, 'log file has content';
+    like $content, qr/routing test marker message/,
+        'log file contains the message passed to info()';
+};
+
+# Reset singleton after all tests to avoid leaking state to other test files
+{ no warnings 'once'; $Genesis::Log::Logger = undef; }
+
+done_testing;

--- a/t/unit-tests/genesis_log-routing.t
+++ b/t/unit-tests/genesis_log-routing.t
@@ -6,7 +6,6 @@ use helper;
 use File::Temp qw/tempdir/;
 
 use_ok 'Genesis::Log';
-Genesis::Log->import();
 
 # ---------------------------------------------------------------------------
 # configure_log() — terminal target (no path argument)

--- a/t/unit-tests/genesis_log-routing.t
+++ b/t/unit-tests/genesis_log-routing.t
@@ -9,21 +9,6 @@ use_ok 'Genesis::Log';
 Genesis::Log->import();
 
 # ---------------------------------------------------------------------------
-# Singleton reset helper
-# ---------------------------------------------------------------------------
-# Because Genesis::Log is a singleton, each subtest that needs a pristine
-# logger must reset $Genesis::Log::Logger before calling new().
-sub reset_logger {
-    no warnings 'once';
-    $Genesis::Log::Logger = undef;
-    # Suppress any QUIET/DEBUG/TRACE env influence for clean defaults
-    local $ENV{QUIET}         = undef;
-    local $ENV{GENESIS_TRACE} = undef;
-    local $ENV{GENESIS_DEBUG} = undef;
-    return Genesis::Log->new();
-}
-
-# ---------------------------------------------------------------------------
 # configure_log() — terminal target (no path argument)
 # ---------------------------------------------------------------------------
 

--- a/t/unit-tests/genesis_log-stack.t
+++ b/t/unit-tests/genesis_log-stack.t
@@ -1,0 +1,154 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use lib 't';
+use helper;
+
+use_ok 'Genesis::Log';
+
+# ---------------------------------------------------------------------------
+# get_stack() tests
+# ---------------------------------------------------------------------------
+
+subtest 'get_stack(0) returns a non-empty list' => sub {
+	my @stack;
+	lives_ok { @stack = get_stack(0) } 'get_stack(0) does not die';
+	ok scalar(@stack) > 0, 'get_stack(0) returns at least one frame';
+};
+
+subtest 'each frame is a hashref' => sub {
+	my @stack = get_stack(0);
+	for my $i (0 .. $#stack) {
+		is ref($stack[$i]), 'HASH', "frame $i is a hashref";
+	}
+};
+
+subtest 'each frame has a file key' => sub {
+	my @stack = get_stack(0);
+	for my $i (0 .. $#stack) {
+		ok exists($stack[$i]{file}), "frame $i has a 'file' key";
+		ok defined($stack[$i]{file}), "frame $i 'file' is defined";
+		is ref(\$stack[$i]{file}), 'SCALAR', "frame $i 'file' is a plain string";
+	}
+};
+
+subtest 'each frame has a line key with a positive integer' => sub {
+	my @stack = get_stack(0);
+	for my $i (0 .. $#stack) {
+		ok exists($stack[$i]{line}), "frame $i has a 'line' key";
+		ok defined($stack[$i]{line}), "frame $i 'line' is defined";
+		like $stack[$i]{line}, qr/^\d+$/, "frame $i 'line' is numeric";
+		ok $stack[$i]{line} > 0, "frame $i 'line' is a positive integer";
+	}
+};
+
+subtest 'frames may have a sub key; outermost frame need not' => sub {
+	my @stack = get_stack(0);
+
+	# At least some frames may carry a sub key — just check those that exist
+	# are non-empty strings (the outermost frame legally omits it).
+	my $had_sub = 0;
+	for my $i (0 .. $#stack) {
+		if (exists $stack[$i]{sub}) {
+			is ref(\$stack[$i]{sub}), 'SCALAR',
+				"frame $i 'sub', when present, is a plain string";
+			$had_sub = 1;
+		}
+	}
+
+	# The outermost frame (last element) should not have a sub key because
+	# get_stack() pushes the final frame without one.
+	ok !exists($stack[-1]{sub}),
+		'outermost (last) frame does not carry a sub key';
+
+	# Suppress "no tests run" if the stack happened to be depth-1 and no sub
+	# key appeared — just note it rather than failing.
+	note "Inner frames with sub keys found: $had_sub" unless $had_sub;
+};
+
+subtest 'higher scope offset returns fewer frames' => sub {
+	my @stack0 = get_stack(0);
+	my @stack5 = get_stack(5);
+	ok scalar(@stack0) > scalar(@stack5),
+		'get_stack(0) returns more frames than get_stack(5)';
+};
+
+subtest 'frames returned from within a subtest include caller info' => sub {
+	# Call get_stack() from inside a nested subtest to confirm the call site
+	# appears in the returned frames.
+	my @stack;
+	my $call_line;
+	subtest 'inner subtest for stack capture' => sub {
+		$call_line = __LINE__ + 1;
+		@stack = get_stack(0);
+		ok scalar(@stack) > 0, 'stack is non-empty inside nested subtest';
+	};
+
+	# At least one frame's line should be >= $call_line because we know
+	# the call happened at or after that line.
+	my $found_line = grep { $_->{line} >= $call_line } @stack;
+	ok $found_line > 0,
+		'at least one frame references a line at or after the get_stack() call';
+};
+
+# ---------------------------------------------------------------------------
+# get_scope() tests
+#
+# NOTE: FWT-701 #1 documented a bug where get_scope() called a non-existent
+# _get_stack() helper.  The code in this worktree has been corrected to call
+# get_stack() instead (Log.pm line 587).  The tests below therefore test the
+# corrected, working behaviour.  If the bug is somehow still present the
+# lives_ok assertion will catch it.
+# ---------------------------------------------------------------------------
+
+subtest 'get_scope(0) returns a defined string' => sub {
+	my $scope;
+	lives_ok { $scope = get_scope(0) } 'get_scope(0) does not die';
+	ok defined($scope), 'get_scope(0) returns a defined value';
+	is ref(\$scope), 'SCALAR', 'get_scope(0) returns a plain string';
+};
+
+subtest 'get_scope return value contains the caller filename' => sub {
+	my $scope = get_scope(0);
+	like $scope, qr/genesis_log-stack\.t/,
+		'scope string contains the name of this test file';
+};
+
+subtest 'get_scope return value contains a line number marker' => sub {
+	my $scope = get_scope(0);
+	like $scope, qr/L\d+/,
+		'scope string contains a line-number marker matching /L\d+/';
+};
+
+subtest 'get_scope returns a non-empty string' => sub {
+	my $scope = get_scope(0);
+	ok length($scope) > 0, 'get_scope(0) returns a non-empty string';
+};
+
+subtest 'get_scope without GENESIS_STACK_TRACE emits a single frame' => sub {
+	# Each rendered frame occupies exactly 2 segments when split on "\n"
+	# (the ANSI-coloured file:line run, then the ANSI-reset suffix).
+	# Without GENESIS_STACK_TRACE only the innermost frame is emitted.
+	local $ENV{GENESIS_STACK_TRACE};
+	delete $ENV{GENESIS_STACK_TRACE};
+
+	sub _scope_from_depth { get_scope(0) }
+	my $scope = _scope_from_depth();
+	my @segs = split /\n/, $scope;
+	is scalar(@segs), 2,
+		'without GENESIS_STACK_TRACE get_scope emits exactly one frame (2 ANSI segments)';
+};
+
+subtest 'get_scope with GENESIS_STACK_TRACE emits multiple frames' => sub {
+	# With GENESIS_STACK_TRACE every frame in the call stack is appended.
+	# Calling through a helper sub guarantees at least 2 frames, giving >= 4 segments.
+	local $ENV{GENESIS_STACK_TRACE} = '1';
+
+	sub _scope_from_depth_trace { get_scope(0) }
+	my $scope = _scope_from_depth_trace();
+	my @segs = split /\n/, $scope;
+	ok scalar(@segs) > 2,
+		'with GENESIS_STACK_TRACE get_scope emits more than one frame (> 2 ANSI segments)';
+};
+
+done_testing;

--- a/t/unit-tests/genesis_log-stack.t
+++ b/t/unit-tests/genesis_log-stack.t
@@ -84,11 +84,13 @@ subtest 'frames returned from within a subtest include caller info' => sub {
 		ok scalar(@stack) > 0, 'stack is non-empty inside nested subtest';
 	};
 
-	# At least one frame's line should be >= $call_line because we know
-	# the call happened at or after that line.
-	my $found_line = grep { $_->{line} >= $call_line } @stack;
-	ok $found_line > 0,
-		'at least one frame references a line at or after the get_stack() call';
+	# Match on both filename (substring — get_stack humanizes paths) and
+	# exact line number to avoid false positives from unrelated frames.
+	my $found_call_site = grep {
+		$_->{file} =~ /genesis_log-stack\.t/ && $_->{line} == $call_line
+	} @stack;
+	ok $found_call_site > 0,
+		'stack includes a frame for the get_stack() call site in this file';
 };
 
 # ---------------------------------------------------------------------------

--- a/t/unit-tests/genesis_log-stack.t
+++ b/t/unit-tests/genesis_log-stack.t
@@ -132,8 +132,8 @@ subtest 'get_scope without GENESIS_STACK_TRACE emits a single frame' => sub {
 	local $ENV{GENESIS_STACK_TRACE};
 	delete $ENV{GENESIS_STACK_TRACE};
 
-	sub _scope_from_depth { get_scope(0) }
-	my $scope = _scope_from_depth();
+	my $scope_from_depth = sub { get_scope(0) };
+	my $scope = $scope_from_depth->();
 	my @segs = split /\n/, $scope;
 	is scalar(@segs), 2,
 		'without GENESIS_STACK_TRACE get_scope emits exactly one frame (2 ANSI segments)';
@@ -144,8 +144,8 @@ subtest 'get_scope with GENESIS_STACK_TRACE emits multiple frames' => sub {
 	# Calling through a helper sub guarantees at least 2 frames, giving >= 4 segments.
 	local $ENV{GENESIS_STACK_TRACE} = '1';
 
-	sub _scope_from_depth_trace { get_scope(0) }
-	my $scope = _scope_from_depth_trace();
+	my $scope_from_depth_trace = sub { get_scope(0) };
+	my $scope = $scope_from_depth_trace->();
 	my @segs = split /\n/, $scope;
 	ok scalar(@segs) > 2,
 		'with GENESIS_STACK_TRACE get_scope emits more than one frame (> 2 ANSI segments)';

--- a/t/unit-tests/genesis_log-styles.t
+++ b/t/unit-tests/genesis_log-styles.t
@@ -1,0 +1,301 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use lib 't';
+use helper;
+
+use Test::Deep;
+
+use_ok 'Genesis::Log';
+
+# ---------------------------------------------------------------------------
+# All 11 named styles exist and return hashrefs
+# ---------------------------------------------------------------------------
+subtest 'all named styles return hashrefs' => sub {
+	my @names = qw(
+		output info debug warning notice
+		error fatal trace qtrace dumpvar dumpstack
+	);
+
+	for my $name (@names) {
+		my $style = log_styles($name);
+		ok defined($style), "log_styles('$name') returns a defined value";
+		is ref($style), 'HASH', "log_styles('$name') returns a hashref";
+	}
+};
+
+# ---------------------------------------------------------------------------
+# Every style has at minimum a 'colors' key
+# ---------------------------------------------------------------------------
+subtest 'every style has a colors key' => sub {
+	for my $name (qw(
+		output info debug warning notice
+		error fatal trace qtrace dumpvar dumpstack
+	)) {
+		my $style = log_styles($name);
+		ok exists($style->{colors}), "log_styles('$name') has a 'colors' key";
+		ok defined($style->{colors}), "log_styles('$name') colors value is defined";
+		ok length($style->{colors}) > 0, "log_styles('$name') colors value is non-empty";
+	}
+};
+
+# ---------------------------------------------------------------------------
+# Every style has an 'emoji' key
+# ---------------------------------------------------------------------------
+subtest 'every style has an emoji key' => sub {
+	for my $name (qw(
+		output info debug warning notice
+		error fatal trace qtrace dumpvar dumpstack
+	)) {
+		my $style = log_styles($name);
+		ok exists($style->{emoji}), "log_styles('$name') has an 'emoji' key";
+		ok defined($style->{emoji}), "log_styles('$name') emoji value is defined";
+	}
+};
+
+# ---------------------------------------------------------------------------
+# Unknown style name returns undef
+# ---------------------------------------------------------------------------
+subtest 'unknown style name returns undef' => sub {
+	my $result = log_styles('bogus');
+	ok !defined($result), "log_styles('bogus') returns undef";
+
+	ok !defined(log_styles('')),      "log_styles('') returns undef";
+	ok !defined(log_styles('OUTPUT')), "log_styles('OUTPUT') (wrong case) returns undef";
+};
+
+# ---------------------------------------------------------------------------
+# Specific style properties: output
+# ---------------------------------------------------------------------------
+subtest "style 'output' has correct properties" => sub {
+	my $style = log_styles('output');
+	is $style->{colors}, 'Ck',      "output: colors => 'Ck'";
+	is $style->{pri},    6,          "output: pri => 6";
+	is $style->{emoji},  'printer',  "output: emoji => 'printer'";
+};
+
+# ---------------------------------------------------------------------------
+# Specific style properties: info
+# ---------------------------------------------------------------------------
+subtest "style 'info' has correct properties" => sub {
+	my $style = log_styles('info');
+	is $style->{colors}, 'cW',           "info: colors => 'cW'";
+	is $style->{pri},    6,               "info: pri => 6";
+	is $style->{emoji},  'information',   "info: emoji => 'information'";
+};
+
+# ---------------------------------------------------------------------------
+# Specific style properties: debug (no pri key)
+# ---------------------------------------------------------------------------
+subtest "style 'debug' has correct properties and no pri key" => sub {
+	my $style = log_styles('debug');
+	is  $style->{colors}, 'mW',           "debug: colors => 'mW'";
+	is  $style->{emoji},  'crystal-ball', "debug: emoji => 'crystal-ball'";
+	ok !exists($style->{pri}),            "debug: no 'pri' key";
+};
+
+# ---------------------------------------------------------------------------
+# Specific style properties: warning
+# ---------------------------------------------------------------------------
+subtest "style 'warning' has correct properties" => sub {
+	my $style = log_styles('warning');
+	is $style->{colors}, 'ky',       "warning: colors => 'ky'";
+	is $style->{pri},    4,           "warning: pri => 4";
+	is $style->{emoji},  'warning',   "warning: emoji => 'warning'";
+};
+
+# ---------------------------------------------------------------------------
+# Specific style properties: notice
+# ---------------------------------------------------------------------------
+subtest "style 'notice' has correct properties" => sub {
+	my $style = log_styles('notice');
+	is $style->{colors}, 'bw',        "notice: colors => 'bw'";
+	is $style->{pri},    4,            "notice: pri => 4";
+	is $style->{emoji},  'megaphone',  "notice: emoji => 'megaphone'";
+};
+
+# ---------------------------------------------------------------------------
+# Specific style properties: error
+# ---------------------------------------------------------------------------
+subtest "style 'error' has correct properties" => sub {
+	my $style = log_styles('error');
+	is $style->{colors}, 'RW',         "error: colors => 'RW'";
+	is $style->{pri},    3,             "error: pri => 3";
+	is $style->{emoji},  'collision',   "error: emoji => 'collision'";
+};
+
+# ---------------------------------------------------------------------------
+# Specific style properties: fatal
+# ---------------------------------------------------------------------------
+subtest "style 'fatal' has correct properties" => sub {
+	my $style = log_styles('fatal');
+	is $style->{colors}, 'rY',        "fatal: colors => 'rY'";
+	is $style->{pri},    0,            "fatal: pri => 0";
+	is $style->{emoji},  'stop-sign',  "fatal: emoji => 'stop-sign'";
+};
+
+# ---------------------------------------------------------------------------
+# Specific style properties: trace (has show_stack)
+# ---------------------------------------------------------------------------
+subtest "style 'trace' has correct properties including show_stack" => sub {
+	my $style = log_styles('trace');
+	is $style->{colors},     'GW',        "trace: colors => 'GW'";
+	is $style->{emoji},      'detective', "trace: emoji => 'detective'";
+	ok exists($style->{show_stack}),      "trace: has 'show_stack' key";
+	is $style->{show_stack}, 'current',   "trace: show_stack => 'current'";
+};
+
+# ---------------------------------------------------------------------------
+# Specific style properties: qtrace (no show_stack key)
+# ---------------------------------------------------------------------------
+subtest "style 'qtrace' has correct properties and no show_stack key" => sub {
+	my $style = log_styles('qtrace');
+	is  $style->{colors}, 'gW',        "qtrace: colors => 'gW'";
+	is  $style->{emoji},  'detective', "qtrace: emoji => 'detective'";
+	ok !exists($style->{show_stack}),  "qtrace: no 'show_stack' key";
+};
+
+# ---------------------------------------------------------------------------
+# Specific style properties: dumpvar (has raw and show_scope)
+# ---------------------------------------------------------------------------
+subtest "style 'dumpvar' has correct properties" => sub {
+	my $style = log_styles('dumpvar');
+	is $style->{colors},     'BW',                "dumpvar: colors => 'BW'";
+	is $style->{emoji},      'magnifying-glass',  "dumpvar: emoji => 'magnifying-glass'";
+	ok exists($style->{show_scope}),              "dumpvar: has 'show_scope' key";
+	is $style->{show_scope}, 'current',           "dumpvar: show_scope => 'current'";
+	ok exists($style->{raw}),                     "dumpvar: has 'raw' key";
+	is $style->{raw},        1,                   "dumpvar: raw => 1";
+};
+
+# ---------------------------------------------------------------------------
+# Specific style properties: dumpstack (has raw)
+# ---------------------------------------------------------------------------
+subtest "style 'dumpstack' has correct properties" => sub {
+	my $style = log_styles('dumpstack');
+	is $style->{colors}, 'Yk',       "dumpstack: colors => 'Yk'";
+	is $style->{emoji},  'pancakes', "dumpstack: emoji => 'pancakes'";
+	ok exists($style->{raw}),        "dumpstack: has 'raw' key";
+	is $style->{raw},    1,          "dumpstack: raw => 1";
+};
+
+# ---------------------------------------------------------------------------
+# Cross-style distinctions: trace vs qtrace show_stack asymmetry
+# ---------------------------------------------------------------------------
+subtest 'trace has show_stack but qtrace does not' => sub {
+	my $trace  = log_styles('trace');
+	my $qtrace = log_styles('qtrace');
+
+	ok  exists($trace->{show_stack}),   "trace has 'show_stack'";
+	ok !exists($qtrace->{show_stack}),  "qtrace does not have 'show_stack'";
+	is $trace->{show_stack}, 'current', "trace show_stack is 'current'";
+};
+
+# ---------------------------------------------------------------------------
+# Cross-style distinctions: raw flag only on dumpvar and dumpstack
+# ---------------------------------------------------------------------------
+subtest 'raw key present only on dumpvar and dumpstack' => sub {
+	my @with_raw    = qw(dumpvar dumpstack);
+	my @without_raw = qw(output info debug warning notice error fatal trace qtrace);
+
+	for my $name (@with_raw) {
+		my $style = log_styles($name);
+		ok exists($style->{raw}), "log_styles('$name') has 'raw' key";
+		is $style->{raw}, 1,      "log_styles('$name') raw => 1";
+	}
+
+	for my $name (@without_raw) {
+		my $style = log_styles($name);
+		ok !exists($style->{raw}), "log_styles('$name') does not have 'raw' key";
+	}
+};
+
+# ---------------------------------------------------------------------------
+# Cross-style distinctions: pri key presence
+# ---------------------------------------------------------------------------
+subtest 'pri key present only on output, info, warning, notice, error, fatal' => sub {
+	my %expected_pri = (
+		output  => 6,
+		info    => 6,
+		warning => 4,
+		notice  => 4,
+		error   => 3,
+		fatal   => 0,
+	);
+	my @without_pri = qw(debug trace qtrace dumpvar dumpstack);
+
+	for my $name (sort keys %expected_pri) {
+		my $style = log_styles($name);
+		ok exists($style->{pri}), "log_styles('$name') has 'pri' key";
+		is $style->{pri}, $expected_pri{$name},
+			"log_styles('$name') pri => $expected_pri{$name}";
+	}
+
+	for my $name (@without_pri) {
+		my $style = log_styles($name);
+		ok !exists($style->{pri}), "log_styles('$name') does not have 'pri' key";
+	}
+};
+
+# ---------------------------------------------------------------------------
+# cmp_deeply: full hashref comparison for each style
+# ---------------------------------------------------------------------------
+subtest 'full hashref deep comparison for each style' => sub {
+	cmp_deeply(
+		log_styles('output'),
+		{ colors => 'Ck', pri => 6, emoji => 'printer' },
+		"output: exact hashref match"
+	);
+	cmp_deeply(
+		log_styles('info'),
+		{ colors => 'cW', pri => 6, emoji => 'information' },
+		"info: exact hashref match"
+	);
+	cmp_deeply(
+		log_styles('debug'),
+		{ colors => 'mW', emoji => 'crystal-ball' },
+		"debug: exact hashref match"
+	);
+	cmp_deeply(
+		log_styles('warning'),
+		{ colors => 'ky', pri => 4, emoji => 'warning' },
+		"warning: exact hashref match"
+	);
+	cmp_deeply(
+		log_styles('notice'),
+		{ colors => 'bw', pri => 4, emoji => 'megaphone' },
+		"notice: exact hashref match"
+	);
+	cmp_deeply(
+		log_styles('error'),
+		{ colors => 'RW', pri => 3, emoji => 'collision' },
+		"error: exact hashref match"
+	);
+	cmp_deeply(
+		log_styles('fatal'),
+		{ colors => 'rY', pri => 0, emoji => 'stop-sign' },
+		"fatal: exact hashref match"
+	);
+	cmp_deeply(
+		log_styles('trace'),
+		{ colors => 'GW', emoji => 'detective', show_stack => 'current' },
+		"trace: exact hashref match"
+	);
+	cmp_deeply(
+		log_styles('qtrace'),
+		{ colors => 'gW', emoji => 'detective' },
+		"qtrace: exact hashref match"
+	);
+	cmp_deeply(
+		log_styles('dumpvar'),
+		{ colors => 'BW', show_scope => 'current', emoji => 'magnifying-glass', raw => 1 },
+		"dumpvar: exact hashref match"
+	);
+	cmp_deeply(
+		log_styles('dumpstack'),
+		{ colors => 'Yk', emoji => 'pancakes', raw => 1 },
+		"dumpstack: exact hashref match"
+	);
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

- Six new unit test files for `Genesis::Log` covering all four acceptance criteria from FWT-576
- **107 tests** across 7 files (6 new + 1 pre-existing), all passing
- Full unit test suite (42 files, 614 tests) passes with no regressions
- Test manifest updated with new entries

## Test Coverage

| File | AC | Methods Covered |
|------|----|-----------------|
| `genesis_log-core.t` | Init | `new()` singleton, `$Logger` export, initial state |
| `genesis_log-levels.t` | AC1 | `find_log_level`, `meets_level`, `log_levels`, `level_ord` |
| `genesis_log-styles.t` | AC2 | All 11 styles, structure validation, deep comparison |
| `genesis_log-stack.t` | AC4 | `get_stack`, `get_scope` |
| `genesis_log-routing.t` | AC3 | `configure_log`, `is_logging`, `set_level`, `style`, file output, `expand_log_template` |
| `genesis_log-convenience.t` | AC2+AC3 | `output`, `info`, `debug`, `notice`, `warning`, `error`, `fatal`, `trace`, `qtrace`, `dump_var` |

## Defect Notes

- FWT-701 #1 (`get_scope` calling `_get_stack`) is already fixed in `v3.1.x-dev` — tests confirm `get_scope` works correctly
- No new code defects discovered during test writing

## Test plan

- [x] `prove -lv t/unit-tests/genesis_log-*.t` — all 7 files pass (107 tests)
- [x] `make unit-tests` — full suite passes (42 files, 614 tests)
- [x] No pre-existing test regressions introduced