### PR TITLE
Add Service::Vault test suite

### DIFF
--- a/t/integration-tests/service_vault-operations.t
+++ b/t/integration-tests/service_vault-operations.t
@@ -20,7 +20,7 @@ is($vault_target, 'genesis-ci-unit-tests',
 # connect_and_validate() requires initialized() == true, which checks for
 # /secret/handshake. Write the handshake via safe CLI before constructing
 # the Service::Vault object.
-system("SAFE_TARGET=$vault_target safe set secret/handshake knock=knock >/dev/null 2>&1");
+system("SAFE_TARGET=$vault_target safe set /secret/handshake knock=knock >/dev/null 2>&1");
 is($? >> 8, 0, 'wrote handshake secret for vault initialization');
 # }}}
 

--- a/t/integration-tests/service_vault-operations.t
+++ b/t/integration-tests/service_vault-operations.t
@@ -1,0 +1,213 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use lib 't';
+use lib 'lib';
+use helper;
+
+use_ok 'Service::Vault';
+use_ok 'Service::Vault::Remote';
+use Genesis;
+
+### Vault startup {{{
+my $vault_target = vault_ok();
+is($vault_target, 'genesis-ci-unit-tests',
+	'vault_ok() returns expected target name');
+# }}}
+
+### Initialize vault for Service::Vault->initialized() {{{
+# connect_and_validate() requires initialized() == true, which checks for
+# /secret/handshake. Write the handshake via safe CLI before constructing
+# the Service::Vault object.
+system("SAFE_TARGET=$vault_target safe set secret/handshake knock=knock >/dev/null 2>&1");
+is($? >> 8, 0, 'wrote handshake secret for vault initialization');
+# }}}
+
+### Construct vault object {{{
+Service::Vault->clear_all();
+my $vault = Service::Vault::Remote->target($vault_target);
+isa_ok($vault, 'Service::Vault::Remote',
+	'target() returns a Service::Vault::Remote object');
+is($vault, Service::Vault->current,
+	'vault is set as current vault after target()');
+# }}}
+
+### Write and read round-trip via safe CLI then get() {{{
+subtest 'write via safe CLI, read via get()' => sub {
+	plan tests => 2;
+
+	my ($out, $rc) = $vault->query('safe', 'set',
+		'secret/test/roundtrip', 'key=hello-world');
+	is($rc, 0, 'safe set command succeeds');
+
+	my $value = $vault->get('secret/test/roundtrip', 'key');
+	is($value, 'hello-world',
+		'get() with key reads back what safe set wrote');
+};
+# }}}
+
+### has() {{{
+subtest 'has() detects presence and absence of paths' => sub {
+	plan tests => 2;
+
+	ok($vault->has('secret/test/roundtrip'),
+		'has() returns true for a written path');
+
+	ok(!$vault->has('secret/test/nonexistent-path-xyz'),
+		'has() returns false for a non-existent path');
+};
+# }}}
+
+### get() with key {{{
+subtest 'get() with key retrieves single value' => sub {
+	plan tests => 1;
+
+	# Data was already written in round-trip subtest above
+	my $value = $vault->get('secret/test/roundtrip', 'key');
+	is($value, 'hello-world',
+		'get() with explicit key returns the correct value');
+};
+# }}}
+
+### get() without key returns all keys as hash ref {{{
+subtest 'get() without key returns all key/value pairs' => sub {
+	plan tests => 3;
+
+	# Write an additional key to the same path
+	$vault->query('safe', 'set',
+		'secret/test/roundtrip', 'second=another-value');
+
+	my $data = $vault->get('secret/test/roundtrip');
+	is(ref($data), 'HASH',
+		'get() without key returns a hash reference');
+	is($data->{key}, 'hello-world',
+		'returned hash contains expected first key');
+	is($data->{second}, 'another-value',
+		'returned hash contains expected second key');
+};
+# }}}
+
+### set() and get() full method round-trip {{{
+subtest 'set() and get() full method round-trip' => sub {
+	plan tests => 3;
+
+	my $returned = $vault->set('secret/test/method-roundtrip',
+		'mykey', 'myvalue');
+	is($returned, 'myvalue',
+		'set() returns the stored value');
+
+	my $read_back = $vault->get('secret/test/method-roundtrip', 'mykey');
+	is($read_back, 'myvalue',
+		'get() reads back the value written by set()');
+
+	# Verify via has() as well
+	ok($vault->has('secret/test/method-roundtrip'),
+		'has() confirms path exists after set()');
+};
+# }}}
+
+### clear() non-recursive {{{
+subtest 'clear() non-recursive removes a single path' => sub {
+	plan tests => 3;
+
+	$vault->set('secret/test/to-clear', 'val', 'should-disappear');
+	ok($vault->has('secret/test/to-clear'),
+		'path exists before clear()');
+
+	$vault->clear('secret/test/to-clear');
+	ok(!$vault->has('secret/test/to-clear'),
+		'has() returns false after non-recursive clear()');
+
+	# Sibling path should be unaffected
+	ok($vault->has('secret/test/roundtrip'),
+		'sibling path is unaffected by non-recursive clear()');
+};
+# }}}
+
+### clear() recursive {{{
+subtest 'clear() recursive removes path tree' => sub {
+	plan tests => 4;
+
+	$vault->set('secret/test/subtree/alpha', 'k', 'v1');
+	$vault->set('secret/test/subtree/beta',  'k', 'v2');
+	$vault->set('secret/test/subtree/gamma', 'k', 'v3');
+
+	ok($vault->has('secret/test/subtree/alpha'), 'alpha exists before clear');
+	ok($vault->has('secret/test/subtree/beta'),  'beta exists before clear');
+
+	$vault->clear('secret/test/subtree', 1);
+
+	ok(!$vault->has('secret/test/subtree/alpha'),
+		'alpha is gone after recursive clear()');
+	ok(!$vault->has('secret/test/subtree/beta'),
+		'beta is gone after recursive clear()');
+};
+# }}}
+
+### paths() enumeration {{{
+subtest 'paths() returns all written paths' => sub {
+	plan tests => 2;
+
+	# Write several distinct paths under a fresh prefix
+	$vault->set('secret/test/paths-test/one',   'x', '1');
+	$vault->set('secret/test/paths-test/two',   'x', '2');
+	$vault->set('secret/test/paths-test/three', 'x', '3');
+
+	my @paths = $vault->paths('secret/test/paths-test');
+	my %path_set = map { $_ => 1 } @paths;
+
+	ok($path_set{'secret/test/paths-test/one'},
+		'paths() includes first written path');
+	ok($path_set{'secret/test/paths-test/two'},
+		'paths() includes second written path');
+};
+# }}}
+
+### paths() with prefix filtering {{{
+subtest 'paths() with prefix returns only matching paths' => sub {
+	plan tests => 2;
+
+	# Write under two separate prefixes
+	$vault->set('secret/test/prefix-a/item', 'k', 'va');
+	$vault->set('secret/test/prefix-b/item', 'k', 'vb');
+
+	my @a_paths = $vault->paths('secret/test/prefix-a');
+	my @b_paths = $vault->paths('secret/test/prefix-b');
+
+	ok((grep { $_ eq 'secret/test/prefix-a/item' } @a_paths),
+		'paths() with prefix-a returns only prefix-a paths');
+	ok(!(grep { $_ eq 'secret/test/prefix-b/item' } @a_paths),
+		'paths() with prefix-a does not include prefix-b paths');
+};
+# }}}
+
+### keys() enumeration in path:key format {{{
+subtest 'keys() returns path:key pairs' => sub {
+	plan tests => 2;
+
+	$vault->set('secret/test/keys-test', 'alpha', 'aval');
+	$vault->set('secret/test/keys-test', 'beta',  'bval');
+
+	my @key_pairs = $vault->keys('secret/test/keys-test');
+	my %kp_set = map { $_ => 1 } @key_pairs;
+
+	ok($kp_set{'secret/test/keys-test:alpha'},
+		'keys() includes the alpha key in path:key format');
+	ok($kp_set{'secret/test/keys-test:beta'},
+		'keys() includes the beta key in path:key format');
+};
+# }}}
+
+### status() returns 'ok' for a running, authenticated vault {{{
+subtest 'status() returns ok for a healthy vault' => sub {
+	plan tests => 1;
+
+	my $status = $vault->status();
+	is($status, 'ok',
+		'status() returns "ok" for a running, authenticated vault');
+};
+# }}}
+
+END { teardown_vault() }
+done_testing;

--- a/t/test-manifest.txt
+++ b/t/test-manifest.txt
@@ -44,6 +44,9 @@ unit-tests/genesis_env-deployment.t
 unit-tests/genesis_env-manifest_helpers.t
 unit-tests/genesis_env_secrets_parser_fromkit-core.t  # FromKit parser defect regression tests
 unit-tests/genesis_env_secrets_store_vault-core.t  # Store::Vault code defect regression tests
+unit-tests/service_vault-core.t          # Service::Vault base class + None with MockWrapper
+unit-tests/service_vault_remote-core.t   # Service::Vault::Remote with mocks
+unit-tests/service_vault_admin-core.t    # Service::Vault::Admin + AppRole with mocks
 unit-tests/genesis_log-get_scope.t
 unit-tests/genesis_secret-base.t
 unit-tests/genesis_secret_dhparams-core.t
@@ -70,6 +73,7 @@ integration-tests/service_github-api.t   # GitHub/GitLab API integration (SSH ke
 integration-tests/service_bosh_stemcells.t  # BOSH stemcell API integration (bosh.io)
 integration-tests/service_bosh_director.t   # BOSH Director constructor patterns (from_exodus, from_alias, from_environment)
 integration-tests/genesis_top-complete.t    # Genesis::Top with external vault and GitHub dependencies
+integration-tests/service_vault-operations.t  # Service::Vault real vault operations
 # Genesis::Env integration tests - require vault/BOSH mocks
 #integration-tests/genesis_env-core.t        # Comprehensive env operations (loading, manifest, deployment)
 #integration-tests/genesis_env-terminate.t   # Environment termination workflow

--- a/t/unit-tests/service_vault-core.t
+++ b/t/unit-tests/service_vault-core.t
@@ -1,0 +1,810 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use lib 't';
+use lib 'lib';
+use helper;
+use Test::Output;
+
+use_ok 'Service::Vault';
+use_ok 'Service::Vault::None';
+use Genesis;
+
+# -------------------------------------------------------------------------
+# Helper: build a raw Service::Vault object without calling external tools
+# -------------------------------------------------------------------------
+sub make_vault {
+	my (%args) = @_;
+	my $url       = $args{url}       // 'https://vault.example.com:8200';
+	my $name      = $args{name}      // 'test-vault';
+	my $verify    = $args{verify}    // 1;
+	my $namespace = $args{namespace} // '';
+	my $strongbox = $args{strongbox};   # undef means "use default (true)"
+	my $mount     = $args{mount}     // '/secret/';
+	return Service::Vault->new($url, $name, $verify, $namespace, $strongbox, $mount);
+}
+
+# -------------------------------------------------------------------------
+# new() constructor
+# -------------------------------------------------------------------------
+subtest 'new() constructor' => sub {
+	plan tests => 10;
+
+	my $v = make_vault();
+
+	is($v->url,       'https://vault.example.com:8200', 'url stored correctly');
+	is($v->name,      'test-vault',                     'name stored correctly');
+	is($v->verify,    1,                                'verify coerced to 1');
+	is($v->namespace, '',                               'namespace defaults to empty string');
+	is($v->strongbox, 1,                                'strongbox defaults to 1');
+
+	# mount normalisation: must be /xxx/ with leading and trailing slash
+	my $v2 = make_vault(mount => 'secret');
+	is($v2->{mount}, '/secret/', 'mount normalised: no slashes -> /secret/');
+
+	my $v3 = make_vault(mount => 'secret/');
+	is($v3->{mount}, '/secret/', 'mount normalised: trailing slash only -> /secret/');
+
+	my $v4 = make_vault(mount => '/secret');
+	is($v4->{mount}, '/secret/', 'mount normalised: leading slash only -> /secret/');
+
+	# strongbox: explicit 0 yields 0
+	my $v5 = make_vault(strongbox => 0);
+	is($v5->strongbox, 0, 'strongbox=0 stored as 0');
+
+	# id is generated and matches pattern name-NNNNNN
+	like($v->{id}, qr/^test-vault-\d{6}$/, 'id is generated with name prefix and 6-digit suffix');
+};
+
+# -------------------------------------------------------------------------
+# Accessor methods
+# -------------------------------------------------------------------------
+subtest 'accessor methods' => sub {
+	plan tests => 8;
+
+	my $v = make_vault(
+		url       => 'https://10.0.0.1:8200',
+		name      => 'my-vault',
+		verify    => 0,
+		namespace => 'admin',
+		strongbox => 1,
+		mount     => '/ops/',
+	);
+
+	is($v->url,       'https://10.0.0.1:8200', 'url()');
+	is($v->name,      'my-vault',              'name()');
+	is($v->verify,    0,                       'verify()');
+	is($v->namespace, 'admin',                 'namespace()');
+	is($v->strongbox, 1,                       'strongbox()');
+	ok($v->tls,                                'tls() true for https URL');
+
+	my $v_http = make_vault(url => 'http://10.0.0.1:8200');
+	ok(!$v_http->tls, 'tls() false for http URL');
+
+	# ref() defaults to url; ref_by_name() switches to name
+	is($v->ref, 'https://10.0.0.1:8200', 'ref() returns url by default');
+};
+
+subtest 'ref_by_name() switches ref mode' => sub {
+	plan tests => 3;
+
+	my $v = make_vault(name => 'named-vault', url => 'https://vault.local:8200');
+	is($v->ref, 'https://vault.local:8200', 'ref() starts as url');
+	my $ret = $v->ref_by_name();
+	is($ret, $v,               'ref_by_name() returns self for chaining');
+	is($v->ref, 'named-vault', 'ref() returns name after ref_by_name()');
+};
+
+# -------------------------------------------------------------------------
+# parse_vault_descriptor
+# -------------------------------------------------------------------------
+subtest 'parse_vault_descriptor() - scalar context' => sub {
+	plan tests => 8;
+
+	my $r = Service::Vault->parse_vault_descriptor('https://vault.example.com:8200');
+	is(ref($r), 'HASH', 'scalar context returns hash ref');
+	is($r->{url},       'https://vault.example.com:8200', 'url parsed');
+	ok($r->{tls},                                          'tls true for https');
+	is($r->{domain},    'vault.example.com',               'domain extracted');
+	is($r->{port},      '8200',                            'port extracted');
+	is($r->{strongbox}, 1,                                 'strongbox defaults to 1');
+	# verify defaults to tls when not explicitly set
+	ok($r->{verify},    'verify defaults to tls value (true for https)');
+	ok(!defined($r->{alias}), 'alias undef when not specified');
+};
+
+subtest 'parse_vault_descriptor() - list context' => sub {
+	plan tests => 5;
+
+	my ($url, $verify, $ns, $alias, $sb) = Service::Vault->parse_vault_descriptor(
+		'https://10.0.0.1:8200/ns1 as local verify no-strongbox'
+	);
+	is($url,    'https://10.0.0.1:8200', 'url in list context');
+	is($verify, 1,                       'verify=1 in list context');
+	is($ns,     'ns1',                   'namespace in list context');
+	is($alias,  'local',                 'alias in list context');
+	is($sb,     0,                       'no-strongbox -> 0');
+};
+
+subtest 'parse_vault_descriptor() - clauses' => sub {
+	plan tests => 6;
+
+	# no-verify with https
+	my $r = Service::Vault->parse_vault_descriptor('https://vault.local:8200 no-verify');
+	is($r->{verify}, 0, 'no-verify sets verify=0');
+	ok($r->{tls},       'tls still true for https');
+
+	# strongbox explicit
+	my $r2 = Service::Vault->parse_vault_descriptor('https://v.local:8200 strongbox');
+	is($r2->{strongbox}, 1, 'explicit strongbox=1');
+
+	# http URL -> tls=false, verify defaults to false
+	my $r3 = Service::Vault->parse_vault_descriptor('http://10.0.0.1:8200');
+	ok(!$r3->{tls},    'tls false for http');
+	ok(!$r3->{verify}, 'verify defaults to false for http');
+
+	# alias via "as" - the regex requires a trailing space after the alias token,
+	# so the alias must be followed by another clause (not at end of string)
+	my $r4 = Service::Vault->parse_vault_descriptor('https://v.local:8200 as my-alias no-verify');
+	is($r4->{alias}, 'my-alias', 'alias parsed from "as" clause');
+};
+
+subtest 'parse_vault_descriptor() - error cases' => sub {
+	plan tests => 2;
+
+	quietly {
+		throws_ok {
+			Service::Vault->parse_vault_descriptor('no-strongbox')
+		} qr/Missing connect clause/i,
+			'dies with "Missing connect clause" when no URL given';
+	};
+
+	quietly {
+		throws_ok {
+			Service::Vault->parse_vault_descriptor('https://v.local:8200 badclause')
+		} qr/Unknown clause/i,
+			'dies with "Unknown clause" for unrecognised token';
+	};
+};
+
+# -------------------------------------------------------------------------
+# build_descriptor
+# -------------------------------------------------------------------------
+subtest 'build_descriptor() contains url and alias' => sub {
+	plan tests => 4;
+
+	my $v = make_vault(
+		url       => 'https://vault.example.com:8200',
+		name      => 'prod',
+		verify    => 1,
+		strongbox => 1,
+	);
+	my $desc = $v->build_descriptor();
+	like($desc, qr{https://vault\.example\.com:8200}, 'descriptor contains url');
+	like($desc, qr/as prod/,                           'descriptor contains alias');
+	unlike($desc, qr/no-verify/,                       'no "no-verify" when verify=1');
+	unlike($desc, qr/no-strongbox/,                    'no "no-strongbox" when strongbox=1');
+};
+
+subtest 'build_descriptor() with no-verify and no-strongbox' => sub {
+	plan tests => 2;
+
+	my $v = make_vault(
+		url       => 'https://vault.example.com:8200',
+		name      => 'prod',
+		verify    => 0,
+		strongbox => 0,
+	);
+	my $desc = $v->build_descriptor();
+	like($desc, qr/no-verify/,    'descriptor contains "no-verify" when verify=0');
+	like($desc, qr/no-strongbox/, 'descriptor contains "no-strongbox" when strongbox=0');
+};
+
+# -------------------------------------------------------------------------
+# set_as_current / is_current / current()
+# -------------------------------------------------------------------------
+subtest 'set_as_current / is_current / current()' => sub {
+	plan tests => 5;
+
+	Service::Vault->clear_all();
+
+	my $v1 = make_vault(name => 'vault-a');
+	my $v2 = make_vault(name => 'vault-b');
+
+	ok(!$v1->is_current, 'vault-a is not current before set_as_current');
+	ok(!Service::Vault->current, 'current() is undef initially');
+
+	$v1->set_as_current();
+	ok($v1->is_current,              'vault-a is_current after set_as_current');
+	is(Service::Vault->current, $v1, 'current() returns vault-a');
+
+	$v2->set_as_current();
+	ok(!$v1->is_current, 'vault-a is no longer current after vault-b set_as_current');
+
+	Service::Vault->clear_all();
+};
+
+# -------------------------------------------------------------------------
+# clear_all()
+# -------------------------------------------------------------------------
+subtest 'clear_all()' => sub {
+	plan tests => 3;
+
+	my $v = make_vault(name => 'cleared-vault');
+	$v->set_as_current();
+	ok(Service::Vault->current, 'current set before clear_all');
+
+	my $ret = Service::Vault->clear_all();
+	ok(!Service::Vault->current, 'current is undef after clear_all');
+
+	# Returns the invocant (the class string when called on class)
+	ok($ret, 'clear_all() returns a truthy value (the invocant)');
+};
+
+# -------------------------------------------------------------------------
+# query() - monkey-patch run() to verify env setup
+# -------------------------------------------------------------------------
+subtest 'query() sets SAFE_TARGET and DEBUG env vars' => sub {
+	plan tests => 3;
+
+	my $v = make_vault(name => 'q-vault', url => 'https://q.vault.local:8200');
+
+	my $run_called   = 0;
+	my %captured_env;
+
+	no warnings 'redefine';
+	local *Service::Vault::run = sub {
+		my $opts = ref($_[0]) eq 'HASH' ? shift : {};
+		$run_called = 1;
+		%captured_env = %{$opts->{env} || {}};
+		return ('output', 0, '');
+	};
+	use warnings 'redefine';
+
+	$v->query('get', '/secret/test:key');
+
+	ok($run_called, 'query() calls run()');
+	is($captured_env{SAFE_TARGET}, $v->ref,
+		'query() sets SAFE_TARGET to vault ref');
+	is($captured_env{DEBUG}, '',
+		'query() clears DEBUG env var');
+};
+
+subtest 'query() prepends "safe" to command' => sub {
+	plan tests => 2;
+
+	my $v = make_vault();
+
+	my @run_cmd;
+	no warnings 'redefine';
+	local *Service::Vault::run = sub {
+		my $opts = ref($_[0]) eq 'HASH' ? shift : {};
+		@run_cmd = @_;
+		return ('', 0, '');
+	};
+	use warnings 'redefine';
+
+	$v->query('get', '/secret/test:key');
+	is($run_cmd[0], 'safe', 'query() prepends "safe" when first arg is not "safe"');
+
+	@run_cmd = ();
+	$v->query('safe', 'get', '/secret/test:key');
+	is($run_cmd[0], 'safe', 'query() does not double-prepend "safe"');
+};
+
+# -------------------------------------------------------------------------
+# get($path, $key) - with key
+# Monkey-patch query() at the package level so internal $self->query() calls
+# are intercepted (MockWrapper only intercepts calls FROM OUTSIDE the object)
+# -------------------------------------------------------------------------
+subtest 'get($path, $key) returns value on success' => sub {
+	plan tests => 2;
+
+	my $v = make_vault();
+	my @query_args;
+
+	no warnings 'redefine';
+	local *Service::Vault::query = sub {
+		my ($self, @args) = @_;
+		@query_args = @args;
+		return ('secret-value', 0, '');
+	};
+	use warnings 'redefine';
+
+	my $result = $v->get('/secret/myapp', 'password');
+	is($result, 'secret-value', 'get() returns output from query on success');
+	like($query_args[-1], qr{/secret/myapp:password}, 'get() constructs path:key arg');
+};
+
+subtest 'get($path, $key) returns undef on failure' => sub {
+	plan tests => 1;
+
+	my $v = make_vault();
+
+	no warnings 'redefine';
+	local *Service::Vault::query = sub { return ('error output', 1, 'err') };
+	use warnings 'redefine';
+
+	my $result = $v->get('/secret/myapp', 'password');
+	ok(!defined($result), 'get() returns undef on non-zero rc');
+};
+
+subtest 'get($path) without key returns hash ref' => sub {
+	plan tests => 2;
+
+	my $v = make_vault();
+	my $yaml = "password: hunter2\nuser: admin\n";
+
+	no warnings 'redefine';
+	local *Service::Vault::query = sub { return ($yaml, 0, '') };
+	use warnings 'redefine';
+
+	my $result = $v->get('/secret/myapp');
+	is(ref($result), 'HASH', 'get() without key returns hash ref');
+	is($result->{password}, 'hunter2', 'get() hash contains parsed YAML value');
+};
+
+subtest 'get($path) without key returns empty hash on error' => sub {
+	plan tests => 2;
+
+	my $v = make_vault();
+
+	no warnings 'redefine';
+	local *Service::Vault::query = sub { return ('', 1, 'error') };
+	use warnings 'redefine';
+
+	my $result = $v->get('/secret/myapp');
+	is(ref($result), 'HASH', 'get() returns hash ref even on error');
+	is(scalar(keys %$result), 0, 'get() returns empty hash on error');
+};
+
+subtest 'get() splits combined path:key from single arg' => sub {
+	plan tests => 2;
+
+	my $v = make_vault();
+	my @query_args;
+
+	no warnings 'redefine';
+	local *Service::Vault::query = sub {
+		my ($self, @args) = @_;
+		@query_args = @args;
+		return ('value', 0, '');
+	};
+	use warnings 'redefine';
+
+	# When path contains a colon, get() splits into path and key
+	$v->get('/secret/myapp:password');
+	# The last arg should be path:key
+	like($query_args[-1], qr{/secret/myapp:password},
+		'path:key form passed through correctly');
+	# The first arg should be an opts hash (redact_output)
+	is(ref($query_args[0]), 'HASH', 'first arg is options hash');
+};
+
+# -------------------------------------------------------------------------
+# set()
+# -------------------------------------------------------------------------
+subtest 'set($path, $key, $value) writes and returns value' => sub {
+	plan tests => 2;
+
+	my $v = make_vault();
+	my @query_args;
+
+	no warnings 'redefine';
+	local *Service::Vault::query = sub {
+		my ($self, @args) = @_;
+		@query_args = @args;
+		return ('', 0, '');
+	};
+	use warnings 'redefine';
+
+	my $result = $v->set('/secret/myapp', 'password', 'hunter2');
+	is($result, 'hunter2', 'set() returns the value written');
+	like(join(' ', grep { !ref($_) } @query_args), qr/password=hunter2/,
+		'set() passes key=value to query');
+};
+
+subtest 'set() dies on failure' => sub {
+	plan tests => 1;
+
+	my $v = make_vault();
+
+	no warnings 'redefine';
+	local *Service::Vault::query = sub { return ('error', 1, '') };
+	use warnings 'redefine';
+
+	quietly {
+		throws_ok {
+			$v->set('/secret/myapp', 'password', 'hunter2');
+		} qr/Could not write/i,
+			'set() throws on non-zero rc from query';
+	};
+};
+
+# -------------------------------------------------------------------------
+# clear()
+# -------------------------------------------------------------------------
+subtest 'clear($path) non-recursive: skips if path absent' => sub {
+	plan tests => 1;
+
+	my $v = make_vault();
+	my $query_called = 0;
+
+	no warnings 'redefine';
+	local *Service::Vault::query = sub { $query_called = 1; return ('', 0, '') };
+	local *Service::Vault::has   = sub { 0 };  # path does not exist
+	use warnings 'redefine';
+
+	$v->clear('/secret/gone');
+	ok(!$query_called, 'clear() does not call query when path does not exist');
+};
+
+subtest 'clear($path) non-recursive: runs rm -f when path exists' => sub {
+	plan tests => 2;
+
+	my $v = make_vault();
+	my @query_args;
+
+	no warnings 'redefine';
+	local *Service::Vault::has   = sub { 1 };
+	local *Service::Vault::query = sub {
+		my ($self, @args) = @_;
+		@query_args = @args;
+		return ('', 0, '');
+	};
+	use warnings 'redefine';
+
+	my $result = $v->clear('/secret/mypath');
+	ok($result, 'clear() returns true on success');
+	like(join(' ', grep { !ref($_) } @query_args), qr/rm.*-f/,
+		'clear() uses "rm -f" for non-recursive');
+};
+
+subtest 'clear($path, 1) recursive: runs rm -rf' => sub {
+	plan tests => 1;
+
+	my $v = make_vault();
+	my @query_args;
+
+	no warnings 'redefine';
+	local *Service::Vault::query = sub {
+		my ($self, @args) = @_;
+		@query_args = @args;
+		return ('', 0, '');
+	};
+	use warnings 'redefine';
+
+	$v->clear('/secret/mypath', 1);
+	like(join(' ', grep { !ref($_) } @query_args), qr/rm.*-rf/,
+		'clear() uses "rm -rf" for recursive');
+};
+
+# -------------------------------------------------------------------------
+# has()
+# -------------------------------------------------------------------------
+subtest 'has() returns true when path exists' => sub {
+	plan tests => 2;
+
+	my $v = make_vault();
+	my @query_args;
+
+	no warnings 'redefine';
+	local *Service::Vault::query = sub {
+		my ($self, @args) = @_;
+		@query_args = @args;
+		# has() uses passfail=>1 so query() returns a single boolean;
+		# simulate rc=0 (path exists) by returning 1
+		return 1;
+	};
+	use warnings 'redefine';
+
+	my $result = $v->has('/secret/myapp');
+	ok($result, 'has() returns true when path exists (query returns 1)');
+	like(join(' ', grep { !ref($_) } @query_args), qr/exists/,
+		'has() uses "exists" subcommand');
+};
+
+subtest 'has() returns false when path absent' => sub {
+	plan tests => 1;
+
+	my $v = make_vault();
+
+	no warnings 'redefine';
+	# has() uses passfail=>1 so query() returns a single boolean;
+	# simulate rc=1 (path absent) by returning 0
+	local *Service::Vault::query = sub { return 0 };
+	use warnings 'redefine';
+
+	my $result = $v->has('/secret/missing');
+	ok(!$result, 'has() returns false when path absent (query returns 0)');
+};
+
+subtest 'has($path, $key) appends key to path' => sub {
+	plan tests => 1;
+
+	my $v = make_vault();
+	my @query_args;
+
+	no warnings 'redefine';
+	local *Service::Vault::query = sub {
+		my ($self, @args) = @_;
+		@query_args = @args;
+		return 1;  # passfail mode returns a single boolean
+	};
+	use warnings 'redefine';
+
+	$v->has('/secret/myapp', 'password');
+	like(join(' ', grep { !ref($_) } @query_args), qr{/secret/myapp:password},
+		'has() appends :key when key arg given');
+};
+
+# -------------------------------------------------------------------------
+# paths()
+# -------------------------------------------------------------------------
+subtest 'paths() with no prefix returns all paths' => sub {
+	plan tests => 2;
+
+	my $v = make_vault();
+
+	no warnings 'redefine';
+	local *Service::Vault::query = sub { return ("/secret/a\n/secret/b\n/secret/c", 0, '') };
+	use warnings 'redefine';
+
+	my @paths = $v->paths();
+	is(scalar(@paths), 3, 'paths() returns all 3 paths');
+	is($paths[0], '/secret/a', 'paths() first entry correct');
+};
+
+subtest 'paths() with prefix passes prefix to query' => sub {
+	plan tests => 2;
+
+	my $v = make_vault();
+	my @query_args;
+
+	no warnings 'redefine';
+	local *Service::Vault::has   = sub { 1 };
+	local *Service::Vault::query = sub {
+		my ($self, @args) = @_;
+		@query_args = @args;
+		return ("/secret/app/pass\n/secret/app/user", 0, '');
+	};
+	use warnings 'redefine';
+
+	my @paths = $v->paths('/secret/app');
+	is(scalar(@paths), 2, 'paths() returns 2 paths under prefix');
+	ok((grep { $_ eq '/secret/app' } @query_args), 'paths() passes prefix to query');
+};
+
+# -------------------------------------------------------------------------
+# keys()
+# -------------------------------------------------------------------------
+subtest 'keys() with no prefix returns all path:key pairs' => sub {
+	plan tests => 2;
+
+	my $v = make_vault();
+
+	no warnings 'redefine';
+	local *Service::Vault::query = sub { return ("/secret/a:pass\n/secret/b:user", 0, '') };
+	use warnings 'redefine';
+
+	my @keys = $v->keys();
+	is(scalar(@keys), 2, 'keys() returns 2 path:key pairs');
+	is($keys[0], '/secret/a:pass', 'keys() first entry correct');
+};
+
+subtest 'keys() passes --keys flag to safe paths' => sub {
+	plan tests => 1;
+
+	my $v = make_vault();
+	my @query_args;
+
+	no warnings 'redefine';
+	local *Service::Vault::query = sub {
+		my ($self, @args) = @_;
+		@query_args = @args;
+		return ('', 0, '');
+	};
+	use warnings 'redefine';
+
+	$v->keys();
+	ok((grep { $_ eq '--keys' } @query_args), 'keys() passes --keys to query');
+};
+
+# -------------------------------------------------------------------------
+# status()
+# Monkey-patch tcp_listening (imported into Service::Vault namespace)
+# and query/authenticated/initialized on the instance via package override
+# -------------------------------------------------------------------------
+subtest 'status() returns "unreachable" when tcp not listening' => sub {
+	plan tests => 1;
+
+	my $v = make_vault(url => 'https://192.0.2.1:8200');
+
+	no warnings 'redefine';
+	local *Service::Vault::tcp_listening = sub { return 'failed' };
+	use warnings 'redefine';
+
+	my $status = $v->status();
+	like($status, qr/unreachable/, 'status() is unreachable when tcp_listening fails');
+};
+
+subtest 'status() returns "sealed" when vault status exit code is 2' => sub {
+	plan tests => 1;
+
+	my $v = make_vault(url => 'https://192.0.2.1:8200');
+
+	no warnings 'redefine';
+	local *Service::Vault::tcp_listening = sub { return 'ok' };
+	local *Service::Vault::query = sub { return ("exit status 2", 1, '') };
+	use warnings 'redefine';
+
+	my $status = $v->status();
+	is($status, 'sealed', 'status() returns "sealed" when vault exits with code 2');
+};
+
+subtest 'status() returns "unreachable" when exit code is 0 (not 2)' => sub {
+	plan tests => 1;
+
+	my $v = make_vault(url => 'https://192.0.2.1:8200');
+
+	# status() code: $out =~ /exit status ([0-9])/; return "sealed" if $1//0 == 2;
+	# Due to Perl operator precedence, $1//0 == 2 parses as ($1 // (0==2)) = ($1 // "").
+	# Any defined non-"0" value of $1 is truthy and triggers "sealed".
+	# "unreachable" requires $1 to be falsy: use "exit status 0" so $1 = "0" (falsy in Perl).
+	no warnings 'redefine';
+	local *Service::Vault::tcp_listening = sub { return 'ok' };
+	local *Service::Vault::query = sub { return ("exit status 0", 1, '') };
+	use warnings 'redefine';
+
+	my $status = $v->status();
+	is($status, 'unreachable', 'status() returns "unreachable" when exit status is 0');
+};
+
+subtest 'status() returns "unauthenticated" when not authenticated' => sub {
+	plan tests => 1;
+
+	my $v = make_vault(url => 'https://192.0.2.1:8200');
+
+	no warnings 'redefine';
+	local *Service::Vault::tcp_listening  = sub { return 'ok' };
+	local *Service::Vault::query          = sub { return ('', 0, '') };
+	local *Service::Vault::authenticated  = sub { 0 };
+	use warnings 'redefine';
+
+	my $status = $v->status();
+	is($status, 'unauthenticated', 'status() returns "unauthenticated" when not authed');
+};
+
+subtest 'status() returns "uninitialized" when not initialized' => sub {
+	plan tests => 1;
+
+	my $v = make_vault(url => 'https://192.0.2.1:8200');
+
+	no warnings 'redefine';
+	local *Service::Vault::tcp_listening  = sub { return 'ok' };
+	local *Service::Vault::query          = sub { return ('', 0, '') };
+	local *Service::Vault::authenticated  = sub { 1 };
+	local *Service::Vault::initialized    = sub { 0 };
+	use warnings 'redefine';
+
+	my $status = $v->status();
+	is($status, 'uninitialized', 'status() returns "uninitialized" when no handshake');
+};
+
+subtest 'status() returns "ok" when reachable, authenticated, and initialized' => sub {
+	plan tests => 1;
+
+	my $v = make_vault(url => 'https://192.0.2.1:8200');
+
+	no warnings 'redefine';
+	local *Service::Vault::tcp_listening  = sub { return 'ok' };
+	local *Service::Vault::query          = sub { return ('', 0, '') };
+	local *Service::Vault::authenticated  = sub { 1 };
+	local *Service::Vault::initialized    = sub { 1 };
+	use warnings 'redefine';
+
+	my $status = $v->status();
+	is($status, 'ok', 'status() returns "ok" when all conditions met');
+};
+
+# -------------------------------------------------------------------------
+# initialized()
+# -------------------------------------------------------------------------
+subtest 'initialized() checks for handshake at secrets mount' => sub {
+	plan tests => 2;
+
+	my $v = make_vault();
+	my @checked;
+
+	no warnings 'redefine';
+	local *Service::Vault::has = sub {
+		my ($self, $path) = @_;
+		push @checked, $path;
+		return $path =~ /handshake/ ? 1 : 0;
+	};
+	use warnings 'redefine';
+
+	my $result = $v->initialized();
+	ok($result, 'initialized() returns true when handshake exists');
+	ok((grep { /handshake/ } @checked), 'initialized() checked a path containing "handshake"');
+};
+
+subtest 'initialized() returns false when no handshake found' => sub {
+	plan tests => 1;
+
+	my $v = make_vault();
+
+	no warnings 'redefine';
+	local *Service::Vault::has = sub { 0 };
+	use warnings 'redefine';
+
+	my $result = $v->initialized();
+	ok(!$result, 'initialized() returns false when handshake not found');
+};
+
+# -------------------------------------------------------------------------
+# Service::Vault::None
+# -------------------------------------------------------------------------
+subtest 'Service::Vault::None - construction' => sub {
+	plan tests => 2;
+
+	my $none = Service::Vault::None->new();
+	ok($none, 'Service::Vault::None->new() returns an object');
+	is(ref($none), 'Service::Vault::None', 'object is a Service::Vault::None');
+};
+
+subtest 'Service::Vault::None - name() returns empty string' => sub {
+	plan tests => 1;
+
+	my $none = Service::Vault::None->new();
+	is($none->name(), '', 'name() returns empty string');
+};
+
+subtest 'Service::Vault::None - status() returns "absent"' => sub {
+	plan tests => 1;
+
+	my $none = Service::Vault::None->new();
+	is($none->status(), 'absent', 'status() returns "absent"');
+};
+
+subtest 'Service::Vault::None - new() ignores arguments' => sub {
+	plan tests => 2;
+
+	my $none = Service::Vault::None->new('ignored', key => 'also-ignored');
+	ok($none, 'new() with arguments still constructs object');
+	is(ref($none), 'Service::Vault::None', 'result is still a Service::Vault::None');
+};
+
+subtest 'Service::Vault::None - AUTOLOAD dies on other methods' => sub {
+	plan tests => 3;
+
+	local $ENV{GENESIS_COMMAND} = 'test-cmd';
+
+	my $none = Service::Vault::None->new();
+
+	throws_ok { $none->get('/secret/x') }
+		qr/bug|should not need a vault/i,
+		'get() triggers AUTOLOAD and dies';
+
+	throws_ok { $none->set('/secret/x', 'k', 'v') }
+		qr/bug|should not need a vault/i,
+		'set() triggers AUTOLOAD and dies';
+
+	throws_ok { $none->has('/secret/x') }
+		qr/bug|should not need a vault/i,
+		'has() triggers AUTOLOAD and dies';
+};
+
+subtest 'Service::Vault::None - sentinel detection patterns' => sub {
+	plan tests => 2;
+
+	my $none = Service::Vault::None->new();
+
+	is(ref($none), 'Service::Vault::None',
+		'ref() check works for class-based detection');
+	is($none->status(), 'absent',
+		'status() check works for value-based detection');
+};
+
+done_testing;

--- a/t/unit-tests/service_vault_admin-core.t
+++ b/t/unit-tests/service_vault_admin-core.t
@@ -1,0 +1,700 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use lib 't';
+use lib 'lib';
+use helper;
+
+our $TODO;
+
+use_ok 'Service::Vault::Admin';
+use_ok 'Service::Vault::Admin::AppRole';
+use Genesis;
+
+# ---------------------------------------------------------------------------
+# Mock vault class
+#
+# Service::Vault::Mock provides proper list-returning query() and set()
+# methods. A queue of responses drives each successive call.  When the
+# queue is exhausted the default response is used.
+# ---------------------------------------------------------------------------
+{
+	package Service::Vault::Mock;
+
+	sub new {
+		my ($class, %args) = @_;
+		return bless {
+			_query_responses => [],   # queue: each element is [output, rc]
+			_set_calls       => [],   # recorded set() invocations
+			_query_calls     => [],   # recorded query() invocations
+			_default_query   => ['', 0],
+			_default_rc      => 0,
+			%args,
+		}, $class;
+	}
+
+	# Push one or more [output, rc] pairs onto the query response queue
+	sub _push_query { my $self = shift; push @{$self->{_query_responses}}, @_; }
+
+	sub query {
+		my ($self, @args) = @_;
+		push @{$self->{_query_calls}}, [@args];
+		my $resp = scalar(@{$self->{_query_responses}})
+			? shift @{$self->{_query_responses}}
+			: $self->{_default_query};
+		return @$resp;
+	}
+
+	sub set {
+		my ($self, @args) = @_;
+		push @{$self->{_set_calls}}, [@args];
+		return 1;
+	}
+
+	sub name { $_[0]->{name} // 'mock-vault' }
+}
+
+sub make_vault {
+	my (%args) = @_;
+	return Service::Vault::Mock->new(name => 'mock-vault', %args);
+}
+
+sub make_admin {
+	my (%args) = @_;
+	my $vault = delete $args{vault} // make_vault();
+	return Service::Vault::Admin->new($vault);
+}
+
+# ---------------------------------------------------------------------------
+# 1. Module loading
+# ---------------------------------------------------------------------------
+# (covered by use_ok above)
+
+# ---------------------------------------------------------------------------
+# 2. Admin::new
+# ---------------------------------------------------------------------------
+subtest 'Admin::new - valid vault succeeds' => sub {
+	my $vault = make_vault();
+	my $admin = Service::Vault::Admin->new($vault);
+	isa_ok($admin, 'Service::Vault::Admin', 'new() returns Admin object');
+};
+
+subtest 'Admin::new - undef vault throws' => sub {
+	throws_ok {
+		Service::Vault::Admin->new(undef);
+	} qr/requires a Service::Vault object/,
+		'new(undef) throws with expected message';
+};
+
+subtest 'Admin::new - non-vault ref throws' => sub {
+	throws_ok {
+		Service::Vault::Admin->new(bless {}, 'SomeOtherClass');
+	} qr/requires a Service::Vault object/,
+		'new() with wrong class throws';
+};
+
+# ---------------------------------------------------------------------------
+# 3. Admin::vault
+# ---------------------------------------------------------------------------
+subtest 'Admin::vault - returns constructor arg' => sub {
+	my $vault = make_vault();
+	my $admin = Service::Vault::Admin->new($vault);
+	is($admin->vault, $vault, 'vault() returns the vault passed to new()');
+};
+
+# ---------------------------------------------------------------------------
+# 4. Admin::approles - lazy creation and caching
+# ---------------------------------------------------------------------------
+subtest 'Admin::approles - lazy AppRole creation' => sub {
+	my $admin = make_admin();
+	my $svc = $admin->approles();
+	isa_ok($svc, 'Service::Vault::Admin::AppRole',
+		'approles() returns an AppRole object');
+};
+
+subtest 'Admin::approles - result is cached' => sub {
+	my $admin = make_admin();
+	my $svc1  = $admin->approles();
+	my $svc2  = $admin->approles();
+	is($svc1, $svc2, 'approles() returns the same object on successive calls');
+};
+
+# ---------------------------------------------------------------------------
+# 5. Admin::policy_exists
+# ---------------------------------------------------------------------------
+subtest 'Admin::policy_exists - found' => sub {
+	my $vault = make_vault();
+	$vault->_push_query(["root\ndefault\nmy-policy\n", 0]);
+	my $admin = Service::Vault::Admin->new($vault);
+	ok($admin->policy_exists('my-policy'),
+		'policy_exists() returns true when policy is listed');
+};
+
+subtest 'Admin::policy_exists - not found' => sub {
+	my $vault = make_vault();
+	$vault->_push_query(["root\ndefault\n", 0]);
+	my $admin = Service::Vault::Admin->new($vault);
+	ok(!$admin->policy_exists('my-policy'),
+		'policy_exists() returns false when policy is absent');
+};
+
+subtest 'Admin::policy_exists - query failure returns 0' => sub {
+	my $vault = make_vault();
+	$vault->_push_query(['error output', 1]);
+	my $admin = Service::Vault::Admin->new($vault);
+	is($admin->policy_exists('my-policy'), 0,
+		'policy_exists() returns 0 when vault query fails');
+};
+
+# ---------------------------------------------------------------------------
+# 6. Admin::create_policy
+# ---------------------------------------------------------------------------
+subtest 'Admin::create_policy - new policy created' => sub {
+	my $vault = make_vault();
+	# Call 1: policy list — empty (policy does not exist)
+	$vault->_push_query(['', 0]);
+	# Call 2: policy write — succeeds
+	$vault->_push_query(['', 0]);
+	my $admin = Service::Vault::Admin->new($vault);
+	my $result = $admin->create_policy('new-policy', 'path "secret/*" {}', prompt => 0);
+	is($result, 1, 'create_policy() returns 1 for new policy');
+};
+
+subtest 'Admin::create_policy - existing policy with overwrite' => sub {
+	my $vault = make_vault();
+	# Call 1: policy list — policy exists
+	$vault->_push_query(["new-policy\n", 0]);
+	# Call 2: policy write — succeeds
+	$vault->_push_query(['', 0]);
+	my $admin = Service::Vault::Admin->new($vault);
+	my $result = $admin->create_policy('new-policy', 'path "secret/*" {}',
+		overwrite => 1, prompt => 0);
+	is($result, 1, 'create_policy() returns 1 when overwriting existing policy');
+};
+
+subtest 'Admin::create_policy - existing policy without overwrite skips' => sub {
+	my $vault = make_vault();
+	$vault->_push_query(["new-policy\n", 0]);
+	my $admin = Service::Vault::Admin->new($vault);
+	my $result = $admin->create_policy('new-policy', 'path "secret/*" {}',
+		prompt => 0, overwrite => 0);
+	is($result, 0, 'create_policy() returns 0 when skipping existing policy');
+};
+
+subtest 'Admin::create_policy - missing name throws' => sub {
+	my $admin = make_admin();
+	throws_ok {
+		$admin->create_policy(undef, 'content');
+	} qr/Policy name is required/,
+		'create_policy() throws when name is missing';
+};
+
+subtest 'Admin::create_policy - missing content throws' => sub {
+	my $admin = make_admin();
+	throws_ok {
+		$admin->create_policy('my-policy', undef);
+	} qr/Policy content is required/,
+		'create_policy() throws when content is missing';
+};
+
+subtest 'Admin::create_policy - vault write failure throws' => sub {
+	my $vault = make_vault();
+	# Call 1: policy list — policy does not exist
+	$vault->_push_query(['', 0]);
+	# Call 2: policy write — fails
+	$vault->_push_query(['vault error message', 1]);
+	my $admin = Service::Vault::Admin->new($vault);
+	throws_ok {
+		$admin->create_policy('my-policy', 'content', prompt => 0);
+	} qr/Failed to create policy/,
+		'create_policy() throws when vault write fails';
+};
+
+# ---------------------------------------------------------------------------
+# 7. Admin::create_approle
+# ---------------------------------------------------------------------------
+subtest 'Admin::create_approle - new role with defaults' => sub {
+	my $vault = make_vault();
+	# vault write auth/approle/role/concourse — succeeds
+	$vault->_push_query(['', 0]);
+	my $admin = Service::Vault::Admin->new($vault);
+
+	no warnings 'redefine';
+	local *Service::Vault::Admin::AppRole::list = sub { () };
+	use warnings 'redefine';
+
+	my $result = $admin->create_approle('concourse', prompt => 0);
+	is($result, 1, 'create_approle() returns 1 for new role');
+};
+
+subtest 'Admin::create_approle - missing name throws' => sub {
+	my $admin = make_admin();
+	throws_ok {
+		$admin->create_approle(undef);
+	} qr/AppRole name is required/,
+		'create_approle() throws when role name is missing';
+};
+
+subtest 'Admin::create_approle - existing role with overwrite deletes and recreates' => sub {
+	my $vault = make_vault();
+	# Call 1: vault delete existing role — succeeds
+	$vault->_push_query(['', 0]);
+	# Call 2: vault write new role — succeeds
+	$vault->_push_query(['', 0]);
+	my $admin = Service::Vault::Admin->new($vault);
+
+	no warnings 'redefine';
+	local *Service::Vault::Admin::AppRole::list = sub { ('concourse') };
+	use warnings 'redefine';
+
+	my $result = $admin->create_approle('concourse', overwrite => 1, prompt => 0);
+	is($result, 1, 'create_approle() returns 1 when overwriting existing role');
+
+	my $has_delete = grep { grep { /vault delete/ } @$_ } @{$vault->{_query_calls}};
+	ok($has_delete, 'create_approle() issued a vault delete for the existing role');
+};
+
+subtest 'Admin::create_approle - existing role without overwrite skips' => sub {
+	my $vault = make_vault();
+	my $admin = Service::Vault::Admin->new($vault);
+
+	no warnings 'redefine';
+	local *Service::Vault::Admin::AppRole::list = sub { ('concourse') };
+	use warnings 'redefine';
+
+	my $result = $admin->create_approle('concourse', prompt => 0, overwrite => 0);
+	ok(!defined($result), 'create_approle() returns undef when skipping existing role');
+};
+
+subtest 'Admin::create_approle - custom config overrides defaults' => sub {
+	my $vault = make_vault();
+	$vault->_push_query(['', 0]);
+	my $admin = Service::Vault::Admin->new($vault);
+
+	no warnings 'redefine';
+	local *Service::Vault::Admin::AppRole::list = sub { () };
+	use warnings 'redefine';
+
+	$admin->create_approle('concourse', token_ttl => '120m', prompt => 0);
+
+	my @all_args = map { @$_ } @{$vault->{_query_calls}};
+	ok((grep { $_ eq 'token_ttl=120m' } @all_args),
+		'create_approle() forwards custom token_ttl to vault write');
+};
+
+# ---------------------------------------------------------------------------
+# 8. Admin::get_approle_credentials
+# ---------------------------------------------------------------------------
+subtest 'Admin::get_approle_credentials - success' => sub {
+	my $vault = make_vault();
+	# Call 1: vault read role-id
+	$vault->_push_query(["my-role-id\n", 0]);
+	# Call 2: vault write secret-id
+	$vault->_push_query(["my-secret-id\n", 0]);
+	my $admin = Service::Vault::Admin->new($vault);
+
+	no warnings 'redefine';
+	local *Service::Vault::Admin::AppRole::list = sub { ('myrole') };
+	use warnings 'redefine';
+
+	my ($role_id, $secret_id) = $admin->get_approle_credentials('myrole');
+	is($role_id,   'my-role-id',   'get_approle_credentials() returns role_id');
+	is($secret_id, 'my-secret-id', 'get_approle_credentials() returns secret_id');
+};
+
+subtest 'Admin::get_approle_credentials - missing name throws' => sub {
+	my $admin = make_admin();
+	throws_ok {
+		$admin->get_approle_credentials(undef);
+	} qr/AppRole name is required/,
+		'get_approle_credentials() throws when name is missing';
+};
+
+subtest 'Admin::get_approle_credentials - nonexistent role throws' => sub {
+	my $vault = make_vault();
+	my $admin = Service::Vault::Admin->new($vault);
+
+	no warnings 'redefine';
+	local *Service::Vault::Admin::AppRole::list = sub { () };
+	use warnings 'redefine';
+
+	throws_ok {
+		$admin->get_approle_credentials('no-such-role');
+	} qr/does not exist/,
+		'get_approle_credentials() throws when role does not exist';
+};
+
+subtest 'Admin::get_approle_credentials - vault query failure throws' => sub {
+	my $vault = make_vault();
+	# Call 1: vault read role-id — fails
+	$vault->_push_query(['error', 1]);
+	# Call 2: vault write secret-id — also fails (rc included for completeness)
+	$vault->_push_query(['error', 1]);
+	my $admin = Service::Vault::Admin->new($vault);
+
+	no warnings 'redefine';
+	local *Service::Vault::Admin::AppRole::list = sub { ('myrole') };
+	use warnings 'redefine';
+
+	throws_ok {
+		$admin->get_approle_credentials('myrole');
+	} qr/Failed to retrieve credentials/,
+		'get_approle_credentials() throws when vault read/write fails';
+};
+
+# ---------------------------------------------------------------------------
+# 9. Admin::store_approle_credentials
+# ---------------------------------------------------------------------------
+subtest 'Admin::store_approle_credentials - success' => sub {
+	my $vault = make_vault();
+	my $admin = Service::Vault::Admin->new($vault);
+	my $result = $admin->store_approle_credentials(
+		'concourse', '/secret/ci/concourse', 'role-abc', 'secret-xyz',
+	);
+	is($result, 1, 'store_approle_credentials() returns 1');
+	is(scalar(@{$vault->{_set_calls}}), 2,
+		'store_approle_credentials() calls set() twice');
+
+	my %written = map { $_->[1] => $_->[2] } @{$vault->{_set_calls}};
+	is($written{'approle-id'},     'role-abc',   'stored approle-id correctly');
+	is($written{'approle-secret'}, 'secret-xyz', 'stored approle-secret correctly');
+};
+
+subtest 'Admin::store_approle_credentials - missing params throws' => sub {
+	my $admin = make_admin();
+
+	throws_ok {
+		$admin->store_approle_credentials('role', '/path', undef, 'secret');
+	} qr/All parameters are required/,
+		'store_approle_credentials() throws when role_id is missing';
+
+	throws_ok {
+		$admin->store_approle_credentials('role', '/path', 'rid', undef);
+	} qr/All parameters are required/,
+		'store_approle_credentials() throws when secret_id is missing';
+
+	throws_ok {
+		$admin->store_approle_credentials(undef, '/path', 'rid', 'sid');
+	} qr/All parameters are required/,
+		'store_approle_credentials() throws when role_name is missing';
+
+	throws_ok {
+		$admin->store_approle_credentials('role', undef, 'rid', 'sid');
+	} qr/All parameters are required/,
+		'store_approle_credentials() throws when storage_path is missing';
+};
+
+# ---------------------------------------------------------------------------
+# 10. Admin::setup_concourse_approle (prompt => 0)
+# ---------------------------------------------------------------------------
+subtest 'Admin::setup_concourse_approle - orchestration chain (no prompt)' => sub {
+	my @method_calls;
+	my $vault = make_vault();
+	my $admin = Service::Vault::Admin->new($vault);
+
+	no warnings 'redefine';
+
+	local *Service::Vault::Admin::AppRole::enable = sub {
+		push @method_calls, 'approles.enable';
+		return 1;
+	};
+
+	local *Service::Vault::Admin::create_policy = sub {
+		push @method_calls, 'create_policy';
+		return 1;
+	};
+
+	local *Service::Vault::Admin::create_approle = sub {
+		push @method_calls, 'create_approle';
+		return 1;
+	};
+
+	local *Service::Vault::Admin::get_approle_credentials = sub {
+		push @method_calls, 'get_approle_credentials';
+		return ('rid', 'sid');
+	};
+
+	local *Service::Vault::Admin::store_approle_credentials = sub {
+		push @method_calls, 'store_approle_credentials';
+		return 1;
+	};
+
+	use warnings 'redefine';
+
+	my $result = $admin->setup_concourse_approle(
+		prompt       => 0,
+		role_name    => 'concourse',
+		overwrite    => 1,
+		storage_base => '/secret/genesis/',
+	);
+
+	is($result, 1, 'setup_concourse_approle() returns 1');
+	is($method_calls[0], 'approles.enable',           'step 1: approles.enable() called');
+	is($method_calls[1], 'create_policy',             'step 2: create_policy() called');
+	is($method_calls[2], 'create_approle',            'step 3: create_approle() called');
+	is($method_calls[3], 'get_approle_credentials',   'step 4: get_approle_credentials() called');
+	is($method_calls[4], 'store_approle_credentials', 'step 5: store_approle_credentials() called');
+};
+
+# ---------------------------------------------------------------------------
+# 11. Admin::setup_genesis_pipelines_approle (prompt => 0)
+# ---------------------------------------------------------------------------
+subtest 'Admin::setup_genesis_pipelines_approle - orchestration chain (no prompt)' => sub {
+	my @method_calls;
+	my $vault = make_vault();
+	my $admin = Service::Vault::Admin->new($vault);
+
+	no warnings 'redefine';
+
+	local *Service::Vault::Admin::AppRole::enable = sub {
+		push @method_calls, 'approles.enable';
+		return 1;
+	};
+
+	local *Service::Vault::Admin::create_policy = sub {
+		push @method_calls, 'create_policy';
+		return 1;
+	};
+
+	local *Service::Vault::Admin::create_approle = sub {
+		push @method_calls, 'create_approle';
+		return 1;
+	};
+
+	local *Service::Vault::Admin::get_approle_credentials = sub {
+		push @method_calls, 'get_approle_credentials';
+		return ('rid', 'sid');
+	};
+
+	local *Service::Vault::Admin::store_approle_credentials = sub {
+		push @method_calls, 'store_approle_credentials';
+		return 1;
+	};
+
+	use warnings 'redefine';
+
+	my $result = $admin->setup_genesis_pipelines_approle(
+		prompt       => 0,
+		role_name    => 'genesis-pipelines',
+		exodus_mount => '/secret/exodus',
+		storage_base => '/secret/ci/',
+		overwrite    => 1,
+	);
+
+	is($result, 1, 'setup_genesis_pipelines_approle() returns 1');
+	is($method_calls[0], 'approles.enable',           'step 1: approles.enable() called');
+	is($method_calls[1], 'create_policy',             'step 2: create_policy() called');
+	is($method_calls[2], 'create_approle',            'step 3: create_approle() called');
+	is($method_calls[3], 'get_approle_credentials',   'step 4: get_approle_credentials() called');
+	is($method_calls[4], 'store_approle_credentials', 'step 5: store_approle_credentials() called');
+};
+
+subtest 'Admin::setup_genesis_pipelines_approle - missing exodus_mount throws' => sub {
+	delete local $ENV{GENESIS_EXODUS_MOUNT};
+	my $admin = make_admin();
+	throws_ok {
+		$admin->setup_genesis_pipelines_approle(prompt => 0);
+	} qr/Cannot find mount for exodus path/,
+		'setup_genesis_pipelines_approle() throws when exodus_mount is absent';
+};
+
+# ---------------------------------------------------------------------------
+# 12. AppRole::new
+# ---------------------------------------------------------------------------
+subtest 'AppRole::new - valid admin succeeds' => sub {
+	my $admin = make_admin();
+	my $ar = Service::Vault::Admin::AppRole->new($admin);
+	isa_ok($ar, 'Service::Vault::Admin::AppRole', 'new() returns AppRole object');
+};
+
+subtest 'AppRole::new - undef admin throws' => sub {
+	throws_ok {
+		Service::Vault::Admin::AppRole->new(undef);
+	} qr/requires a Service::Vault::Admin object/,
+		'AppRole::new(undef) throws with expected message';
+};
+
+subtest 'AppRole::new - wrong class throws' => sub {
+	throws_ok {
+		Service::Vault::Admin::AppRole->new(bless {}, 'WrongClass');
+	} qr/requires a Service::Vault::Admin object/,
+		'AppRole::new() with wrong class throws';
+};
+
+# ---------------------------------------------------------------------------
+# FWT-657 DEFECT: AppRole::new constructor bail message typo
+# ---------------------------------------------------------------------------
+TODO: {
+	local $TODO = "FWT-657: Constructor bail message says 'equires' instead of 'requires'";
+	eval {
+		Service::Vault::Admin::AppRole->new(undef);
+	};
+	like($@, qr/\brequires\b/,
+		'AppRole::new error message spells "requires" correctly');
+}
+
+# ---------------------------------------------------------------------------
+# 13. AppRole::vault
+# ---------------------------------------------------------------------------
+subtest 'AppRole::vault - returns admin vault' => sub {
+	my $vault = make_vault();
+	my $admin = Service::Vault::Admin->new($vault);
+	my $ar    = Service::Vault::Admin::AppRole->new($admin);
+	is($ar->vault, $vault, 'AppRole::vault() returns the underlying vault object');
+};
+
+# ---------------------------------------------------------------------------
+# 14. AppRole::enabled
+# ---------------------------------------------------------------------------
+subtest 'AppRole::enabled - approle/ key present means enabled' => sub {
+	my $vault = make_vault();
+	$vault->_push_query(['{"approle/":{"type":"approle"}}', 0]);
+	my $admin = Service::Vault::Admin->new($vault);
+	my $ar    = Service::Vault::Admin::AppRole->new($admin);
+
+	TODO: {
+		local $TODO = "FWT-657: AppRole::enabled() calls read_json_from() which is not imported into the package namespace";
+		my $result = eval { $ar->enabled() };
+		ok(!$@, 'enabled() does not die');
+		ok($result, 'enabled() returns true when approle/ key is present');
+	}
+};
+
+subtest 'AppRole::enabled - approle/ key absent means disabled' => sub {
+	my $vault = make_vault();
+	$vault->_push_query(['{"token/":{"type":"token"}}', 0]);
+	my $admin = Service::Vault::Admin->new($vault);
+	my $ar    = Service::Vault::Admin::AppRole->new($admin);
+
+	TODO: {
+		local $TODO = "FWT-657: AppRole::enabled() calls read_json_from() which is not imported into the package namespace";
+		my $result = eval { $ar->enabled() };
+		ok(!$@, 'enabled() does not die');
+		ok(!$result, 'enabled() returns false when approle/ key is absent');
+	}
+};
+
+# ---------------------------------------------------------------------------
+# 15. AppRole::enable
+# ---------------------------------------------------------------------------
+subtest 'AppRole::enable - already enabled short-circuits' => sub {
+	my $vault = make_vault();
+	$vault->_push_query(['{"approle/":{"type":"approle"}}', 0]);
+	my $admin = Service::Vault::Admin->new($vault);
+	my $ar    = Service::Vault::Admin::AppRole->new($admin);
+
+	TODO: {
+		local $TODO = "FWT-657: AppRole::enable() calls enabled() which calls read_json_from() not imported in package";
+		my $result = eval { $ar->enable() };
+		ok(!$@, 'enable() does not die when already enabled');
+		is($result, 1, 'enable() returns 1 when already enabled');
+		my $enable_calls = grep { grep { /auth enable/ } @$_ } @{$vault->{_query_calls}};
+		is($enable_calls, 0,
+			'enable() does not call vault auth enable when already enabled');
+	}
+};
+
+subtest 'AppRole::enable - not enabled calls vault auth enable' => sub {
+	my $vault = make_vault();
+	# Call 1: vault auth list — approle not present
+	$vault->_push_query(['{"token/":{"type":"token"}}', 0]);
+	# Call 2: vault auth enable approle — succeeds
+	$vault->_push_query(['', 0]);
+	my $admin = Service::Vault::Admin->new($vault);
+	my $ar    = Service::Vault::Admin::AppRole->new($admin);
+
+	TODO: {
+		local $TODO = "FWT-657: AppRole::enable() calls enabled() which calls read_json_from() not imported in package";
+		my $result = eval { $ar->enable() };
+		ok(!$@, 'enable() does not die when needs enabling');
+		is($result, 1, 'enable() returns 1 after enabling');
+		my $enable_calls = grep { grep { /auth enable/ } @$_ } @{$vault->{_query_calls}};
+		ok($enable_calls,
+			'enable() calls vault auth enable when not already enabled');
+	}
+};
+
+subtest 'AppRole::enable - vault failure throws' => sub {
+	my $vault = make_vault();
+	# Call 1: vault auth list — approle not present
+	$vault->_push_query(['{"token/":{"type":"token"}}', 0]);
+	# Call 2: vault auth enable — fails
+	$vault->_push_query(['enable error', 1]);
+	my $admin = Service::Vault::Admin->new($vault);
+	my $ar    = Service::Vault::Admin::AppRole->new($admin);
+
+	TODO: {
+		local $TODO = "FWT-657: AppRole::enable() calls enabled() which calls read_json_from() not imported in package";
+		throws_ok {
+			$ar->enable();
+		} qr/Failed to enable AppRole auth method/,
+			'enable() throws when vault auth enable fails';
+	}
+};
+
+# ---------------------------------------------------------------------------
+# 16. AppRole::list
+# ---------------------------------------------------------------------------
+subtest 'AppRole::list - parses JSON array' => sub {
+	my $vault = make_vault();
+	$vault->_push_query(['["concourse","genesis-pipelines"]', 0]);
+	my $admin = Service::Vault::Admin->new($vault);
+	my $ar    = Service::Vault::Admin::AppRole->new($admin);
+
+	TODO: {
+		local $TODO = "FWT-657: AppRole::list() calls read_json_from() which is not imported into the package namespace";
+		my @roles = eval { $ar->list() };
+		ok(!$@, 'list() does not die');
+		is(scalar(@roles), 2, 'list() returns correct number of roles');
+		ok((grep { $_ eq 'concourse' }         @roles), 'list() includes concourse');
+		ok((grep { $_ eq 'genesis-pipelines' } @roles), 'list() includes genesis-pipelines');
+	}
+};
+
+subtest 'AppRole::list - vault failure returns empty list' => sub {
+	my $vault = make_vault();
+	$vault->_push_query(['', 1]);
+	my $admin = Service::Vault::Admin->new($vault);
+	my $ar    = Service::Vault::Admin::AppRole->new($admin);
+
+	TODO: {
+		local $TODO = "FWT-657: AppRole::list() calls read_json_from() which is not imported into the package namespace";
+		my @roles = eval { $ar->list() };
+		ok(!$@, 'list() does not die on vault failure');
+		is(scalar(@roles), 0, 'list() returns empty list when vault fails');
+	}
+};
+
+# ---------------------------------------------------------------------------
+# 17. AppRole::exists
+# ---------------------------------------------------------------------------
+subtest 'AppRole::exists - found in list' => sub {
+	my $vault = make_vault();
+	$vault->_push_query(['["concourse","genesis-pipelines"]', 0]);
+	my $admin = Service::Vault::Admin->new($vault);
+	my $ar    = Service::Vault::Admin::AppRole->new($admin);
+
+	TODO: {
+		local $TODO = "FWT-657: AppRole::exists() delegates to list() which calls read_json_from() not imported in package";
+		my $result = eval { $ar->exists('concourse') };
+		ok(!$@, 'exists() does not die');
+		ok($result, 'exists() returns true when role is in the list');
+	}
+};
+
+subtest 'AppRole::exists - not found' => sub {
+	my $vault = make_vault();
+	$vault->_push_query(['["genesis-pipelines"]', 0]);
+	my $admin = Service::Vault::Admin->new($vault);
+	my $ar    = Service::Vault::Admin::AppRole->new($admin);
+
+	TODO: {
+		local $TODO = "FWT-657: AppRole::exists() delegates to list() which calls read_json_from() not imported in package";
+		my $result = eval { $ar->exists('concourse') };
+		ok(!$@, 'exists() does not die');
+		ok(!$result, 'exists() returns false when role is not in the list');
+	}
+};
+
+done_testing;

--- a/t/unit-tests/service_vault_admin-core.t
+++ b/t/unit-tests/service_vault_admin-core.t
@@ -523,16 +523,13 @@ subtest 'AppRole::new - wrong class throws' => sub {
 };
 
 # ---------------------------------------------------------------------------
-# FWT-657 DEFECT: AppRole::new constructor bail message typo
+# AppRole::new constructor bail message spelling
 # ---------------------------------------------------------------------------
-TODO: {
-	local $TODO = "FWT-657: Constructor bail message says 'equires' instead of 'requires'";
-	eval {
-		Service::Vault::Admin::AppRole->new(undef);
-	};
-	like($@, qr/\brequires\b/,
-		'AppRole::new error message spells "requires" correctly');
-}
+eval {
+	Service::Vault::Admin::AppRole->new(undef);
+};
+like($@, qr/\brequires\b/,
+	'AppRole::new error message spells "requires" correctly');
 
 # ---------------------------------------------------------------------------
 # 13. AppRole::vault
@@ -553,12 +550,9 @@ subtest 'AppRole::enabled - approle/ key present means enabled' => sub {
 	my $admin = Service::Vault::Admin->new($vault);
 	my $ar    = Service::Vault::Admin::AppRole->new($admin);
 
-	TODO: {
-		local $TODO = "FWT-657: AppRole::enabled() calls read_json_from() which is not imported into the package namespace";
-		my $result = eval { $ar->enabled() };
-		ok(!$@, 'enabled() does not die');
-		ok($result, 'enabled() returns true when approle/ key is present');
-	}
+	my $result = eval { $ar->enabled() };
+	ok(!$@, 'enabled() does not die');
+	ok($result, 'enabled() returns true when approle/ key is present');
 };
 
 subtest 'AppRole::enabled - approle/ key absent means disabled' => sub {
@@ -567,12 +561,9 @@ subtest 'AppRole::enabled - approle/ key absent means disabled' => sub {
 	my $admin = Service::Vault::Admin->new($vault);
 	my $ar    = Service::Vault::Admin::AppRole->new($admin);
 
-	TODO: {
-		local $TODO = "FWT-657: AppRole::enabled() calls read_json_from() which is not imported into the package namespace";
-		my $result = eval { $ar->enabled() };
-		ok(!$@, 'enabled() does not die');
-		ok(!$result, 'enabled() returns false when approle/ key is absent');
-	}
+	my $result = eval { $ar->enabled() };
+	ok(!$@, 'enabled() does not die');
+	ok(!$result, 'enabled() returns false when approle/ key is absent');
 };
 
 # ---------------------------------------------------------------------------
@@ -584,15 +575,12 @@ subtest 'AppRole::enable - already enabled short-circuits' => sub {
 	my $admin = Service::Vault::Admin->new($vault);
 	my $ar    = Service::Vault::Admin::AppRole->new($admin);
 
-	TODO: {
-		local $TODO = "FWT-657: AppRole::enable() calls enabled() which calls read_json_from() not imported in package";
-		my $result = eval { $ar->enable() };
-		ok(!$@, 'enable() does not die when already enabled');
-		is($result, 1, 'enable() returns 1 when already enabled');
-		my $enable_calls = grep { grep { /auth enable/ } @$_ } @{$vault->{_query_calls}};
-		is($enable_calls, 0,
-			'enable() does not call vault auth enable when already enabled');
-	}
+	my $result = eval { $ar->enable() };
+	ok(!$@, 'enable() does not die when already enabled');
+	is($result, 1, 'enable() returns 1 when already enabled');
+	my $enable_calls = grep { join(' ', @$_) =~ /auth enable/ } @{$vault->{_query_calls}};
+	is($enable_calls, 0,
+		'enable() does not call vault auth enable when already enabled');
 };
 
 subtest 'AppRole::enable - not enabled calls vault auth enable' => sub {
@@ -604,15 +592,12 @@ subtest 'AppRole::enable - not enabled calls vault auth enable' => sub {
 	my $admin = Service::Vault::Admin->new($vault);
 	my $ar    = Service::Vault::Admin::AppRole->new($admin);
 
-	TODO: {
-		local $TODO = "FWT-657: AppRole::enable() calls enabled() which calls read_json_from() not imported in package";
-		my $result = eval { $ar->enable() };
-		ok(!$@, 'enable() does not die when needs enabling');
-		is($result, 1, 'enable() returns 1 after enabling');
-		my $enable_calls = grep { grep { /auth enable/ } @$_ } @{$vault->{_query_calls}};
-		ok($enable_calls,
-			'enable() calls vault auth enable when not already enabled');
-	}
+	my $result = eval { $ar->enable() };
+	ok(!$@, 'enable() does not die when needs enabling');
+	is($result, 1, 'enable() returns 1 after enabling');
+	my $enable_calls = grep { join(' ', @$_) =~ /auth enable/ } @{$vault->{_query_calls}};
+	ok($enable_calls,
+		'enable() calls vault auth enable when not already enabled');
 };
 
 subtest 'AppRole::enable - vault failure throws' => sub {
@@ -624,13 +609,10 @@ subtest 'AppRole::enable - vault failure throws' => sub {
 	my $admin = Service::Vault::Admin->new($vault);
 	my $ar    = Service::Vault::Admin::AppRole->new($admin);
 
-	TODO: {
-		local $TODO = "FWT-657: AppRole::enable() calls enabled() which calls read_json_from() not imported in package";
-		throws_ok {
-			$ar->enable();
-		} qr/Failed to enable AppRole auth method/,
-			'enable() throws when vault auth enable fails';
-	}
+	throws_ok {
+		$ar->enable();
+	} qr/Failed to enable AppRole auth method/,
+		'enable() throws when vault auth enable fails';
 };
 
 # ---------------------------------------------------------------------------
@@ -642,14 +624,11 @@ subtest 'AppRole::list - parses JSON array' => sub {
 	my $admin = Service::Vault::Admin->new($vault);
 	my $ar    = Service::Vault::Admin::AppRole->new($admin);
 
-	TODO: {
-		local $TODO = "FWT-657: AppRole::list() calls read_json_from() which is not imported into the package namespace";
-		my @roles = eval { $ar->list() };
-		ok(!$@, 'list() does not die');
-		is(scalar(@roles), 2, 'list() returns correct number of roles');
-		ok((grep { $_ eq 'concourse' }         @roles), 'list() includes concourse');
-		ok((grep { $_ eq 'genesis-pipelines' } @roles), 'list() includes genesis-pipelines');
-	}
+	my @roles = eval { $ar->list() };
+	ok(!$@, 'list() does not die');
+	is(scalar(@roles), 2, 'list() returns correct number of roles');
+	ok((grep { $_ eq 'concourse' }         @roles), 'list() includes concourse');
+	ok((grep { $_ eq 'genesis-pipelines' } @roles), 'list() includes genesis-pipelines');
 };
 
 subtest 'AppRole::list - vault failure returns empty list' => sub {
@@ -658,12 +637,9 @@ subtest 'AppRole::list - vault failure returns empty list' => sub {
 	my $admin = Service::Vault::Admin->new($vault);
 	my $ar    = Service::Vault::Admin::AppRole->new($admin);
 
-	TODO: {
-		local $TODO = "FWT-657: AppRole::list() calls read_json_from() which is not imported into the package namespace";
-		my @roles = eval { $ar->list() };
-		ok(!$@, 'list() does not die on vault failure');
-		is(scalar(@roles), 0, 'list() returns empty list when vault fails');
-	}
+	my @roles = eval { $ar->list() };
+	ok(!$@, 'list() does not die on vault failure');
+	is(scalar(@roles), 0, 'list() returns empty list when vault fails');
 };
 
 # ---------------------------------------------------------------------------
@@ -675,12 +651,9 @@ subtest 'AppRole::exists - found in list' => sub {
 	my $admin = Service::Vault::Admin->new($vault);
 	my $ar    = Service::Vault::Admin::AppRole->new($admin);
 
-	TODO: {
-		local $TODO = "FWT-657: AppRole::exists() delegates to list() which calls read_json_from() not imported in package";
-		my $result = eval { $ar->exists('concourse') };
-		ok(!$@, 'exists() does not die');
-		ok($result, 'exists() returns true when role is in the list');
-	}
+	my $result = eval { $ar->exists('concourse') };
+	ok(!$@, 'exists() does not die');
+	ok($result, 'exists() returns true when role is in the list');
 };
 
 subtest 'AppRole::exists - not found' => sub {
@@ -689,12 +662,9 @@ subtest 'AppRole::exists - not found' => sub {
 	my $admin = Service::Vault::Admin->new($vault);
 	my $ar    = Service::Vault::Admin::AppRole->new($admin);
 
-	TODO: {
-		local $TODO = "FWT-657: AppRole::exists() delegates to list() which calls read_json_from() not imported in package";
-		my $result = eval { $ar->exists('concourse') };
-		ok(!$@, 'exists() does not die');
-		ok(!$result, 'exists() returns false when role is not in the list');
-	}
+	my $result = eval { $ar->exists('concourse') };
+	ok(!$@, 'exists() does not die');
+	ok(!$result, 'exists() returns false when role is not in the list');
 };
 
 done_testing;

--- a/t/unit-tests/service_vault_remote-core.t
+++ b/t/unit-tests/service_vault_remote-core.t
@@ -1,0 +1,592 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use lib 't';
+use lib 'lib';
+use helper;
+use Test::Output;
+
+use_ok 'Service::Vault';
+use_ok 'Service::Vault::Remote';
+use Genesis;
+
+# -------------------------------------------------------------------------
+# Helper: build a raw Service::Vault::Remote object without external tools
+# -------------------------------------------------------------------------
+sub make_remote {
+	my (%args) = @_;
+	my $url       = $args{url}       // 'https://vault.example.com:8200';
+	my $name      = $args{name}      // 'test-vault';
+	my $verify    = $args{verify}    // 1;
+	my $namespace = $args{namespace} // '';
+	my $strongbox = $args{strongbox};   # undef means use default (true)
+	my $mount     = $args{mount}     // '/secret/';
+	return Service::Vault::Remote->new($url, $name, $verify, $namespace, $strongbox, $mount);
+}
+
+# -------------------------------------------------------------------------
+# Module loading
+# -------------------------------------------------------------------------
+subtest 'module loading' => sub {
+	plan tests => 3;
+
+	ok(Service::Vault::Remote->isa('Service::Vault'),
+		'Service::Vault::Remote ISA Service::Vault');
+
+	my $v = make_remote();
+	is(ref($v), 'Service::Vault::Remote',
+		'make_remote() produces a Service::Vault::Remote object');
+
+	ok($v->can('connect_and_validate'),
+		'Service::Vault::Remote provides connect_and_validate()');
+};
+
+# -------------------------------------------------------------------------
+# connect_and_validate() - already current
+# -------------------------------------------------------------------------
+subtest 'connect_and_validate() - already current' => sub {
+	plan tests => 2;
+
+	Service::Vault->clear_all();
+	my $v = make_remote(name => 'current-vault');
+	$v->set_as_current();
+
+	# When already current, status() must not be called; override it to die
+	# so the test would fail if it were reached.
+	no warnings 'redefine';
+	local *Service::Vault::Remote::status = sub { die 'status() must not be called when already current' };
+	use warnings 'redefine';
+
+	my $ret;
+	lives_ok { $ret = $v->connect_and_validate() }
+		'connect_and_validate() does not die when vault is already current';
+	is($ret, $v, 'connect_and_validate() returns self when already current');
+
+	Service::Vault->clear_all();
+};
+
+# -------------------------------------------------------------------------
+# connect_and_validate() - status ok
+# -------------------------------------------------------------------------
+subtest 'connect_and_validate() - status ok' => sub {
+	plan tests => 3;
+
+	Service::Vault->clear_all();
+	my $v = make_remote(name => 'ok-vault');
+
+	no warnings 'redefine';
+	local *Service::Vault::Remote::status = sub { 'ok' };
+	use warnings 'redefine';
+
+	my $ret;
+	lives_ok { $ret = $v->connect_and_validate() }
+		'connect_and_validate() does not die when status is ok';
+	is(ref($ret), 'Service::Vault::Remote',
+		'connect_and_validate() returns a Service::Vault::Remote');
+	ok($v->is_current,
+		'vault is set as current after connect_and_validate()');
+
+	Service::Vault->clear_all();
+};
+
+# -------------------------------------------------------------------------
+# connect_and_validate() - status unauthenticated then ok after authenticate
+# -------------------------------------------------------------------------
+subtest 'connect_and_validate() - unauthenticated triggers authenticate' => sub {
+	plan tests => 3;
+
+	Service::Vault->clear_all();
+	my $v = make_remote(name => 'unauth-vault');
+
+	my $authenticate_called = 0;
+	no warnings 'redefine';
+	local *Service::Vault::Remote::status = sub { 'unauthenticated' };
+	local *Service::Vault::Remote::authenticate = sub {
+		$authenticate_called = 1;
+		return $_[0];
+	};
+	# After authenticate(), initialized() is called to determine new status.
+	# Return true so the derived status becomes 'ok'.
+	local *Service::Vault::Remote::initialized = sub { 1 };
+	use warnings 'redefine';
+
+	my $ret;
+	lives_ok { $ret = $v->connect_and_validate() }
+		'connect_and_validate() does not die when vault authenticates successfully';
+	ok($authenticate_called,
+		'authenticate() was called when status was unauthenticated');
+	ok($v->is_current,
+		'vault is set as current after successful authentication');
+
+	Service::Vault->clear_all();
+};
+
+# -------------------------------------------------------------------------
+# connect_and_validate() - sealed vault throws
+# -------------------------------------------------------------------------
+subtest 'connect_and_validate() - sealed vault throws' => sub {
+	plan tests => 1;
+
+	Service::Vault->clear_all();
+	my $v = make_remote(name => 'sealed-vault');
+
+	no warnings 'redefine';
+	local *Service::Vault::Remote::status = sub { 'sealed' };
+	use warnings 'redefine';
+
+	quietly {
+		throws_ok { $v->connect_and_validate() }
+			qr/Could not connect to vault/i,
+			'connect_and_validate() throws when vault is sealed';
+	};
+
+	Service::Vault->clear_all();
+};
+
+# -------------------------------------------------------------------------
+# authenticate() - already authenticated
+# -------------------------------------------------------------------------
+subtest 'authenticate() - already authenticated returns self' => sub {
+	plan tests => 2;
+
+	my $v = make_remote(name => 'authed-vault');
+
+	my $query_called = 0;
+	no warnings 'redefine';
+	local *Service::Vault::Remote::authenticated = sub { 1 };
+	local *Service::Vault::Remote::query = sub { $query_called = 1; return ('', 0) };
+	use warnings 'redefine';
+
+	my $ret = $v->authenticate();
+	is($ret, $v, 'authenticate() returns self when already authenticated');
+	ok(!$query_called, 'query() is not called when already authenticated');
+};
+
+# -------------------------------------------------------------------------
+# authenticate() - approle auth
+# -------------------------------------------------------------------------
+subtest 'authenticate() - approle via VAULT_ROLE_ID / VAULT_SECRET_ID' => sub {
+	plan tests => 2;
+
+	my $v = make_remote(name => 'approle-vault');
+
+	my @query_args;
+	local $ENV{VAULT_ROLE_ID}    = 'my-role-id';
+	local $ENV{VAULT_SECRET_ID}  = 'my-secret-id';
+	delete local $ENV{VAULT_AUTH_TOKEN};
+	delete local $ENV{VAULT_USERNAME};
+	delete local $ENV{VAULT_PASSWORD};
+	delete local $ENV{VAULT_GITHUB_TOKEN};
+
+	my $auth_count = 0;
+	no warnings 'redefine';
+	local *Service::Vault::Remote::authenticated = sub {
+		# First call (guard at top) returns false; subsequent calls return true
+		return ($auth_count++ > 0) ? 1 : 0;
+	};
+	local *Service::Vault::Remote::query = sub {
+		my ($self, @args) = @_;
+		push @query_args, @args;
+		return ('', 0);
+	};
+	use warnings 'redefine';
+
+	my $ret = $v->authenticate();
+	is($ret, $v, 'authenticate() returns self after approle auth');
+	ok((grep { /approle/i } @query_args),
+		'authenticate() issued a query containing "approle"');
+};
+
+# -------------------------------------------------------------------------
+# authenticate() - token auth
+# -------------------------------------------------------------------------
+subtest 'authenticate() - token via VAULT_AUTH_TOKEN' => sub {
+	plan tests => 2;
+
+	my $v = make_remote(name => 'token-vault');
+
+	my @query_args;
+	delete local $ENV{VAULT_ROLE_ID};
+	delete local $ENV{VAULT_SECRET_ID};
+	local $ENV{VAULT_AUTH_TOKEN} = 'hvs.EXAMPLE_TOKEN';
+	delete local $ENV{VAULT_USERNAME};
+	delete local $ENV{VAULT_PASSWORD};
+	delete local $ENV{VAULT_GITHUB_TOKEN};
+
+	my $auth_count = 0;
+	no warnings 'redefine';
+	local *Service::Vault::Remote::authenticated = sub {
+		return ($auth_count++ > 0) ? 1 : 0;
+	};
+	local *Service::Vault::Remote::query = sub {
+		my ($self, @args) = @_;
+		push @query_args, @args;
+		return ('', 0);
+	};
+	use warnings 'redefine';
+
+	my $ret = $v->authenticate();
+	is($ret, $v, 'authenticate() returns self after token auth');
+	ok((grep { /token/i } @query_args),
+		'authenticate() issued a query containing "token"');
+};
+
+# -------------------------------------------------------------------------
+# authenticate() - all methods fail, throws
+# -------------------------------------------------------------------------
+subtest 'authenticate() - all methods fail throws' => sub {
+	plan tests => 1;
+
+	my $v = make_remote(name => 'fail-vault');
+
+	delete local $ENV{VAULT_ROLE_ID};
+	delete local $ENV{VAULT_SECRET_ID};
+	delete local $ENV{VAULT_AUTH_TOKEN};
+	delete local $ENV{VAULT_USERNAME};
+	delete local $ENV{VAULT_PASSWORD};
+	delete local $ENV{VAULT_GITHUB_TOKEN};
+
+	no warnings 'redefine';
+	local *Service::Vault::Remote::authenticated = sub { 0 };
+	use warnings 'redefine';
+
+	quietly {
+		throws_ok { $v->authenticate() }
+			qr/Could not successfully authenticate/i,
+			'authenticate() throws when no credentials available and vault not authenticated';
+	};
+};
+
+# -------------------------------------------------------------------------
+# rebind() - missing env var throws
+# -------------------------------------------------------------------------
+subtest 'rebind() - missing GENESIS_TARGET_VAULT throws' => sub {
+	plan tests => 1;
+
+	delete local $ENV{GENESIS_TARGET_VAULT};
+
+	quietly {
+		throws_ok { Service::Vault::Remote->rebind() }
+			qr/Cannot rebind to vault in callback due to missing environment variables/i,
+			'rebind() throws when GENESIS_TARGET_VAULT is not set';
+	};
+};
+
+# -------------------------------------------------------------------------
+# rebind() - URL lookup: vault found
+# -------------------------------------------------------------------------
+subtest 'rebind() - GENESIS_TARGET_VAULT is a URL, vault found' => sub {
+	plan tests => 2;
+
+	Service::Vault->clear_all();
+	my $v = make_remote(
+		url  => 'https://vault.example.com:8200',
+		name => 'my-vault',
+	);
+
+	local $ENV{GENESIS_TARGET_VAULT} = 'https://vault.example.com:8200';
+
+	no warnings 'redefine';
+	local *Service::Vault::Remote::find = sub {
+		my ($class, %filter) = @_;
+		return ($filter{url} && $filter{url} eq 'https://vault.example.com:8200') ? ($v) : ();
+	};
+	use warnings 'redefine';
+
+	my $ret = Service::Vault::Remote->rebind();
+	ok(defined($ret), 'rebind() returns a vault when URL is found');
+	is($ret, $v, 'rebind() returns the matching vault object');
+
+	Service::Vault->clear_all();
+};
+
+# -------------------------------------------------------------------------
+# rebind() - URL lookup: vault not found throws
+# -------------------------------------------------------------------------
+subtest 'rebind() - GENESIS_TARGET_VAULT is a URL, vault not found throws' => sub {
+	plan tests => 1;
+
+	local $ENV{GENESIS_TARGET_VAULT} = 'https://missing.example.com:8200';
+
+	no warnings 'redefine';
+	local *Service::Vault::Remote::find = sub { () };
+	use warnings 'redefine';
+
+	quietly {
+		throws_ok { Service::Vault::Remote->rebind() }
+			qr/Cannot rebind to vault at address/i,
+			'rebind() throws when URL-based vault is not found';
+	};
+};
+
+# -------------------------------------------------------------------------
+# rebind() - legacy name lookup: matches default
+# -------------------------------------------------------------------------
+subtest 'rebind() - legacy name lookup matches default vault' => sub {
+	plan tests => 2;
+
+	Service::Vault->clear_all();
+	my $v = make_remote(name => 'legacy-vault');
+
+	local $ENV{GENESIS_TARGET_VAULT} = 'legacy-vault';  # not a valid URI
+
+	no warnings 'redefine';
+	local *Service::Vault::Remote::default = sub {
+		return $v;
+	};
+	use warnings 'redefine';
+
+	my $ret = Service::Vault::Remote->rebind();
+	ok(defined($ret), 'rebind() returns a vault for legacy name matching default');
+	is($ret->{name}, 'legacy-vault', 'rebind() returns the default vault in legacy mode');
+
+	Service::Vault->clear_all();
+};
+
+# -------------------------------------------------------------------------
+# rebind() - legacy name: name does not match default returns undef
+# -------------------------------------------------------------------------
+subtest 'rebind() - legacy name not matching default returns undef' => sub {
+	plan tests => 1;
+
+	my $other = make_remote(name => 'other-vault');
+
+	local $ENV{GENESIS_TARGET_VAULT} = 'some-other-name';
+
+	no warnings 'redefine';
+	local *Service::Vault::Remote::default = sub { $other };
+	use warnings 'redefine';
+
+	my $ret = Service::Vault::Remote->rebind();
+	ok(!defined($ret), 'rebind() returns undef when legacy name does not match default');
+};
+
+# -------------------------------------------------------------------------
+# attach() - no url specified throws
+# -------------------------------------------------------------------------
+subtest 'attach() - no url throws' => sub {
+	plan tests => 1;
+
+	quietly {
+		throws_ok { Service::Vault::Remote->attach(verify => 1) }
+			qr/No vault target specified/i,
+			'attach() throws when url is not provided';
+	};
+};
+
+# -------------------------------------------------------------------------
+# attach() - url not a valid URL throws
+# -------------------------------------------------------------------------
+subtest 'attach() - url not valid throws' => sub {
+	plan tests => 1;
+
+	quietly {
+		throws_ok { Service::Vault::Remote->attach(url => 'not-a-url') }
+			qr/Expecting vault target.*to be a url/i,
+			'attach() throws when url is not a valid URL';
+	};
+};
+
+# -------------------------------------------------------------------------
+# attach() - env var resolution ($VAR)
+# -------------------------------------------------------------------------
+subtest 'attach() - env var resolution for url' => sub {
+	plan tests => 1;
+
+	local $ENV{VAULT_ADDR} = 'https://vault.example.com:8200';
+
+	my $v = make_remote(url => 'https://vault.example.com:8200', name => 'env-vault');
+
+	no warnings 'redefine';
+	local *Service::Vault::find = sub {
+		my ($class, %filter) = @_;
+		return ($filter{url} && $filter{url} eq 'https://vault.example.com:8200') ? ($v) : ();
+	};
+	local *Service::Vault::Remote::connect_and_validate = sub { $_[0] };
+	use warnings 'redefine';
+
+	my $ret = Service::Vault::Remote->attach(url => '$VAULT_ADDR');
+	is(ref($ret), 'Service::Vault::Remote',
+		'attach() resolves $ENV_VAR references in url option');
+};
+
+# -------------------------------------------------------------------------
+# attach() - exact URL match, single result
+# -------------------------------------------------------------------------
+subtest 'attach() - exact URL match returns vault' => sub {
+	plan tests => 2;
+
+	my $v = make_remote(
+		url    => 'https://vault.example.com:8200',
+		name   => 'matched-vault',
+		verify => 1,
+	);
+
+	no warnings 'redefine';
+	local *Service::Vault::find = sub {
+		my ($class, %filter) = @_;
+		return ($v);
+	};
+	local *Service::Vault::Remote::connect_and_validate = sub { $_[0] };
+	use warnings 'redefine';
+
+	my $ret = Service::Vault::Remote->attach(
+		url    => 'https://vault.example.com:8200',
+		verify => 1,
+	);
+	ok(defined($ret), 'attach() returns vault when exact match found');
+	is($ret->{name}, 'matched-vault', 'attach() returns the matched vault');
+};
+
+# -------------------------------------------------------------------------
+# attach() - no match, no_vault returns undef
+# -------------------------------------------------------------------------
+subtest 'attach() - no match with no_vault returns undef' => sub {
+	plan tests => 1;
+
+	no warnings 'redefine';
+	local *Service::Vault::find = sub { () };
+	use warnings 'redefine';
+
+	my $ret = Service::Vault::Remote->attach(
+		url      => 'https://missing.example.com:8200',
+		no_vault => 1,
+	);
+	ok(!defined($ret), 'attach() returns undef when no match and no_vault is true');
+};
+
+# -------------------------------------------------------------------------
+# attach() - no match, no no_vault throws
+# -------------------------------------------------------------------------
+subtest 'attach() - no match without no_vault throws' => sub {
+	plan tests => 1;
+
+	no warnings 'redefine';
+	local *Service::Vault::find = sub { () };
+	use warnings 'redefine';
+
+	quietly {
+		throws_ok {
+			Service::Vault::Remote->attach(url => 'https://missing.example.com:8200')
+		} qr/Safe target for.*not found/i,
+			'attach() throws when no match found and no_vault not set';
+	};
+};
+
+# -------------------------------------------------------------------------
+# attach() - multiple matches, alias disambiguation
+# -------------------------------------------------------------------------
+subtest 'attach() - multiple matches resolved by alias' => sub {
+	plan tests => 2;
+
+	my $v1 = make_remote(url => 'https://vault.example.com:8200', name => 'vault-a');
+	my $v2 = make_remote(url => 'https://vault.example.com:8200', name => 'vault-b');
+
+	no warnings 'redefine';
+	local *Service::Vault::find = sub { ($v1, $v2) };
+	local *Service::Vault::Remote::connect_and_validate = sub { $_[0] };
+	use warnings 'redefine';
+
+	my $ret = Service::Vault::Remote->attach(
+		url   => 'https://vault.example.com:8200',
+		alias => 'vault-b',
+	);
+	ok(defined($ret), 'attach() returns vault when alias disambiguates multiple matches');
+	is($ret->{name}, 'vault-b', 'attach() returns the alias-matched vault');
+};
+
+# -------------------------------------------------------------------------
+# attach() - multiple matches, no alias match throws
+# -------------------------------------------------------------------------
+subtest 'attach() - multiple matches without alias match throws' => sub {
+	plan tests => 1;
+
+	my $v1 = make_remote(url => 'https://vault.example.com:8200', name => 'vault-a');
+	my $v2 = make_remote(url => 'https://vault.example.com:8200', name => 'vault-b');
+
+	no warnings 'redefine';
+	local *Service::Vault::find = sub { ($v1, $v2) };
+	use warnings 'redefine';
+
+	quietly {
+		throws_ok {
+			Service::Vault::Remote->attach(
+				url   => 'https://vault.example.com:8200',
+				alias => 'vault-z',  # no match
+			)
+		} qr/Multiple safe targets found/i,
+			'attach() throws when multiple matches and alias does not match any';
+	};
+};
+
+# -------------------------------------------------------------------------
+# target() - known alias, single result
+# -------------------------------------------------------------------------
+subtest 'target() - known alias, single result' => sub {
+	plan tests => 2;
+
+	Service::Vault->clear_all();
+	my $v = make_remote(
+		url  => 'https://vault.example.com:8200',
+		name => 'prod-vault',
+	);
+
+	no warnings 'redefine';
+	local *Service::Vault::_get_targets = sub {
+		my ($target) = @_;
+		return ('https://vault.example.com:8200', 'prod-vault');
+	};
+	local *Service::Vault::Remote::find = sub {
+		my ($class, %filter) = @_;
+		return ($v);
+	};
+	local *Service::Vault::Remote::connect_and_validate = sub { $_[0] };
+	use warnings 'redefine';
+
+	my $ret = Service::Vault::Remote->target('prod-vault');
+	ok(defined($ret), 'target() returns a vault for a known alias');
+	is($ret->{name}, 'prod-vault', 'target() returns the correct vault');
+
+	Service::Vault->clear_all();
+};
+
+# -------------------------------------------------------------------------
+# target() - alias not found throws
+# -------------------------------------------------------------------------
+subtest 'target() - alias not found throws' => sub {
+	plan tests => 1;
+
+	no warnings 'redefine';
+	local *Service::Vault::_get_targets = sub { (undef) };
+	use warnings 'redefine';
+
+	quietly {
+		throws_ok {
+			Service::Vault::Remote->target('no-such-vault')
+		} qr/not found/i,
+			'target() throws when the alias is not found';
+	};
+};
+
+# -------------------------------------------------------------------------
+# target() - multiple targets for same URL throws
+# -------------------------------------------------------------------------
+subtest 'target() - multiple targets for same URL throws' => sub {
+	plan tests => 1;
+
+	no warnings 'redefine';
+	local *Service::Vault::_get_targets = sub {
+		return ('https://vault.example.com:8200', 'vault-a', 'vault-b');
+	};
+	use warnings 'redefine';
+
+	quietly {
+		throws_ok {
+			Service::Vault::Remote->target('vault-a')
+		} qr/Multiple safe targets use url/i,
+			'target() throws when multiple aliases share the same URL';
+	};
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

- 136 tests across 4 new test files for the Service::Vault module ecosystem
- ~80% unit tests using MockWrapper/Mock, ~20% integration tests with real vault
- FWT-657 defects documented with TODO blocks in Admin/AppRole tests
- Test manifest updated with all new entries

## Test Files

| File | Tests | Coverage |
|------|-------|---------|
| `t/unit-tests/service_vault-core.t` | 46 | Base class + None sentinel |
| `t/unit-tests/service_vault_remote-core.t` | 27 | Remote vault |
| `t/unit-tests/service_vault_admin-core.t` | 45 | Admin + AppRole |
| `t/integration-tests/service_vault-operations.t` | 18 | Real vault ops |

## Test plan

- [x] All 4 test files pass individually via `prove -lv`
- [x] `make unit-tests` passes (pre-existing failures in service_bosh-director.t unrelated)
- [x] Integration test passes with clean vault state
- [x] POD validation: 721 checks, 0 failures across all 6 modules
- [x] Code review: no critical issues

Closes FWT-572