### PR TITLE
FWT-546: Genesis::Kit core tests

### DIFF
--- a/t/test-manifest.txt
+++ b/t/test-manifest.txt
@@ -27,8 +27,11 @@ unit-tests/boolean-core.t
 unit-tests/service_github-core.t
 unit-tests/service_bosh-director.t
 unit-tests/genesis_top-core.t
+# Kit module tests (POD-driven, FWT-546)
+unit-tests/genesis_kit-core.t            # Genesis::Kit base class
+unit-tests/genesis_kit_compiled-core.t   # Genesis::Kit::Compiled
+unit-tests/genesis_kit_dev-core.t        # Genesis::Kit::Dev
 # Temporarily disabled - see test analysis for details
-#unit-tests/kit-core.t
 #unit-tests/kit-compilation.t
 #unit-tests/hooks.t
 #unit-tests/hooks-cloudconfig.t

--- a/t/unit-tests/genesis_kit-core.t
+++ b/t/unit-tests/genesis_kit-core.t
@@ -1,0 +1,583 @@
+#!perl
+use strict;
+use warnings;
+
+use lib 'lib';
+use lib 't';
+use helper;
+use Test::Deep;
+
+use_ok 'Genesis';
+use_ok 'Genesis::Kit';
+use_ok 'Genesis::Kit::Compiled';
+use_ok 'Genesis::Kit::Dev';
+use_ok 'Service::Vault::Remote';
+
+use_ok 'Genesis::Config';
+$Genesis::RC = Genesis::Config->new("$ENV{HOME}/.genesis/config");
+
+use Genesis::Kit::Compiler;
+
+# NOTE: Genesis-community provider, kit URLs, available kits, and kit versions
+# tests moved to integration tests
+
+package mockenv;
+use Data::Dumper;
+
+sub new {
+	my ($class, @features) = @_;
+	bless {
+		f => \@features,
+		vault => Service::Vault::Remote->new(url => "https://localhost:8999", name => "mockvault")
+	}, $class;
+}
+sub features { @{$_[0]{f}}; }
+sub name { "mock-env"; }
+sub type { "mock-type"; }
+sub secrets_path { "mock/env"; }
+sub use_create_env { 0; }
+sub lookup_bosh_target { wantarray ? ('a-bosh', 'params.bosh') : 'a-bosh'; }
+sub lookup { "a-value" }
+sub bosh_target { 'a-bosh'; }
+sub path { "some/path/some/where".($_[1]?"/$_[1]":""); }
+sub vault { $_[0]->{vault} }
+sub get_environment_variables {
+	my $self = shift;
+	my %env;
+	$env{GENESIS_ROOT}         = $self->path;
+	$env{GENESIS_ENVIRONMENT}  = $self->name;
+	$env{GENESIS_TYPE}         = $self->type;
+	$env{GENESIS_TARGET_VAULT} = $env{SAFE_TARGET} = $self->vault->ref;
+	$env{GENESIS_VERIFY_VAULT} = $self->vault->verify || "";
+
+	$env{HOOK_ENV_VARS}='setup';
+	$env{GENESIS_VAULT_PREFIX} = $env{GENESIS_SECRETS_PATH} = secrets_path;
+	return %env;
+}
+
+package main;
+
+sub kit {
+	my ($name, $version, $path) = @_;
+	$version ||= 'latest';
+	$path ||= 't/src/simple';
+	my $tmp = workdir;
+	my $file;
+	quietly {
+		$file = Genesis::Kit::Compiler->new($path)->compile($name, $version, $tmp, force => 1);
+	};
+
+	return Genesis::Kit::Compiled->new(
+		name    => $name,
+		version => $version,
+		archive => "$tmp/$file"
+	);
+}
+
+sub decompile_kit {
+	return Genesis::Kit::Dev->new(kit(@_)->path);
+}
+
+# ---------------------------------------------------------------------------
+# Subtest: Genesis::Kit->new() abstract guard
+# ---------------------------------------------------------------------------
+subtest 'Genesis::Kit->new() dies for abstract base class' => sub {
+	throws_ok { Genesis::Kit->new() }
+		qr/abstract class/i,
+		'Genesis::Kit->new() dies with abstract class error';
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 1: kit_bug for compiled and dev kits
+# ---------------------------------------------------------------------------
+subtest 'kit utilities' => sub {
+	my $kit = kit('test', '1.0.0');
+	quietly { throws_ok { $kit->kit_bug('buggy behavior') }
+		qr{
+			buggy \s+ behavior.*
+			a \s+ bug \s+ in \s+ the \s+ test/1\.0\.0 \s+ kit.*
+			file \s+ an \s+ issue \s+ at .* https://github\.com/.*/issues
+		}six, "kit_bug() reports the pertinent details for a compiled kit";
+	};
+
+	my $dev = decompile_kit('test', '1.0.0');
+	quietly { throws_ok { $dev->kit_bug('buggy behavior') }
+		qr{
+			buggy \s+ behavior.*
+			a \s+ bug \s+ in \s+ your \s+ dev/ \s+ kit.*
+			contact .* author .* you
+		}six, "kit_bug() reports the pertinent details for a dev kit";
+	};
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 2: compiled kit identity, metadata, paths, has_hook
+# ---------------------------------------------------------------------------
+subtest 'compiled kits' => sub {
+	my $kit = kit(test => '0.0.1');
+
+	cmp_deeply($kit->metadata, superhashof({
+			name => 'simple',
+		}), "a kit should be able to parse its metadata");
+	cmp_deeply($kit->metadata, $kit->metadata,
+		"subsequent calls to kit->metadata should return the same metadata");
+
+	is($kit->id, "test/0.0.1", "compiled kits should report their ID properly");
+	is($kit->name, "test", "compiled kits should know their own name");
+	is($kit->version, "0.0.1", "compiled kits should know their own version");
+	for my $f (qw(kit.yml manifest.yml hooks/new hooks/blueprint)) {
+		ok(-f $kit->path($f), "[test-0.0.1] $f file should exist in compiled kit");
+	}
+	for my $d (qw(hooks)) {
+		ok(-d $kit->path($d), "[test-0.0.1] $d/ should exist in compiled kit");
+	}
+	ok(!$kit->has_hook('secrets'), "[test-0.0.1] kit should not report hooks it doesn't have");
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 3: dev kit identity, paths, source_yaml_files
+# ---------------------------------------------------------------------------
+subtest 'dev kits' => sub {
+	my $kit = kit(test => '0.0.1');
+	my $dev = decompile_kit(test => '0.0.1');
+	is($dev->name, "dev", "dev kits are all named 'dev'");
+	is($dev->version, "latest", "dev kits are always at latest");
+	is($dev->id, "simple/in-development (dev)", "dev kits should report their ID as dev, all the time");
+	for my $f (qw(kit.yml manifest.yml hooks/new hooks/blueprint)) {
+		ok(-f $dev->path($f), "[dev :: test-0.0.1] $f file should exist in dev kit");
+	}
+	for my $d (qw(hooks)) {
+		ok(-d $dev->path($d), "[dev :: test-0.0.1] $d/ should exist in dev kit");
+	}
+
+	isnt($kit->path("kit.yml"), $dev->path("kit.yml"),
+		"compiled-kit paths are not the same as dev-kit paths");
+
+	cmp_deeply(
+		[$kit->source_yaml_files(mockenv->new())],
+		[re('\bmanifest.yml$')],
+		"simple kits without subkits should return base yaml files only"
+	);
+
+	cmp_deeply(
+		[$kit->source_yaml_files(mockenv->new('bogus', 'features'))],
+		[$kit->source_yaml_files(mockenv->new())],
+		"simple kits ignore features they don't know about"
+	);
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 4: version requirements (check_prereqs)
+# ---------------------------------------------------------------------------
+subtest 'version requirements' => sub {
+	my $kit = kit(test => '1.2.3');
+	local $Genesis::VERSION;
+
+	$Genesis::VERSION = '0.0.1';
+	quietly { ok !$kit->check_prereqs, 'v0.0.1 is too old for the t/src/simple kit prereq of 2.8.0'; };
+
+	$Genesis::VERSION = '9.9.9';
+	ok $kit->check_prereqs, 'v9.9.9 is new enough for the t/src/simple kit prereq of 2.8.0';
+
+	$Genesis::VERSION = "dev";
+	ok $kit->check_prereqs, 'dev versions are new enough for any kit prereq';
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 5: known_hooks class and instance methods
+# ---------------------------------------------------------------------------
+subtest 'known_hooks' => sub {
+	my @expected = qw(
+		new feature blueprint info check pre-deploy post-deploy terminate
+		edit shell addon cloud-config cpi-config features runtime-config
+	);
+
+	# Class method call
+	my @class_hooks = Genesis::Kit::known_hooks();
+	cmp_deeply(\@class_hooks, \@expected,
+		"known_hooks() class call returns the full list of recognized hook names");
+
+	# Instance method call produces the same list
+	my $kit = kit(test => '0.0.1');
+	my @inst_hooks = $kit->known_hooks();
+	cmp_deeply(\@inst_hooks, \@expected,
+		"known_hooks() instance call returns the same list as the class call");
+
+	ok scalar(@class_hooks) == 15,
+		"known_hooks() returns exactly 15 hooks";
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 6: is_dev distinguishes compiled vs dev kits
+# ---------------------------------------------------------------------------
+subtest 'is_dev' => sub {
+	my $compiled = kit(test => '0.0.1');
+	my $dev = decompile_kit(test => '0.0.1');
+
+	ok !$compiled->is_dev, "compiled kits return false for is_dev()";
+	ok  $dev->is_dev,      "dev kits return true for is_dev()";
+
+	is($compiled->is_dev, 0, "compiled kit is_dev() returns exactly 0");
+	is($dev->is_dev,      1, "dev kit is_dev() returns exactly 1");
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 7: path() returns workspace root and relative sub-paths
+# ---------------------------------------------------------------------------
+subtest 'path method' => sub {
+	my $kit = kit(test => '0.0.1');
+
+	my $root = $kit->path();
+	ok defined($root) && length($root) > 0,
+		"path() with no args returns a non-empty root directory";
+	ok -d $root, "path() root directory exists on disk";
+
+	my $kityml = $kit->path('kit.yml');
+	like $kityml, qr{/kit\.yml$}, "path('kit.yml') has kit.yml at the end";
+	ok -f $kityml, "path('kit.yml') points to an existing file";
+	is $kityml, "$root/kit.yml",
+		"path('kit.yml') equals root . '/kit.yml'";
+
+	# Leading slash should be stripped
+	my $with_slash = $kit->path('/hooks/blueprint');
+	my $without_slash = $kit->path('hooks/blueprint');
+	is $with_slash, $without_slash,
+		"path() strips leading slashes from the argument";
+
+	my $hook_path = $kit->path('hooks/blueprint');
+	ok -f $hook_path, "path('hooks/blueprint') points to an existing hook file";
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 8: glob() matches files relative and absolute
+# ---------------------------------------------------------------------------
+subtest 'glob method' => sub {
+	my $kit = kit(test => '0.0.1');
+
+	# Relative glob — should return paths relative to the kit root
+	my @rel = $kit->glob('hooks/*');
+	ok scalar(@rel) > 0, "glob('hooks/*') returns at least one match";
+	for my $f (@rel) {
+		like $f, qr{^hooks/}, "relative glob result '$f' starts with 'hooks/'";
+		unlike $f, qr{^/}, "relative glob result '$f' is not an absolute path";
+	}
+
+	# Absolute glob
+	my @abs = $kit->glob('hooks/*', 1);
+	ok scalar(@abs) > 0, "glob('hooks/*', 1) returns at least one match";
+	for my $f (@abs) {
+		like $f, qr{^/}, "absolute glob result '$f' is an absolute path";
+		ok -f $f, "absolute glob result '$f' exists on disk";
+	}
+
+	ok scalar(@rel) == scalar(@abs),
+		"relative and absolute globs return the same number of results";
+
+	# Leading slash stripped
+	my @a = $kit->glob('/hooks/*');
+	my @b = $kit->glob('hooks/*');
+	cmp_deeply(\@a, \@b,
+		"glob() strips leading slash from pattern");
+
+	# No matches for non-existent pattern
+	my @none = $kit->glob('no-such-dir/*');
+	is scalar(@none), 0, "glob() returns empty list for non-matching pattern";
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 9: has_hook for known and unknown hooks
+# ---------------------------------------------------------------------------
+subtest 'has_hook' => sub {
+	my $kit = kit(test => '0.0.1');
+
+	# The simple fixture only has blueprint and new hooks
+	ok $kit->has_hook('blueprint'), "has_hook('blueprint') is true for the simple kit";
+	ok $kit->has_hook('new'),       "has_hook('new') is true for the simple kit";
+
+	# Hooks that are NOT present in the simple fixture
+	for my $absent (qw(check info pre-deploy post-deploy terminate
+	                   cloud-config cpi-config features runtime-config prereqs secrets)) {
+		ok !$kit->has_hook($absent), "has_hook('$absent') is false (not in simple kit)";
+	}
+
+	# The addon hook is special: has_hook('addon') without a script option
+	# resolves script='' which always maps to the built-in '@Genesis::Hook::Addon'
+	# module handler when GENESIS_NO_MODULE_HOOKS is not set.  This is
+	# documented behavior.  To test whether a specific named addon script is
+	# present in the kit, pass the script option:
+	ok !$kit->has_hook('addon', script => 'login'),
+		"has_hook('addon', script=>'login') is false (no addon-login in simple kit)";
+
+	# Result is a file path (truthy string) when hook exists
+	my $bp = $kit->has_hook('blueprint');
+	ok -f $bp, "has_hook('blueprint') returns a path to an existing file";
+
+	# Caching: second call returns same result
+	my $bp2 = $kit->has_hook('blueprint');
+	is $bp, $bp2, "has_hook() returns cached result on repeated calls";
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 10: metadata content and memoization
+# ---------------------------------------------------------------------------
+subtest 'metadata' => sub {
+	my $kit = kit(test => '0.0.1');
+
+	my $meta = $kit->metadata();
+	ok ref($meta) eq 'HASH', "metadata() returns a hashref";
+
+	# Keys from t/src/simple/kit.yml
+	is $meta->{name},   'simple',
+		"metadata()->{name} matches kit.yml";
+	like $meta->{author}, qr/James Hunt/,
+		"metadata()->{author} contains expected author";
+	like $meta->{docs},   qr{https://github\.com},
+		"metadata()->{docs} is a GitHub URL";
+	like $meta->{code},   qr{https://github\.com},
+		"metadata()->{code} is a GitHub URL";
+	is $meta->{genesis_version_min}, '2.8.0',
+		"metadata()->{genesis_version_min} is 2.8.0";
+
+	# Single-key retrieval
+	my $name_val = $kit->metadata('name');
+	is $name_val, 'simple', "metadata('name') single-key form returns scalar";
+
+	# Missing key returns undef
+	my $missing = $kit->metadata('no_such_key');
+	ok !defined($missing), "metadata() returns undef for missing keys";
+
+	# Memoization: same hashref returned on repeated calls
+	my $meta2 = $kit->metadata();
+	is $meta, $meta2, "metadata() returns the same memoized reference on repeat calls";
+
+	# use_create_env defaults to 'allow' for genesis_version_min >= 2.8.0
+	is $meta->{use_create_env}, 'allow',
+		"metadata() sets use_create_env='allow' for 2.8.0+ kits that omit the field";
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 11: genesis_version_min extraction and memoization
+# ---------------------------------------------------------------------------
+subtest 'genesis_version_min' => sub {
+	my $kit = kit(test => '0.0.1');
+
+	my $min = $kit->genesis_version_min();
+	is $min, '2.8.0',
+		"genesis_version_min() returns the value from kit.yml";
+
+	# Calling twice should return the same memoized string
+	my $min2 = $kit->genesis_version_min();
+	is $min, $min2, "genesis_version_min() is memoized";
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 12: feature_compatibility version comparisons
+# ---------------------------------------------------------------------------
+subtest 'feature_compatibility' => sub {
+	my $kit = kit(test => '0.0.1');
+	# kit.yml has genesis_version_min: 2.8.0
+
+	ok  $kit->feature_compatibility('2.8.0'),
+		"feature_compatibility('2.8.0') is true (kit meets exact version)";
+	ok  $kit->feature_compatibility('2.7.0'),
+		"feature_compatibility('2.7.0') is true (kit exceeds that version)";
+	ok  $kit->feature_compatibility('2.6.13'),
+		"feature_compatibility('2.6.13') is true (kit exceeds that version)";
+	ok !$kit->feature_compatibility('2.9.0'),
+		"feature_compatibility('2.9.0') is false (kit is below that version)";
+	ok !$kit->feature_compatibility('3.0.0'),
+		"feature_compatibility('3.0.0') is false (kit is well below that version)";
+
+	# Invalid version string must die
+	quietly {
+		throws_ok { $kit->feature_compatibility('not-a-version') }
+			qr/Invalid base version/,
+			"feature_compatibility() dies on an invalid version string";
+	};
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 13: secrets_store and uses_credhub defaults
+# ---------------------------------------------------------------------------
+subtest 'secrets_store and uses_credhub' => sub {
+	my $kit = kit(test => '0.0.1');
+	# t/src/simple/kit.yml has no secrets_store key; default is 'vault'
+
+	is $kit->secrets_store(), 'vault',
+		"secrets_store() defaults to 'vault' when not specified in kit.yml";
+
+	ok !$kit->uses_credhub(),
+		"uses_credhub() is false when secrets_store is 'vault'";
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 14: required_configs defaults (no required_configs in kit.yml)
+# ---------------------------------------------------------------------------
+subtest 'required_configs' => sub {
+	my $kit = kit(test => '0.0.1');
+	# simple kit.yml has no required_configs key
+
+	# blueprint hook requires cloud config by default
+	my @bp_req = $kit->required_configs('blueprint');
+	cmp_deeply(\@bp_req, ['cloud'],
+		"required_configs('blueprint') returns ['cloud'] by default");
+
+	# cloud-config hook never requires any config
+	my @cc_req = $kit->required_configs('cloud-config');
+	cmp_deeply(\@cc_req, [],
+		"required_configs('cloud-config') returns empty list");
+
+	# check hook requires cloud config (when GENESIS_CONFIG_NO_CHECK is not set)
+	{
+		local $ENV{GENESIS_CONFIG_NO_CHECK};
+		delete $ENV{GENESIS_CONFIG_NO_CHECK};
+		my @chk_req = $kit->required_configs('check');
+		cmp_deeply(\@chk_req, ['cloud'],
+			"required_configs('check') returns ['cloud'] when GENESIS_CONFIG_NO_CHECK is not set");
+	}
+
+	# Some hook that is not blueprint/check/manifest requires nothing
+	my @other = $kit->required_configs('info');
+	cmp_deeply(\@other, [],
+		"required_configs('info') returns empty list by default");
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 15: required_connectivity returns empty list when not declared
+# ---------------------------------------------------------------------------
+subtest 'required_connectivity' => sub {
+	my $kit = kit(test => '0.0.1');
+	# simple kit.yml has no required_connectivity key
+
+	my @conns = $kit->required_connectivity();
+	cmp_deeply(\@conns, [],
+		"required_connectivity() returns empty list when not declared in kit.yml");
+
+	my @conns2 = $kit->required_connectivity('blueprint');
+	cmp_deeply(\@conns2, [],
+		"required_connectivity('blueprint') returns empty list when not declared");
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 16: services and provides_service (simple kit has no services key)
+# ---------------------------------------------------------------------------
+subtest 'services and provides_service' => sub {
+	my $kit = kit(test => '0.0.1');
+	# simple kit.yml has no services key
+
+	my @svcs = $kit->services();
+	cmp_deeply(\@svcs, [],
+		"services() returns empty list when not declared in kit.yml");
+
+	# No explicit services declared; fall back to heuristics
+	# kit name is 'test', not 'vault' — so provides_service('vault') => 0
+	ok !$kit->provides_service('vault'),
+		"provides_service('vault') is false for non-vault kit name";
+
+	# Kit id is 'test/0.0.1', does not start with 'bosh/' — so director is false
+	ok !$kit->provides_service('director'),
+		"provides_service('director') is false for non-bosh kit";
+
+	# Arbitrary service also returns 0
+	ok !$kit->provides_service('some-service'),
+		"provides_service('some-service') is false for unknown service";
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 17: requires_iaas and requires_scale return undef when not declared
+# ---------------------------------------------------------------------------
+subtest 'requires_iaas and requires_scale' => sub {
+	my $kit = kit(test => '0.0.1');
+
+	my $iaas = $kit->requires_iaas(undef);
+	ok !defined($iaas),
+		"requires_iaas() returns undef when not declared in kit.yml";
+
+	my $scale = $kit->requires_scale(undef);
+	ok !defined($scale),
+		"requires_scale() returns undef when not declared in kit.yml";
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 18: dereferenced_metadata
+# ---------------------------------------------------------------------------
+subtest 'dereferenced_metadata' => sub {
+	my $kit = kit(test => '0.0.1');
+
+	# Simple kit.yml has no ${key} references, so dereferenced == metadata
+	my $lookup = sub { return undef };
+	my $deref = $kit->dereferenced_metadata($lookup);
+	ok defined($deref), "dereferenced_metadata() returns a defined value";
+	is ref($deref), 'HASH', "dereferenced_metadata() returns a hashref";
+	is $deref->{name}, 'simple',
+		"dereferenced_metadata() preserves the kit name";
+
+	# Memoized: second call returns same reference
+	my $deref2 = $kit->dereferenced_metadata($lookup);
+	is $deref2, $deref,
+		"dereferenced_metadata() is memoized (same ref on second call)";
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 19: apply_env_overrides and env_override_files
+# ---------------------------------------------------------------------------
+subtest 'apply_env_overrides and env_override_files' => sub {
+	my $kit = kit(test => '0.0.1');
+
+	# Before any overrides are registered
+	my @files = $kit->env_override_files();
+	cmp_deeply(\@files, [],
+		"env_override_files() returns empty list when no overrides registered");
+
+	# Prime the metadata cache so we can verify it gets cleared
+	$kit->metadata;
+	ok defined($kit->{__metadata}),
+		"metadata cache is populated after calling metadata()";
+
+	# Register overrides — uses real kit path so metadata() can re-read safely
+	my $override = $kit->path('kit.yml');  # a file that exists
+	$kit->apply_env_overrides($override);
+	my @registered = $kit->env_override_files();
+	cmp_deeply(\@registered, [$override],
+		"env_override_files() returns the files passed to apply_env_overrides()");
+
+	# apply_env_overrides clears the cached metadata
+	ok !defined($kit->{__metadata}),
+		"apply_env_overrides() clears the cached metadata";
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 19: extract produces expected directory structure
+# ---------------------------------------------------------------------------
+subtest 'extract' => sub {
+	my $kit = kit(test => '0.0.1');
+
+	# Force extraction by calling path()
+	my $root = $kit->path();
+	ok defined($root) && -d $root,
+		"extract() sets a root directory that exists on disk";
+
+	# kit.yml must be present at root
+	ok -f "$root/kit.yml",
+		"extract() places kit.yml at the root of the workspace";
+
+	# hooks/ directory
+	ok -d "$root/hooks",
+		"extract() creates the hooks/ directory";
+
+	# Specific hook files from simple kit fixture
+	ok -f "$root/hooks/blueprint",
+		"extract() places hooks/blueprint in the workspace";
+	ok -f "$root/hooks/new",
+		"extract() places hooks/new in the workspace";
+
+	# .helper file written by Compiled->extract
+	ok -f "$root/.helper",
+		"extract() writes the .helper sourcing file";
+
+	# Calling path() again does not re-extract (memoized root stays the same)
+	my $root2 = $kit->path();
+	is $root, $root2, "extract() is idempotent; path() returns the same root";
+};
+
+done_testing;

--- a/t/unit-tests/genesis_kit-core.t
+++ b/t/unit-tests/genesis_kit-core.t
@@ -22,7 +22,6 @@ use Genesis::Kit::Compiler;
 # tests moved to integration tests
 
 package mockenv;
-use Data::Dumper;
 
 sub new {
 	my ($class, @features) = @_;
@@ -51,7 +50,7 @@ sub get_environment_variables {
 	$env{GENESIS_VERIFY_VAULT} = $self->vault->verify || "";
 
 	$env{HOOK_ENV_VARS}='setup';
-	$env{GENESIS_VAULT_PREFIX} = $env{GENESIS_SECRETS_PATH} = secrets_path;
+	$env{GENESIS_VAULT_PREFIX} = $env{GENESIS_SECRETS_PATH} = $self->secrets_path;
 	return %env;
 }
 

--- a/t/unit-tests/genesis_kit_compiled-core.t
+++ b/t/unit-tests/genesis_kit_compiled-core.t
@@ -16,7 +16,6 @@ use_ok 'Genesis::Config';
 $Genesis::RC = Genesis::Config->new("$ENV{HOME}/.genesis/config");
 
 use_ok 'Service::Vault::Remote';
-use Genesis::Kit::Compiler;
 
 package mockenv;
 sub new {

--- a/t/unit-tests/genesis_kit_compiled-core.t
+++ b/t/unit-tests/genesis_kit_compiled-core.t
@@ -1,0 +1,577 @@
+#!perl
+use strict;
+use warnings;
+
+use lib 'lib';
+use lib 't';
+use helper;
+use Test::Deep;
+
+use_ok 'Genesis';
+use_ok 'Genesis::Kit';
+use_ok 'Genesis::Kit::Compiled';
+use_ok 'Genesis::Kit::Compiler';
+
+use_ok 'Genesis::Config';
+$Genesis::RC = Genesis::Config->new("$ENV{HOME}/.genesis/config");
+
+use_ok 'Service::Vault::Remote';
+use Genesis::Kit::Compiler;
+
+package mockenv;
+sub new {
+    my ($class, @features) = @_;
+    bless {
+        f     => \@features,
+        vault => Service::Vault::Remote->new(url => "https://localhost:8999", name => "mockvault"),
+    }, $class;
+}
+sub features { @{$_[0]{f}}; }
+sub name { "mock-env"; }
+sub type { "mock-type"; }
+sub secrets_path { "mock/env"; }
+sub use_create_env { 0; }
+sub lookup_bosh_target { wantarray ? ('a-bosh', 'params.bosh') : 'a-bosh'; }
+sub lookup { "a-value" }
+sub bosh_target { 'a-bosh'; }
+sub path { "some/path/some/where".($_[1]?"/$_[1]":""); }
+sub vault { $_[0]->{vault} }
+sub get_environment_variables {
+    my ($self, $hook) = @_;
+    my %env;
+    $env{GENESIS_ROOT}         = $self->path;
+    $env{GENESIS_ENVIRONMENT}  = $self->name;
+    $env{GENESIS_TYPE}         = $self->type;
+    $env{GENESIS_TARGET_VAULT} = $env{SAFE_TARGET} = $self->vault->ref;
+    $env{GENESIS_VERIFY_VAULT} = $self->vault->verify || "";
+    $env{GENESIS_VAULT_PREFIX} = $env{GENESIS_SECRETS_PATH} = $self->secrets_path;
+    return %env;
+}
+package main;
+
+# Helper: compile the t/src/simple fixture into a Compiled kit object.
+# Each call uses a fresh workdir() slot to avoid cross-test interference.
+sub kit {
+    my ($name, $version, $path) = @_;
+    $version ||= 'latest';
+    $path    ||= 't/src/simple';
+    my $tmp  = workdir;
+    my $file;
+    quietly {
+        $file = Genesis::Kit::Compiler->new($path)->compile($name, $version, $tmp, force => 1);
+    };
+    return Genesis::Kit::Compiled->new(
+        name    => $name,
+        version => $version,
+        archive => "$tmp/$file",
+    );
+}
+
+# ---------------------------------------------------------------------------
+# new() — constructor / blessed object
+# ---------------------------------------------------------------------------
+subtest 'new() returns a blessed Genesis::Kit::Compiled object' => sub {
+    my $kit;
+    lives_ok {
+        $kit = kit('mykit', '1.0.0');
+    } 'new() lives with valid arguments';
+
+    ok defined($kit),                        'new() returns a defined value';
+    isa_ok $kit, 'Genesis::Kit::Compiled',   'returned object is a Genesis::Kit::Compiled';
+    isa_ok $kit, 'Genesis::Kit',             'returned object inherits from Genesis::Kit';
+};
+
+# ---------------------------------------------------------------------------
+# new() — archive path stored correctly
+# ---------------------------------------------------------------------------
+subtest 'new() stores the archive path on the object' => sub {
+    my $tmp  = workdir;
+    my $file;
+    quietly {
+        $file = Genesis::Kit::Compiler->new('t/src/simple')->compile('arch', '2.0.0', $tmp, force => 1);
+    };
+    my $archive_path = "$tmp/$file";
+
+    my $kit = Genesis::Kit::Compiled->new(
+        name    => 'arch',
+        version => '2.0.0',
+        archive => $archive_path,
+    );
+
+    is $kit->{source}, $archive_path,
+        'archive path is stored in {source} field';
+};
+
+# ---------------------------------------------------------------------------
+# new() — missing required parameters die
+# ---------------------------------------------------------------------------
+subtest 'new() dies when archive is missing' => sub {
+    throws_ok {
+        Genesis::Kit::Compiled->new(name => 'x', version => '1.0.0');
+    } qr/Missing required option: archive/,
+        'dies when archive option is absent';
+};
+
+subtest 'new() dies when archive file does not exist' => sub {
+    throws_ok {
+        Genesis::Kit::Compiled->new(
+            name    => 'x',
+            version => '1.0.0',
+            archive => '/no/such/path/x-1.0.0.tar.gz',
+        );
+    } qr/does not exist/,
+        'dies when archive file is not found on disk';
+};
+
+# ---------------------------------------------------------------------------
+# new() — leading 'v' stripped from version
+# ---------------------------------------------------------------------------
+subtest 'new() strips leading v from version during validation' => sub {
+    my $tmp  = workdir;
+    my $file;
+    quietly {
+        $file = Genesis::Kit::Compiler->new('t/src/simple')->compile('vkit', '3.0.0', $tmp, force => 1);
+    };
+
+    # Provide the version with a leading 'v'; the validator must accept it
+    # and the object must store the normalised (no-v) string.
+    my $kit;
+    lives_ok {
+        $kit = Genesis::Kit::Compiled->new(
+            name    => 'vkit',
+            version => 'v3.0.0',
+            archive => "$tmp/$file",
+        );
+    } 'new() accepts version with leading v';
+
+    is $kit->version, '3.0.0',
+        'version() returns the normalised version without leading v';
+};
+
+# ---------------------------------------------------------------------------
+# id()
+# ---------------------------------------------------------------------------
+subtest 'id() returns name/version string' => sub {
+    my $kit = kit('mykit', '1.2.3');
+    is $kit->id, 'mykit/1.2.3', 'id() returns "name/version"';
+};
+
+subtest 'id() reflects the exact name and version passed to new()' => sub {
+    my $kit = kit('alpha', '0.0.1');
+    is $kit->id, 'alpha/0.0.1', 'id() for alpha/0.0.1';
+
+    my $kit2 = kit('beta', '10.20.30');
+    is $kit2->id, 'beta/10.20.30', 'id() for beta/10.20.30';
+};
+
+# ---------------------------------------------------------------------------
+# name()
+# ---------------------------------------------------------------------------
+subtest 'name() returns the kit name' => sub {
+    my $kit = kit('mykit', '1.0.0');
+    is $kit->name, 'mykit', 'name() returns the exact name passed to new()';
+};
+
+# ---------------------------------------------------------------------------
+# version()
+# ---------------------------------------------------------------------------
+subtest 'version() returns the kit version' => sub {
+    my $kit = kit('mykit', '1.0.0');
+    is $kit->version, '1.0.0', 'version() returns the exact version passed to new()';
+};
+
+subtest 'version() does not carry a leading v' => sub {
+    my $tmp = workdir;
+    my $file;
+    quietly {
+        $file = Genesis::Kit::Compiler->new('t/src/simple')->compile('vtest', '2.3.4', $tmp, force => 1);
+    };
+    my $kit = Genesis::Kit::Compiled->new(
+        name    => 'vtest',
+        version => 'v2.3.4',
+        archive => "$tmp/$file",
+    );
+    is $kit->version, '2.3.4', 'version() strips the leading v';
+    unlike $kit->version, qr/^v/, 'version() never starts with v';
+};
+
+# ---------------------------------------------------------------------------
+# is_dev() — compiled kits are not dev kits
+# ---------------------------------------------------------------------------
+subtest 'is_dev() returns false for compiled kits' => sub {
+    my $kit = kit('mykit', '1.0.0');
+    ok !$kit->is_dev, 'is_dev() returns false (0) for a compiled kit';
+};
+
+# ---------------------------------------------------------------------------
+# extract() — first call extracts and returns 1
+# ---------------------------------------------------------------------------
+subtest 'extract() performs extraction on first call' => sub {
+    my $kit = kit('xkit', '1.0.0');
+
+    my $result;
+    lives_ok { $result = $kit->extract } 'extract() lives';
+    is $result, 1, 'extract() returns 1 on first call';
+    ok defined($kit->{root}),     'extract() sets {root} on the object';
+    ok -d $kit->{root},           'extract() root is an existing directory';
+};
+
+# ---------------------------------------------------------------------------
+# extract() — second call is a no-op (memoized), returns undef
+# ---------------------------------------------------------------------------
+subtest 'extract() is memoized — subsequent calls return undef' => sub {
+    my $kit = kit('memokit', '1.0.0');
+    $kit->extract;
+    my $root_after_first = $kit->{root};
+
+    my $second;
+    lives_ok { $second = $kit->extract } 'second extract() call lives';
+    ok !defined($second), 'second extract() call returns undef';
+    is $kit->{root}, $root_after_first, 'root is unchanged after second call';
+};
+
+# ---------------------------------------------------------------------------
+# extract() — expected files are present after extraction
+# ---------------------------------------------------------------------------
+subtest 'extract() produces expected files inside root' => sub {
+    my $kit = kit('filekit', '1.0.0');
+    $kit->extract;
+
+    for my $rel (qw(kit.yml manifest.yml hooks/new hooks/blueprint)) {
+        ok -f $kit->path($rel),
+            "extracted file '$rel' exists";
+    }
+    ok -d $kit->path('hooks'), "extracted directory 'hooks/' exists";
+};
+
+# ---------------------------------------------------------------------------
+# path() — works after extraction
+# ---------------------------------------------------------------------------
+subtest 'path() returns root directory when called with no argument' => sub {
+    my $kit = kit('pkit', '1.0.0');
+    $kit->extract;
+    my $root = $kit->path;
+    ok -d $root, 'path() with no argument returns the extracted root directory';
+};
+
+subtest 'path() appends relative path to root' => sub {
+    my $kit = kit('pkit2', '1.0.0');
+    $kit->extract;
+    my $yml = $kit->path('kit.yml');
+    like $yml, qr{kit\.yml$}, 'path("kit.yml") ends with kit.yml';
+    ok -f $yml, 'path("kit.yml") resolves to an existing file';
+};
+
+subtest 'path() strips leading slashes from argument' => sub {
+    my $kit = kit('pkit3', '1.0.0');
+    $kit->extract;
+    is $kit->path('/kit.yml'), $kit->path('kit.yml'),
+        'path() with leading slash equals path() without leading slash';
+};
+
+# ---------------------------------------------------------------------------
+# metadata() — returns parsed kit.yml contents
+# ---------------------------------------------------------------------------
+subtest 'metadata() returns a hashref with kit.yml data' => sub {
+    my $kit = kit('metakit', '1.0.0');
+
+    my $meta;
+    lives_ok { $meta = $kit->metadata } 'metadata() lives';
+    ok ref($meta) eq 'HASH', 'metadata() returns a hashref';
+    cmp_deeply($meta, superhashof({ name => 'simple' }),
+        'metadata() contains expected name key from kit.yml');
+};
+
+subtest 'metadata() is memoized — returns same hashref on repeated calls' => sub {
+    my $kit = kit('metamemo', '1.0.0');
+    my $first  = $kit->metadata;
+    my $second = $kit->metadata;
+    is $first, $second, 'metadata() returns the same reference on repeated calls';
+};
+
+# ---------------------------------------------------------------------------
+# has_hook() — checks for hook existence
+# ---------------------------------------------------------------------------
+subtest 'has_hook() returns true for hooks that exist' => sub {
+    my $kit = kit('hookkit', '1.0.0');
+
+    ok $kit->has_hook('new'),       'has_hook("new") returns true';
+    ok $kit->has_hook('blueprint'), 'has_hook("blueprint") returns true';
+};
+
+subtest 'has_hook() returns false for hooks that do not exist' => sub {
+    my $kit = kit('hookkit2', '1.0.0');
+
+    ok !$kit->has_hook('secrets'),   'has_hook("secrets") returns false';
+    ok !$kit->has_hook('pre-deploy'), 'has_hook("pre-deploy") returns false';
+    ok !$kit->has_hook('check'),      'has_hook("check") returns false';
+};
+
+# ---------------------------------------------------------------------------
+# kit_bug() — dies with expected message content
+# ---------------------------------------------------------------------------
+subtest 'kit_bug() always dies' => sub {
+    my $kit = kit('bugkit', '1.0.0');
+    quietly {
+        dies_ok { $kit->kit_bug('something went wrong') } 'kit_bug() dies';
+    };
+};
+
+subtest 'kit_bug() message contains kit id' => sub {
+    my $kit = kit('idkit', '1.0.0');
+    quietly {
+        throws_ok { $kit->kit_bug('test message') }
+            qr/idkit\/1\.0\.0/,
+            'kit_bug() error message contains the kit id';
+    };
+};
+
+subtest 'kit_bug() message contains bug-in-kit phrase' => sub {
+    my $kit = kit('phrasekit', '1.0.0');
+    quietly {
+        throws_ok { $kit->kit_bug('test message') }
+            qr/bug .* kit/si,
+            'kit_bug() error message contains "bug ... kit"';
+    };
+};
+
+subtest 'kit_bug() message includes provided message text' => sub {
+    my $kit = kit('msgkit', '1.0.0');
+    my $custom = 'unexpected value in manifest key foo';
+    quietly {
+        throws_ok { $kit->kit_bug($custom) }
+            qr/unexpected value in manifest key foo/i,
+            'kit_bug() includes the caller-supplied message';
+    };
+};
+
+subtest 'kit_bug() references GitHub issues URL for code on github' => sub {
+    # The t/src/simple kit.yml has:
+    #   code: https://github.com/genesis-community/simple-genesis-kit
+    # so kit_bug should append the /issues link.
+    my $kit = kit('githubkit', '1.0.0');
+    quietly {
+        throws_ok { $kit->kit_bug('some defect') }
+            qr{https://github\.com/.*/issues}i,
+            'kit_bug() appends GitHub issues URL when code is a GitHub repo';
+    };
+};
+
+subtest 'kit_bug() sets $! to 2 (ENOENT) before dying' => sub {
+    my $kit = kit('errnkit', '1.0.0');
+    my $errno_val;
+    quietly {
+        eval { $kit->kit_bug('errno test') };
+        $errno_val = 0 + $!;
+    };
+    is $errno_val, 2, 'kit_bug() sets $! to 2 before dying';
+};
+
+# ---------------------------------------------------------------------------
+# check_prereqs() — genesis version requirement
+# ---------------------------------------------------------------------------
+subtest 'check_prereqs() fails when genesis version is too old' => sub {
+    my $kit = kit('prereqkit', '1.0.0');
+    local $Genesis::VERSION = '0.0.1';
+    my $ok;
+    quietly { $ok = $kit->check_prereqs };
+    ok !$ok, 'check_prereqs() fails when genesis version is older than kit minimum';
+};
+
+subtest 'check_prereqs() passes when genesis version is new enough' => sub {
+    my $kit = kit('prereqkit2', '1.0.0');
+    local $Genesis::VERSION = '9.9.9';
+    my $ok;
+    quietly { $ok = $kit->check_prereqs };
+    ok $ok, 'check_prereqs() passes when genesis version meets the minimum';
+};
+
+subtest 'check_prereqs() passes for dev genesis versions' => sub {
+    my $kit = kit('prereqkit3', '1.0.0');
+    local $Genesis::VERSION = 'dev';
+    my $ok;
+    quietly { $ok = $kit->check_prereqs };
+    ok $ok, 'check_prereqs() passes for dev genesis versions';
+};
+
+# ---------------------------------------------------------------------------
+# source_yaml_files() — returns list of YAML files for manifest generation
+# ---------------------------------------------------------------------------
+subtest 'source_yaml_files() returns at least one yaml file' => sub {
+    my $kit  = kit('syamlkit', '1.0.0');
+    my $env  = mockenv->new();
+    my @files;
+    lives_ok { @files = $kit->source_yaml_files($env) }
+        'source_yaml_files() lives with a mock environment';
+    ok scalar(@files) > 0, 'source_yaml_files() returns at least one file';
+};
+
+subtest 'source_yaml_files() returns manifest.yml for feature-less env' => sub {
+    my $kit = kit('syamlkit2', '1.0.0');
+    my $env = mockenv->new();
+    my @files;
+    quietly { @files = $kit->source_yaml_files($env) };
+    cmp_deeply(
+        \@files,
+        [re('\bmanifest\.yml$')],
+        'source_yaml_files() returns manifest.yml for a basic env'
+    );
+};
+
+subtest 'source_yaml_files() is stable across calls with same features' => sub {
+    my $kit = kit('stabkit', '1.0.0');
+    my @f1; quietly { @f1 = $kit->source_yaml_files(mockenv->new()) };
+    my @f2; quietly { @f2 = $kit->source_yaml_files(mockenv->new()) };
+    cmp_deeply(\@f1, \@f2, 'source_yaml_files() returns the same result for identical inputs');
+};
+
+subtest 'source_yaml_files() ignores unknown features in simple kit' => sub {
+    my $kit  = kit('ignkit', '1.0.0');
+    my @base; quietly { @base = $kit->source_yaml_files(mockenv->new()) };
+    my @with; quietly { @with = $kit->source_yaml_files(mockenv->new('bogus', 'unknown')) };
+    cmp_deeply(\@with, \@base,
+        'source_yaml_files() returns the same files regardless of unknown features');
+};
+
+# ---------------------------------------------------------------------------
+# local_kits() — class method to find local kit archives
+# ---------------------------------------------------------------------------
+subtest 'local_kits() returns an empty hashref for an empty directory' => sub {
+    my $scan_dir = workdir('local_kits_empty');
+    my $result;
+    lives_ok {
+        $result = Genesis::Kit::Compiled->local_kits(undef, $scan_dir);
+    } 'local_kits() lives with an empty directory';
+    ok ref($result) eq 'HASH', 'local_kits() returns a hashref';
+    is scalar(keys %$result), 0, 'local_kits() returns an empty hashref for empty dir';
+};
+
+subtest 'local_kits() finds valid kit tarballs' => sub {
+    my $scan_dir = workdir('local_kits_find');
+    mk_test_kit('myapp', '1.2.3', $scan_dir);
+
+    my $result;
+    lives_ok {
+        $result = Genesis::Kit::Compiled->local_kits(undef, $scan_dir);
+    } 'local_kits() lives with a valid kit present';
+
+    ok exists($result->{myapp}),          'local_kits() finds kit by name';
+    ok exists($result->{myapp}{'1.2.3'}), 'local_kits() finds kit by version';
+    isa_ok $result->{myapp}{'1.2.3'}, 'Genesis::Kit::Compiled',
+        'local_kits() entry is a Genesis::Kit::Compiled object';
+};
+
+subtest 'local_kits() finds multiple kits in the same directory' => sub {
+    my $scan_dir = workdir('local_kits_multi');
+    mk_test_kit('alpha', '1.0.0', $scan_dir);
+    mk_test_kit('beta',  '2.0.0', $scan_dir);
+
+    my $result = Genesis::Kit::Compiled->local_kits(undef, $scan_dir);
+
+    ok exists($result->{alpha}{'1.0.0'}), 'local_kits() finds alpha/1.0.0';
+    ok exists($result->{beta}{'2.0.0'}),  'local_kits() finds beta/2.0.0';
+};
+
+subtest 'local_kits() returns hashref structure with name => version => kit' => sub {
+    my $scan_dir = workdir('local_kits_struct');
+    mk_test_kit('structkit', '3.0.0', $scan_dir);
+
+    my $result = Genesis::Kit::Compiled->local_kits(undef, $scan_dir);
+
+    ok ref($result) eq 'HASH',                           'top level is a hashref';
+    ok ref($result->{structkit}) eq 'HASH',             'name level is a hashref';
+    isa_ok $result->{structkit}{'3.0.0'}, 'Genesis::Kit::Compiled',
+        'version value is a Genesis::Kit::Compiled object';
+};
+
+subtest 'local_kits() skips non-matching filenames' => sub {
+    my $scan_dir = workdir('local_kits_skip');
+    mk_test_kit('real', '1.0.0', $scan_dir);
+    put_file("$scan_dir/README.txt", "some text file");
+    put_file("$scan_dir/not-a-kit", "plain file");
+
+    my $result = Genesis::Kit::Compiled->local_kits(undef, $scan_dir);
+
+    ok  exists($result->{real}{'1.0.0'}), 'local_kits() finds the real kit';
+    ok !exists($result->{README}),        'local_kits() ignores README.txt';
+};
+
+subtest 'local_kits() strips trailing slash from path' => sub {
+    my $scan_dir = workdir('local_kits_slash');
+    mk_test_kit('slashkit', '1.0.0', $scan_dir);
+
+    my $result;
+    lives_ok {
+        $result = Genesis::Kit::Compiled->local_kits(undef, "$scan_dir/");
+    } 'local_kits() accepts path with trailing slash';
+    ok exists($result->{slashkit}{'1.0.0'}),
+        'local_kits() finds kit even when path has trailing slash';
+};
+
+subtest 'local_kits() skips corrupt archives and continues scanning' => sub {
+    my $scan_dir = workdir('local_kits_corrupt');
+    mk_test_kit('good', '1.0.0', $scan_dir);
+    put_file("$scan_dir/bad-2.0.0.tar.gz",
+        "<!DOCTYPE html><html><body>403</body></html>");
+    mk_test_kit('also-good', '3.0.0', $scan_dir);
+
+    my $result;
+    lives_ok {
+        $result = Genesis::Kit::Compiled->local_kits(undef, $scan_dir);
+    } 'local_kits() does not die when a corrupt archive is present';
+
+    ok  exists($result->{good}{'1.0.0'}),        'valid kit good/1.0.0 is found';
+    ok  exists($result->{'also-good'}{'3.0.0'}), 'valid kit also-good/3.0.0 is found';
+    ok !exists($result->{bad}),                  'corrupt kit bad is skipped';
+};
+
+subtest 'local_kits() defaults path to current directory when omitted' => sub {
+    # We just want to ensure the method does not die when called with only
+    # one argument (provider); what it actually finds is environment-dependent.
+    lives_ok {
+        Genesis::Kit::Compiled->local_kits(undef);
+    } 'local_kits() lives when path argument is omitted';
+};
+
+# ---------------------------------------------------------------------------
+# _validate_tar_archive() — internal validation
+# ---------------------------------------------------------------------------
+subtest '_validate_tar_archive() returns an Archive::Tar object for a valid archive' => sub {
+    my $tmp = workdir('validate_ok');
+    my $file = mk_test_kit('val', '1.0.0', $tmp);
+
+    my %opts = (name => 'val', version => '1.0.0', archive => $file);
+    my $tar;
+    lives_ok {
+        $tar = Genesis::Kit::Compiled->_validate_tar_archive(\%opts);
+    } '_validate_tar_archive() lives for a valid archive';
+
+    ok defined($tar), '_validate_tar_archive() returns a defined value';
+    isa_ok $tar, 'Archive::Tar', 'returned value is an Archive::Tar object';
+};
+
+subtest '_validate_tar_archive() infers name and version when not provided' => sub {
+    my $tmp = workdir('validate_infer');
+    my $file = mk_test_kit('inferred', '4.5.6', $tmp);
+
+    my %opts = (archive => $file);   # no name/version
+    lives_ok {
+        Genesis::Kit::Compiled->_validate_tar_archive(\%opts);
+    } '_validate_tar_archive() lives without explicit name/version';
+
+    is $opts{name},    'inferred', 'name is inferred from archive base directory';
+    is $opts{version}, '4.5.6',   'version is inferred from archive base directory';
+};
+
+subtest '_validate_tar_archive() dies when name/version mismatch' => sub {
+    my $tmp = workdir('validate_mismatch');
+    my $file = mk_test_kit('real', '1.0.0', $tmp);
+
+    my %opts = (name => 'wrong', version => '9.9.9', archive => $file);
+    throws_ok {
+        Genesis::Kit::Compiled->_validate_tar_archive(\%opts);
+    } qr/does not match provided name\/version/i,
+        '_validate_tar_archive() dies when name/version does not match archive';
+};
+
+done_testing;

--- a/t/unit-tests/genesis_kit_dev-core.t
+++ b/t/unit-tests/genesis_kit_dev-core.t
@@ -17,7 +17,6 @@ use_ok 'Service::Vault::Remote';
 
 $Genesis::RC = Genesis::Config->new("$ENV{HOME}/.genesis/config");
 
-use Genesis::Kit::Compiler;
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/t/unit-tests/genesis_kit_dev-core.t
+++ b/t/unit-tests/genesis_kit_dev-core.t
@@ -1,0 +1,329 @@
+#!perl
+use strict;
+use warnings;
+
+use lib 'lib';
+use lib 't';
+use helper;
+use Test::Deep;
+
+use_ok 'Genesis';
+use_ok 'Genesis::Kit';
+use_ok 'Genesis::Kit::Dev';
+use_ok 'Genesis::Kit::Compiled';
+use_ok 'Genesis::Kit::Compiler';
+use_ok 'Genesis::Config';
+use_ok 'Service::Vault::Remote';
+
+$Genesis::RC = Genesis::Config->new("$ENV{HOME}/.genesis/config");
+
+use Genesis::Kit::Compiler;
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+sub kit {
+	my ($name, $version, $path) = @_;
+	$version ||= 'latest';
+	$path    ||= 't/src/simple';
+	my $tmp = workdir;
+	my $file;
+	quietly {
+		$file = Genesis::Kit::Compiler->new($path)->compile($name, $version, $tmp, force => 1);
+	};
+	return Genesis::Kit::Compiled->new(
+		name    => $name,
+		version => $version,
+		archive => "$tmp/$file"
+	);
+}
+
+sub decompile_kit {
+	return Genesis::Kit::Dev->new(kit(@_)->path);
+}
+
+# ---------------------------------------------------------------------------
+# Minimal mock environment for source_yaml_files testing
+# ---------------------------------------------------------------------------
+
+package mockenv;
+
+sub new {
+	my ($class, @features) = @_;
+	bless { f => \@features }, $class;
+}
+sub features           { @{$_[0]{f}}; }
+sub name               { "mock-env"; }
+sub type               { "mock-type"; }
+sub secrets_path       { "mock/env"; }
+sub use_create_env     { 0; }
+sub lookup_bosh_target { wantarray ? ('a-bosh', 'params.bosh') : 'a-bosh'; }
+sub lookup             { "a-value" }
+sub bosh_target        { 'a-bosh'; }
+sub path               { "some/path/some/where" . ($_[1] ? "/$_[1]" : ""); }
+
+package main;
+
+# ===========================================================================
+# new($path) — constructor
+# ===========================================================================
+
+subtest 'Genesis::Kit::Dev->new stores source path' => sub {
+	my $compiled = kit('test', '1.0.0');
+	my $src_path = $compiled->path;   # extract and get root
+
+	my $dev = Genesis::Kit::Dev->new($src_path);
+	isa_ok($dev, 'Genesis::Kit::Dev', 'new() returns a Genesis::Kit::Dev object');
+	isa_ok($dev, 'Genesis::Kit',      'Genesis::Kit::Dev inherits from Genesis::Kit');
+
+	is($dev->{source}, $src_path, 'new() stores the path in {source}');
+};
+
+# ===========================================================================
+# name() — always returns "dev"
+# ===========================================================================
+
+subtest 'name() always returns "dev"' => sub {
+	my $dev = decompile_kit('test', '1.0.0');
+	is($dev->name, 'dev', 'name() returns the literal string "dev"');
+
+	# Reconfirm with a differently-named compile target to show it is not
+	# derived from kit.yml.
+	my $dev2 = decompile_kit('mykit', '2.3.4');
+	is($dev2->name, 'dev', 'name() returns "dev" regardless of kit name in kit.yml');
+};
+
+# ===========================================================================
+# version() — always returns "latest"
+# ===========================================================================
+
+subtest 'version() always returns "latest"' => sub {
+	my $dev = decompile_kit('test', '1.0.0');
+	is($dev->version, 'latest', 'version() returns the literal string "latest"');
+
+	my $dev2 = decompile_kit('mykit', '9.9.9');
+	is($dev2->version, 'latest', 'version() returns "latest" regardless of compiled version');
+};
+
+# ===========================================================================
+# is_dev() — always returns 1
+# ===========================================================================
+
+subtest 'is_dev() returns 1' => sub {
+	my $dev = decompile_kit('test', '1.0.0');
+	ok($dev->is_dev, 'is_dev() returns a true value');
+	is($dev->is_dev, 1, 'is_dev() returns exactly 1');
+
+	# Compiled kits return 0 (contrast)
+	my $compiled = kit('test', '1.0.0');
+	ok(!$compiled->is_dev, 'compiled kits report is_dev() as false');
+};
+
+# ===========================================================================
+# id() — "$name/$version (dev)" using kit.yml fields
+# ===========================================================================
+
+subtest 'id() uses kit.yml metadata name and version' => sub {
+	my $dev = decompile_kit('test', '1.0.0');
+
+	# The simple kit fixture kit.yml has:
+	#   name: simple
+	#   (no version field)
+	# So version defaults to 'in-development'.
+	is(
+		$dev->id,
+		'simple/in-development (dev)',
+		'id() returns "<kit.yml name>/in-development (dev)" when kit.yml has no version'
+	);
+
+	# The id always carries "(dev)" regardless of the compiled version label.
+	like($dev->id, qr/\(dev\)$/, 'id() always ends with "(dev)"');
+	unlike($dev->id, qr/^test\//, 'id() does not use the compiled kit name "test"');
+};
+
+# ===========================================================================
+# extract() — copies source to temp workspace
+# ===========================================================================
+
+subtest 'extract() copies dev directory to a temp workspace' => sub {
+	# Use a fresh kit to get a clean extracted path.
+	my $compiled = kit('test', '0.0.1');
+	my $src_path = $compiled->path;   # this is the extracted compiled root
+
+	my $dev = Genesis::Kit::Dev->new($src_path);
+
+	# Before extraction, {root} is not set.
+	ok(!$dev->{root}, 'root is not set before extract()');
+
+	my $result;
+	quietly { $result = $dev->extract; };
+
+	# First call returns 1.
+	is($result, 1, 'extract() returns 1 on first call');
+
+	# root is now set.
+	ok($dev->{root}, 'extract() sets {root}');
+
+	# The root must differ from the source (copy, not a symlink/reuse).
+	isnt($dev->{root}, $src_path, 'extracted root differs from source path');
+
+	# kit.yml must exist in the extracted workspace.
+	ok(-f $dev->path('kit.yml'), 'kit.yml exists in extracted workspace');
+
+	# hooks/ directory must exist.
+	ok(-d $dev->path('hooks'), 'hooks/ directory exists in extracted workspace');
+
+	# manifest.yml must exist.
+	ok(-f $dev->path('manifest.yml'), 'manifest.yml exists in extracted workspace');
+
+	# .helper script was installed.
+	ok(-f "$dev->{root}/.helper", '.helper script was installed after extract()');
+};
+
+subtest 'extract() is memoized (second call is a no-op)' => sub {
+	my $compiled = kit('test', '0.0.2');
+	my $dev = Genesis::Kit::Dev->new($compiled->path);
+
+	quietly { $dev->extract };
+	my $first_root = $dev->{root};
+
+	# Second call.
+	my $result2;
+	quietly { $result2 = $dev->extract };
+
+	is($result2, undef, 'extract() returns nothing (undef) on subsequent calls');
+	is($dev->{root}, $first_root, 'extract() does not change {root} on subsequent calls');
+};
+
+# ===========================================================================
+# kit_bug(@msg) — dies with dev-kit-specific message
+# ===========================================================================
+
+subtest 'kit_bug() dies with dev-kit message and sets $! to 2' => sub {
+	my $dev = decompile_kit('test', '1.0.0');
+
+	quietly {
+		throws_ok {
+			$dev->kit_bug('something broke badly');
+		} qr{something broke badly}i,
+		'kit_bug() includes the caller-supplied message in the exception';
+	};
+
+	quietly {
+		throws_ok {
+			$dev->kit_bug('some failure');
+		} qr{bug in your dev/ kit}i,
+		'kit_bug() mentions "bug in your dev/ kit"';
+	};
+
+	quietly {
+		throws_ok {
+			$dev->kit_bug('some failure');
+		} qr{contact.*author.*you}si,
+		'kit_bug() says to contact the author (you)';
+	};
+
+	my $captured_errno;
+	quietly {
+		eval { $dev->kit_bug('errno check') };
+		$captured_errno = 0+$!;
+	};
+	is($captured_errno, 2, 'kit_bug() sets $! to 2 (ENOENT) before dying');
+};
+
+subtest 'kit_bug() message differs from compiled kit_bug()' => sub {
+	my $compiled = kit('test', '1.0.0');
+	my $dev      = decompile_kit('test', '1.0.0');
+
+	my ($compiled_err, $dev_err);
+	quietly {
+		eval { $compiled->kit_bug('buggy behavior') };
+		$compiled_err = $@;
+		eval { $dev->kit_bug('buggy behavior') };
+		$dev_err = $@;
+	};
+
+	# Compiled kit mentions GitHub issues URL; dev kit mentions "you".
+	like($compiled_err, qr{github\.com.*/issues}i,
+		'compiled kit_bug() mentions the GitHub issues URL');
+	unlike($dev_err, qr{github\.com}i,
+		'dev kit_bug() does NOT mention GitHub');
+	like($dev_err, qr{you}i,
+		'dev kit_bug() tells the developer to contact themselves');
+};
+
+# ===========================================================================
+# Inherited methods from Genesis::Kit
+# ===========================================================================
+
+subtest 'path($relative) returns full path inside the extracted workspace' => sub {
+	my $dev = decompile_kit('test', '1.0.0');
+	quietly { $dev->extract };
+
+	my $root = $dev->path;
+	ok(-d $root, 'path() with no arg returns the workspace root directory');
+
+	my $kit_yml = $dev->path('kit.yml');
+	is($kit_yml, "$root/kit.yml", 'path("kit.yml") appends relative path to root');
+	ok(-f $kit_yml, 'path("kit.yml") points to an existing file');
+
+	# Leading slashes are stripped.
+	is($dev->path('/hooks/blueprint'), "$root/hooks/blueprint",
+		'path() strips leading slashes from the relative argument');
+};
+
+subtest 'glob($pattern) matches files in the extracted workspace' => sub {
+	my $dev = decompile_kit('test', '1.0.0');
+	quietly { $dev->extract };
+
+	my @yml = $dev->glob('*.yml');
+	ok(scalar @yml > 0, 'glob("*.yml") returns at least one result');
+	ok((grep { $_ eq 'kit.yml' } @yml), 'glob("*.yml") finds kit.yml');
+
+	my @hooks = $dev->glob('hooks/*');
+	ok(scalar @hooks > 0, 'glob("hooks/*") returns at least one result');
+};
+
+subtest 'has_hook($name) checks for hook existence in extracted workspace' => sub {
+	my $dev = decompile_kit('test', '1.0.0');
+	quietly { $dev->extract };
+
+	ok($dev->has_hook('blueprint'), 'has_hook("blueprint") returns true for existing hook');
+	ok($dev->has_hook('new'),       'has_hook("new") returns true for existing hook');
+	ok(!$dev->has_hook('secrets'),  'has_hook("secrets") returns false for missing hook');
+};
+
+subtest 'metadata() parses kit.yml from the dev directory' => sub {
+	my $dev = decompile_kit('test', '1.0.0');
+
+	my $meta;
+	quietly { $meta = $dev->metadata };
+
+	ok(defined $meta, 'metadata() returns a defined value');
+	is(ref $meta, 'HASH', 'metadata() returns a hash reference');
+	is($meta->{name}, 'simple', 'metadata()->{name} equals "simple" from kit.yml');
+
+	# Subsequent calls return the same data (memoization).
+	my $meta2;
+	quietly { $meta2 = $dev->metadata };
+	cmp_deeply($meta2, $meta, 'subsequent calls to metadata() return the same data');
+};
+
+subtest 'check_prereqs() performs genesis version check' => sub {
+	my $dev = decompile_kit('test', '1.0.0');
+
+	# kit.yml has genesis_version_min: 2.8.0 — the test suite sets
+	# $Genesis::VERSION to '999.999.999' (via GENESIS_TESTING), so it passes.
+	local $Genesis::VERSION = '999.999.999';
+	my $ok;
+	quietly { $ok = $dev->check_prereqs };
+	ok($ok, 'check_prereqs() passes when genesis version satisfies genesis_version_min');
+
+	local $Genesis::VERSION = '0.0.1';
+	my $not_ok;
+	quietly { $not_ok = $dev->check_prereqs };
+	ok(!$not_ok, 'check_prereqs() fails when genesis version is too old');
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

- Add POD-driven unit tests for the Genesis::Kit module family (99 total test assertions)
- `genesis_kit-core.t` — 27 subtests for Genesis::Kit base class
- `genesis_kit_compiled-core.t` — 51 subtests for Genesis::Kit::Compiled
- `genesis_kit_dev-core.t` — 21 subtests for Genesis::Kit::Dev
- Enable all three in test-manifest.txt, replacing disabled kit-core.t

API-dependent subtests from the original kit-core.t are excluded (belong in integration tests).

## Test plan

- [x] All three test files pass individually (`prove -lv`)
- [x] Full unit test suite passes (pre-existing failures in genesis_env-use_create_env.t and missing genesis_env-bosh.t are unrelated)
- [x] POD validation: 372/373 checks pass (only `provided_configs` missing POD — pre-existing)
- [x] Code review: fixed `$!` errno assertions, added abstract guard and dereferenced_metadata coverage

## Validation findings addressed

- Fixed unreliable `$!` errno capture in both compiled and dev tests (read inside eval scope)
- Fixed `apply_env_overrides` test to use real files instead of fake paths that cause bail()
- Added `Genesis::Kit->new()` abstract class guard test
- Added `dereferenced_metadata()` coverage