### PR TITLE
FWT-569: Genesis::Env unit test completion

### DIFF
--- a/t/test-manifest.txt
+++ b/t/test-manifest.txt
@@ -49,6 +49,14 @@ unit-tests/genesis_env-build_vault_path_components.t
 unit-tests/genesis_env-deployment_cache.t
 unit-tests/genesis_env-deployment.t
 unit-tests/genesis_env-manifest_helpers.t
+# Genesis::Env method coverage (FWT-569)
+unit-tests/genesis_env-lookups.t         # lookup() and lookup_unevaled() variants
+unit-tests/genesis_env-relations.t       # relate() and relate_by_name() environment relationships
+unit-tests/genesis_env-ocfp.t            # is_ocfp(), ocfp_type(), ocfp_env() OCFP configuration
+unit-tests/genesis_env-bosh.t            # _parse_bosh_env(), is_bosh_director(), bosh_env(), bosh_alias()
+unit-tests/genesis_env-exodus.t          # Path construction: secrets/exodus/ci/ocfp_config mount/slug/base
+unit-tests/genesis_env-configs.t         # configs(), required_configs(), has_config() BOSH config mgmt
+unit-tests/genesis_env-vault_ops.t       # get_ancestral_vault(), exodus_lookup(), vault_paths()
 unit-tests/genesis_env_secrets_parser_fromkit-core.t  # FromKit parser defect regression tests
 unit-tests/genesis_env_secrets_store_vault-core.t  # Store::Vault code defect regression tests
 unit-tests/service_vault-core.t          # Service::Vault base class + None with MockWrapper

--- a/t/unit-tests/genesis_env-bosh.t
+++ b/t/unit-tests/genesis_env-bosh.t
@@ -1,0 +1,362 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+
+use lib 'lib';
+use lib 't';
+use helper;
+
+use Test::More;
+use Test::Deep;
+use Test::Exception;
+
+use Genesis;
+$Genesis::VERSION = '999.999.999';
+use_ok 'Genesis::Config';
+$Genesis::RC = Genesis::Config->new("$ENV{HOME}/.genesis/config");
+
+use_ok 'Genesis::Top';
+use_ok 'Genesis::Env';
+
+$ENV{GENESIS_OUTPUT_COLUMNS}=80;
+$ENV{NOCOLOR}=1;
+
+subtest '_parse_bosh_env - simple name only' => sub {
+	plan tests => 5;
+
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file($top->path('us-west-1-preprod.yml'), <<EOF);
+---
+kit:
+  name:    dev
+  version: latest
+genesis:
+  env:      us-west-1-preprod
+  bosh_env: us-west-1-preprod
+EOF
+
+	my $env = $top->load_env('us-west-1-preprod');
+
+	# Scalar context returns hashref
+	my $data = $env->_parse_bosh_env('us-west-1-preprod');
+	isa_ok($data, 'HASH', '_parse_bosh_env in scalar context returns hashref');
+	is($data->{name},         'us-west-1-preprod', 'name field parsed correctly');
+	is($data->{dep_type},     undef,               'dep_type is undef when absent');
+	is($data->{vault_url},    undef,               'vault_url is undef when absent');
+	is($data->{exodus_mount}, undef,               'exodus_mount is undef when absent');
+};
+
+subtest '_parse_bosh_env - name with type' => sub {
+	plan tests => 4;
+
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file($top->path('typed.yml'), <<EOF);
+---
+kit:
+  name:    dev
+  version: latest
+genesis:
+  env:      typed
+  bosh_env: typed
+EOF
+
+	my $env = $top->load_env('typed');
+
+	my $data = $env->_parse_bosh_env('us-west-1-preprod/bosh');
+	is($data->{name},         'us-west-1-preprod', 'name parsed from name/type descriptor');
+	is($data->{dep_type},     'bosh',              'dep_type parsed from name/type descriptor');
+	is($data->{vault_url},    undef,               'vault_url absent when not specified');
+	is($data->{exodus_mount}, undef,               'exodus_mount absent when not specified');
+};
+
+subtest '_parse_bosh_env - full descriptor with URL and mount' => sub {
+	plan tests => 5;
+
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file($top->path('full.yml'), <<EOF);
+---
+kit:
+  name:    dev
+  version: latest
+genesis:
+  env:      full
+  bosh_env: full
+EOF
+
+	my $env = $top->load_env('full');
+
+	my $data = $env->_parse_bosh_env('us-west-1-preprod/bosh@https://vault.example.com/secret/exodus');
+	is($data->{name},         'us-west-1-preprod',       'name parsed from full descriptor');
+	is($data->{dep_type},     'bosh',                    'dep_type parsed from full descriptor');
+	is($data->{vault_url},    'https://vault.example.com', 'vault_url parsed from full descriptor');
+	is($data->{exodus_mount}, 'secret/exodus',           'exodus_mount parsed from full descriptor');
+	is($data->{description},  'us-west-1-preprod/bosh@https://vault.example.com/secret/exodus',
+		'description echoes original descriptor');
+};
+
+subtest '_parse_bosh_env - partial descriptor with mount only (no URL)' => sub {
+	plan tests => 4;
+
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file($top->path('partial.yml'), <<EOF);
+---
+kit:
+  name:    dev
+  version: latest
+genesis:
+  env:      partial
+  bosh_env: partial
+EOF
+
+	my $env = $top->load_env('partial');
+
+	my $data = $env->_parse_bosh_env('us-west-1-preprod/bosh@/secret/exodus');
+	is($data->{name},         'us-west-1-preprod', 'name parsed correctly');
+	is($data->{dep_type},     'bosh',              'dep_type parsed correctly');
+	is($data->{vault_url},    undef,               'vault_url is undef when omitted before slash');
+	is($data->{exodus_mount}, 'secret/exodus',     'exodus_mount parsed when no vault URL');
+};
+
+subtest '_parse_bosh_env - list context returns 4-element list' => sub {
+	plan tests => 4;
+
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file($top->path('listctx.yml'), <<EOF);
+---
+kit:
+  name:    dev
+  version: latest
+genesis:
+  env:      listctx
+  bosh_env: listctx
+EOF
+
+	my $env = $top->load_env('listctx');
+
+	my ($name, $dep_type, $vault_url, $exodus_mount) =
+		$env->_parse_bosh_env('us-west-1-preprod/bosh@https://vault.example.com/secret/exodus');
+
+	is($name,         'us-west-1-preprod',         'list context: name');
+	is($dep_type,     'bosh',                       'list context: dep_type');
+	is($vault_url,    'https://vault.example.com',  'list context: vault_url');
+	is($exodus_mount, 'secret/exodus',              'list context: exodus_mount');
+};
+
+subtest '_parse_bosh_env - bails on empty or undef input' => sub {
+	plan tests => 2;
+
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file($top->path('bail-test.yml'), <<EOF);
+---
+kit:
+  name:    dev
+  version: latest
+genesis:
+  env:      bail-test
+  bosh_env: bail-test
+EOF
+
+	my $env = $top->load_env('bail-test');
+
+	throws_ok { $env->_parse_bosh_env('') }
+		qr/Undefined BOSH environment description/,
+		'_parse_bosh_env bails with empty string';
+
+	throws_ok { $env->_parse_bosh_env(undef) }
+		qr/Undefined BOSH environment description/,
+		'_parse_bosh_env bails with undef';
+};
+
+subtest 'is_bosh_director - true for director kit' => sub {
+	plan tests => 1;
+
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/custom-bosh');
+
+	put_file($top->path('director.yml'), <<EOF);
+---
+kit:
+  name:    dev
+  version: latest
+genesis:
+  env: director
+EOF
+
+	my $env = $top->load_env('director');
+	ok($env->is_bosh_director,
+		'is_bosh_director returns true for kit with director service');
+};
+
+subtest 'is_bosh_director - false for non-director kit' => sub {
+	plan tests => 1;
+
+	my $top = make_top(name => 'cf', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file($top->path('regular.yml'), <<EOF);
+---
+kit:
+  name:    dev
+  version: latest
+genesis:
+  env: regular
+EOF
+
+	my $env = $top->load_env('regular');
+	ok(!$env->is_bosh_director,
+		'is_bosh_director returns false for kit without director service');
+};
+
+subtest 'bosh_env - scalar context returns hashref' => sub {
+	plan tests => 5;
+
+	my $top = make_top(name => 'cf', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file($top->path('us-west-1-preprod.yml'), <<EOF);
+---
+kit:
+  name:    dev
+  version: latest
+genesis:
+  env:      us-west-1-preprod
+  bosh_env: us-west-1-preprod
+EOF
+
+	my $env = $top->load_env('us-west-1-preprod');
+	my $data = $env->bosh_env;
+
+	isa_ok($data, 'HASH', 'bosh_env in scalar context returns hashref');
+	is($data->{name},        'us-west-1-preprod', 'bosh_env hashref has correct name');
+	ok(exists $data->{dep_type},     'bosh_env hashref has dep_type key');
+	ok(exists $data->{vault_url},    'bosh_env hashref has vault_url key');
+	ok(exists $data->{exodus_mount}, 'bosh_env hashref has exodus_mount key');
+};
+
+subtest 'bosh_env - list context returns values' => sub {
+	plan tests => 5;
+
+	my $top = make_top(name => 'cf', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file($top->path('us-west-1-prod.yml'), <<EOF);
+---
+kit:
+  name:    dev
+  version: latest
+genesis:
+  env:      us-west-1-prod
+  bosh_env: us-west-1-prod/bosh
+EOF
+
+	my $env = $top->load_env('us-west-1-prod');
+	my ($name, $dep_type, $vault_url, $exodus_mount, $description) = $env->bosh_env;
+
+	is($name,        'us-west-1-prod', 'bosh_env list: name');
+	is($dep_type,    'bosh',           'bosh_env list: dep_type');
+	is($vault_url,   undef,            'bosh_env list: vault_url (undef when absent)');
+	is($exodus_mount, undef,           'bosh_env list: exodus_mount (undef when absent)');
+	is($description, 'us-west-1-prod/bosh', 'bosh_env list: description echoes original');
+};
+
+subtest 'bosh_env - returns empty hashref for create-env environment' => sub {
+	plan tests => 2;
+
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/custom-bosh');
+
+	put_file($top->path('create-env-dir.yml'), <<EOF);
+---
+kit:
+  name:    dev
+  version: latest
+genesis:
+  env: create-env-dir
+EOF
+
+	my $env = $top->load_env('create-env-dir');
+
+	# Director kits with no bosh_env return empty hashref (they ARE the director)
+	my $data = $env->bosh_env;
+	isa_ok($data, 'HASH', 'bosh_env returns hashref even for director env');
+	is(scalar keys %$data, 0, 'bosh_env returns empty hashref for director with no bosh_env set');
+};
+
+subtest 'bosh_alias - returns name for standard environment' => sub {
+	plan tests => 1;
+
+	my $top = make_top(name => 'cf', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file($top->path('us-west-1-sandbox.yml'), <<EOF);
+---
+kit:
+  name:    dev
+  version: latest
+genesis:
+  env:      us-west-1-sandbox
+  bosh_env: us-west-1-sandbox
+EOF
+
+	my $env = $top->load_env('us-west-1-sandbox');
+	is($env->bosh_alias, 'us-west-1-sandbox',
+		'bosh_alias returns BOSH director name');
+};
+
+subtest 'bosh_alias - returns undef for director (create-env) environment' => sub {
+	plan tests => 1;
+
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/custom-bosh');
+
+	put_file($top->path('proto-bosh.yml'), <<EOF);
+---
+kit:
+  name:    dev
+  version: latest
+genesis:
+  env: proto-bosh
+EOF
+
+	my $env = $top->load_env('proto-bosh');
+	is($env->bosh_alias, undef,
+		'bosh_alias returns undef for director environment with no bosh_env');
+};
+
+subtest 'bosh_alias - uses dep_type name from parsed descriptor' => sub {
+	plan tests => 1;
+
+	my $top = make_top(name => 'cf', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file($top->path('us-east-1-prod.yml'), <<EOF);
+---
+kit:
+  name:    dev
+  version: latest
+genesis:
+  env:      us-east-1-prod
+  bosh_env: us-east-1-bosh/bosh
+EOF
+
+	my $env = $top->load_env('us-east-1-prod');
+	is($env->bosh_alias, 'us-east-1-bosh',
+		'bosh_alias returns name portion when bosh_env includes a type');
+};
+
+done_testing;
+
+# vim: ts=2 sw=2 sts=2 noet fdm=marker foldlevel=1 nu

--- a/t/unit-tests/genesis_env-configs.t
+++ b/t/unit-tests/genesis_env-configs.t
@@ -1,0 +1,389 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+
+use lib 'lib';
+use lib 't';
+use helper;
+
+use Test::More;
+use Test::Deep;
+use Test::Exception;
+
+use Genesis;
+$Genesis::VERSION = '999.999.999';
+use_ok 'Genesis::Config';
+$Genesis::RC = Genesis::Config->new("$ENV{HOME}/.genesis/config");
+
+use_ok 'Genesis::Top';
+use_ok 'Genesis::Env';
+
+$ENV{GENESIS_OUTPUT_COLUMNS} = 80;
+$ENV{NOCOLOR} = 1;
+
+# Helper: build a standard non-create-env environment backed by 'simple' kit
+sub make_simple_env {
+	my ($env_name, %extra_genesis) = @_;
+	my $top = make_top(name => 'cf', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	my $genesis_block = "  env: $env_name\n";
+	for my $k (keys %extra_genesis) {
+		$genesis_block .= "  $k: $extra_genesis{$k}\n";
+	}
+
+	put_file($top->path("$env_name.yml"), <<"EOF");
+---
+kit:
+  name:    dev
+  version: latest
+  features: []
+genesis:
+$genesis_block
+EOF
+
+	return $top->load_env($env_name);
+}
+
+# Helper: build a create-env environment backed by 'bosh-3.0.0-create-env' kit
+sub make_create_env {
+	my ($env_name) = @_;
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/bosh-3.0.0-create-env');
+
+	put_file($top->path("$env_name.yml"), <<"EOF");
+---
+kit:
+  name:    dev
+  version: latest
+  features: []
+genesis:
+  env: $env_name
+EOF
+
+	return $top->load_env($env_name);
+}
+
+# ======================================================================
+# configs()
+# ======================================================================
+
+subtest 'configs - empty when nothing registered' => sub {
+	plan tests => 3;
+
+	# Isolate from any GENESIS_*_CONFIG vars in the outer environment
+	local %ENV = %ENV;
+	delete $ENV{$_} for grep { /^GENESIS_[A-Z0-9_]+_CONFIG/ } keys %ENV;
+
+	my $env = make_simple_env('no-configs');
+	$env->{__configs} = {};
+
+	my @list = $env->configs;
+	is(scalar(@list), 0, 'configs() returns empty list when nothing registered');
+
+	my $ref = $env->configs;
+	is(ref($ref), 'ARRAY', 'configs() in scalar context returns an arrayref');
+	is(scalar(@{$ref}), 0, 'configs() arrayref is empty when nothing registered');
+};
+
+subtest 'configs - picks up GENESIS_CLOUD_CONFIG env var' => sub {
+	plan tests => 2;
+
+	local %ENV = %ENV;
+	delete $ENV{$_} for grep { /^GENESIS_[A-Z0-9_]+_CONFIG/ } keys %ENV;
+
+	my $env = make_simple_env('cloud-env-var');
+	$env->{__configs} = {};
+
+	local $ENV{GENESIS_CLOUD_CONFIG} = '/tmp/cloud.yml';
+
+	my @list = $env->configs;
+	is(scalar(@list), 1, 'configs() returns one entry when GENESIS_CLOUD_CONFIG set');
+	is($list[0], 'cloud', 'configs() returns "cloud" from GENESIS_CLOUD_CONFIG');
+};
+
+subtest 'configs - picks up GENESIS_RUNTIME_CONFIG env var' => sub {
+	plan tests => 2;
+
+	local %ENV = %ENV;
+	delete $ENV{$_} for grep { /^GENESIS_[A-Z0-9_]+_CONFIG/ } keys %ENV;
+
+	my $env = make_simple_env('runtime-env-var');
+	$env->{__configs} = {};
+
+	local $ENV{GENESIS_RUNTIME_CONFIG} = '/tmp/runtime.yml';
+
+	my @list = $env->configs;
+	is(scalar(@list), 1, 'configs() returns one entry when GENESIS_RUNTIME_CONFIG set');
+	is($list[0], 'runtime', 'configs() returns "runtime" from GENESIS_RUNTIME_CONFIG');
+};
+
+subtest 'configs - use_config registers in both __configs and returns via configs()' => sub {
+	plan tests => 3;
+
+	local %ENV = %ENV;
+	delete $ENV{$_} for grep { /^GENESIS_[A-Z0-9_]+_CONFIG/ } keys %ENV;
+
+	my $env = make_simple_env('use-config-test');
+	$env->{__configs} = {};
+
+	# use_config sets both __configs and the env var
+	$env->use_config('/tmp/cloud.yml', 'cloud');
+
+	my @list = $env->configs;
+	is(scalar(@list), 1, 'configs() returns 1 entry after use_config(cloud)');
+	is($list[0], 'cloud', 'configs() returns "cloud" after use_config(cloud)');
+
+	$env->use_config('/tmp/runtime.yml', 'runtime');
+	my @both = sort $env->configs;
+	is(scalar(@both), 2, 'configs() returns 2 entries after use_config(cloud) and use_config(runtime)');
+};
+
+subtest 'configs - scalar context returns arrayref' => sub {
+	plan tests => 2;
+
+	local %ENV = %ENV;
+	delete $ENV{$_} for grep { /^GENESIS_[A-Z0-9_]+_CONFIG/ } keys %ENV;
+
+	my $env = make_simple_env('scalar-context');
+	$env->{__configs} = {};
+	$env->use_config('/tmp/cloud.yml', 'cloud');
+
+	my $ref = $env->configs;
+	is(ref($ref), 'ARRAY', 'configs() scalar context returns arrayref');
+	is($ref->[0], 'cloud', 'arrayref contains "cloud"');
+};
+
+# ======================================================================
+# required_configs()
+# ======================================================================
+
+subtest 'required_configs - returns empty list for create-env environments' => sub {
+	plan tests => 2;
+
+	my $env = make_create_env('create-env-test');
+	ok($env->use_create_env, 'sanity: environment is a create-env');
+
+	my @required = $env->required_configs('blueprint');
+	is(scalar(@required), 0, 'required_configs(blueprint) returns empty list for create-env');
+};
+
+subtest 'required_configs - blueprint hook requires cloud (default kit behaviour)' => sub {
+	plan tests => 2;
+
+	my $env = make_simple_env('req-blueprint');
+
+	my @required = $env->required_configs('blueprint');
+	is(scalar(@required), 1, 'required_configs(blueprint) returns 1 config');
+	is($required[0], 'cloud', 'required_configs(blueprint) requires cloud config');
+};
+
+subtest 'required_configs - manifest hook requires cloud (default kit behaviour)' => sub {
+	plan tests => 2;
+
+	my $env = make_simple_env('req-manifest');
+
+	my @required = $env->required_configs('manifest');
+	is(scalar(@required), 1, 'required_configs(manifest) returns 1 config');
+	is($required[0], 'cloud', 'required_configs(manifest) requires cloud config');
+};
+
+subtest 'required_configs - check hook requires cloud unless GENESIS_CONFIG_NO_CHECK' => sub {
+	plan tests => 2;
+
+	local %ENV = %ENV;
+	delete $ENV{GENESIS_CONFIG_NO_CHECK};
+
+	my $env = make_simple_env('req-check');
+
+	my @required = $env->required_configs('check');
+	is(scalar(@required), 1, 'required_configs(check) returns 1 config by default');
+	is($required[0], 'cloud', 'required_configs(check) requires cloud');
+};
+
+subtest 'required_configs - check hook requires nothing when GENESIS_CONFIG_NO_CHECK set' => sub {
+	plan tests => 1;
+
+	local $ENV{GENESIS_CONFIG_NO_CHECK} = '1';
+
+	my $env = make_simple_env('req-check-skip');
+
+	my @required = $env->required_configs('check');
+	is(scalar(@required), 0, 'required_configs(check) returns empty when GENESIS_CONFIG_NO_CHECK set');
+};
+
+subtest 'required_configs - explicit blueprint hook requires cloud when called directly' => sub {
+	plan tests => 2;
+
+	my $env = make_simple_env('req-direct');
+
+	# Calling blueprint directly (without deploy expansion) requires cloud
+	my @required = $env->required_configs('blueprint');
+	is(scalar(@required), 1, 'required_configs(blueprint) called directly returns 1 config');
+	is($required[0], 'cloud', 'required_configs(blueprint) called directly requires cloud');
+};
+
+# ======================================================================
+# has_config() and config_file()
+# ======================================================================
+
+subtest 'has_config - false when config not registered' => sub {
+	plan tests => 2;
+
+	local %ENV = %ENV;
+	delete $ENV{$_} for grep { /^GENESIS_[A-Z0-9_]+_CONFIG/ } keys %ENV;
+
+	my $env = make_simple_env('has-config-false');
+	$env->{__configs} = {};
+
+	ok(!$env->has_config('cloud'),   'has_config(cloud) is false when not registered');
+	ok(!$env->has_config('runtime'), 'has_config(runtime) is false when not registered');
+};
+
+subtest 'has_config - true after use_config registers it' => sub {
+	plan tests => 2;
+
+	local %ENV = %ENV;
+	delete $ENV{$_} for grep { /^GENESIS_[A-Z0-9_]+_CONFIG/ } keys %ENV;
+
+	my $env = make_simple_env('has-config-true');
+	$env->{__configs} = {};
+
+	$env->use_config('/tmp/cloud.yml', 'cloud');
+	ok($env->has_config('cloud'),    'has_config(cloud) is true after use_config(cloud)');
+	ok(!$env->has_config('runtime'), 'has_config(runtime) is still false');
+};
+
+subtest 'has_config - true when GENESIS_CLOUD_CONFIG env var is set' => sub {
+	plan tests => 1;
+
+	local %ENV = %ENV;
+	delete $ENV{$_} for grep { /^GENESIS_[A-Z0-9_]+_CONFIG/ } keys %ENV;
+
+	my $env = make_simple_env('has-config-env');
+	$env->{__configs} = {};
+
+	local $ENV{GENESIS_CLOUD_CONFIG} = '/tmp/cloud.yml';
+	ok($env->has_config('cloud'), 'has_config(cloud) is true when GENESIS_CLOUD_CONFIG env var is set');
+};
+
+subtest 'has_config - with named config (type@name)' => sub {
+	plan tests => 3;
+
+	local %ENV = %ENV;
+	delete $ENV{$_} for grep { /^GENESIS_[A-Z0-9_]+_CONFIG/ } keys %ENV;
+
+	my $env = make_simple_env('has-config-named');
+	$env->{__configs} = {};
+
+	$env->use_config('/tmp/cloud-az1.yml', 'cloud', 'az1');
+
+	ok($env->has_config('cloud', 'az1'),
+		'has_config(cloud, az1) is true after use_config with name');
+	ok(!$env->has_config('cloud'),
+		'has_config(cloud) without name is false (different label)');
+	ok(!$env->has_config('cloud', 'az2'),
+		'has_config(cloud, az2) is false for a different name');
+};
+
+# ======================================================================
+# missing_required_configs()
+# ======================================================================
+
+subtest 'missing_required_configs - all required when none registered' => sub {
+	plan tests => 2;
+
+	local %ENV = %ENV;
+	delete $ENV{$_} for grep { /^GENESIS_[A-Z0-9_]+_CONFIG/ } keys %ENV;
+
+	my $env = make_simple_env('missing-all');
+	$env->{__configs} = {};
+
+	my @missing = $env->missing_required_configs('blueprint');
+	is(scalar(@missing), 1, 'missing_required_configs(blueprint) returns 1 when nothing registered');
+	is($missing[0], 'cloud', 'missing_required_configs(blueprint) identifies "cloud" as missing');
+};
+
+subtest 'missing_required_configs - empty when all required are present' => sub {
+	plan tests => 1;
+
+	local %ENV = %ENV;
+	delete $ENV{$_} for grep { /^GENESIS_[A-Z0-9_]+_CONFIG/ } keys %ENV;
+
+	my $env = make_simple_env('missing-none');
+	$env->{__configs} = {};
+
+	$env->use_config('/tmp/cloud.yml', 'cloud');
+
+	my @missing = $env->missing_required_configs('blueprint');
+	is(scalar(@missing), 0, 'missing_required_configs(blueprint) returns empty when cloud is registered');
+};
+
+subtest 'missing_required_configs - empty for create-env environments' => sub {
+	plan tests => 1;
+
+	my $env = make_create_env('missing-create-env');
+
+	my @missing = $env->missing_required_configs('deploy');
+	is(scalar(@missing), 0, 'missing_required_configs() returns empty list for create-env');
+};
+
+# ======================================================================
+# has_required_configs()
+# ======================================================================
+
+subtest 'has_required_configs - false when required configs absent' => sub {
+	plan tests => 1;
+
+	local %ENV = %ENV;
+	delete $ENV{$_} for grep { /^GENESIS_[A-Z0-9_]+_CONFIG/ } keys %ENV;
+
+	my $env = make_simple_env('hrc-false');
+	$env->{__configs} = {};
+
+	ok(!$env->has_required_configs('blueprint'),
+		'has_required_configs(blueprint) is false when cloud config not registered');
+};
+
+subtest 'has_required_configs - true when all required configs present' => sub {
+	plan tests => 1;
+
+	local %ENV = %ENV;
+	delete $ENV{$_} for grep { /^GENESIS_[A-Z0-9_]+_CONFIG/ } keys %ENV;
+
+	my $env = make_simple_env('hrc-true');
+	$env->{__configs} = {};
+
+	$env->use_config('/tmp/cloud.yml', 'cloud');
+
+	ok($env->has_required_configs('blueprint'),
+		'has_required_configs(blueprint) is true when cloud config is registered');
+};
+
+subtest 'has_required_configs - always true for create-env environments' => sub {
+	plan tests => 1;
+
+	my $env = make_create_env('hrc-create-env');
+
+	ok($env->has_required_configs('deploy'),
+		'has_required_configs(deploy) is always true for create-env environments');
+};
+
+subtest 'has_required_configs - true when hook requires no configs' => sub {
+	plan tests => 1;
+
+	local %ENV = %ENV;
+	delete $ENV{$_} for grep { /^GENESIS_[A-Z0-9_]+_CONFIG/ } keys %ENV;
+
+	my $env = make_simple_env('hrc-no-req');
+	$env->{__configs} = {};
+
+	# cloud-config hook is special-cased in Kit::required_configs to return ()
+	ok($env->has_required_configs('cloud-config'),
+		'has_required_configs(cloud-config) is true (no configs required for this hook)');
+};
+
+done_testing;
+
+# vim: ts=2 sw=2 sts=2 noet fdm=marker foldlevel=1 nu

--- a/t/unit-tests/genesis_env-exodus.t
+++ b/t/unit-tests/genesis_env-exodus.t
@@ -1,0 +1,530 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+
+use lib 'lib';
+use lib 't';
+use helper;
+
+use Test::More;
+use Test::Deep;
+use Test::Exception;
+
+use Genesis;
+$Genesis::VERSION = '999.999.999';
+use_ok 'Genesis::Config';
+$Genesis::RC = Genesis::Config->new("$ENV{HOME}/.genesis/config");
+
+use_ok 'Genesis::Top';
+use_ok 'Genesis::Env';
+
+$ENV{GENESIS_OUTPUT_COLUMNS} = 80;
+$ENV{NOCOLOR} = 1;
+
+# ----------------------------------------------------------------------------
+# Shared helper: create an env with genesis.* settings, type=bosh
+# ----------------------------------------------------------------------------
+sub make_bosh_env {
+	my (%genesis_opts) = @_;
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	my $env_name = delete $genesis_opts{env} // 'us-west-1-preprod';
+	my $genesis_block = "  env: $env_name\n";
+	for my $key (sort keys %genesis_opts) {
+		$genesis_block .= "  $key: $genesis_opts{$key}\n";
+	}
+
+	put_file($top->path("$env_name.yml"), <<"EOF");
+---
+kit:
+  name:    dev
+  version: latest
+  features: []
+
+genesis:
+$genesis_block
+EOF
+
+	return $top->load_env($env_name);
+}
+
+# Helper: create env with params.* block as well
+sub make_bosh_env_with_params {
+	my (%opts) = @_;
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	my $env_name = delete $opts{env} // 'us-west-1-preprod';
+	my $genesis_block = "  env: $env_name\n";
+	my $params_block  = "";
+
+	for my $key (sort keys %opts) {
+		if ($key =~ /^params\.(.+)$/) {
+			$params_block .= "  $1: $opts{$key}\n";
+		} else {
+			$genesis_block .= "  $key: $opts{$key}\n";
+		}
+	}
+
+	put_file($top->path("$env_name.yml"), <<"EOF");
+---
+kit:
+  name:    dev
+  version: latest
+  features: []
+
+genesis:
+$genesis_block
+params:
+$params_block
+EOF
+
+	return $top->load_env($env_name);
+}
+
+# ============================================================================
+# secrets_mount
+# ============================================================================
+
+subtest 'secrets_mount - default value' => sub {
+	plan tests => 2;
+
+	my $env = make_bosh_env();
+	is($env->secrets_mount, '/secret/',
+		'secrets_mount returns /secret/ by default');
+	is($env->secrets_mount, $env->default_secrets_mount,
+		'secrets_mount equals default_secrets_mount when not configured');
+};
+
+subtest 'secrets_mount - custom genesis.secrets_mount' => sub {
+	plan tests => 3;
+
+	my $env1 = make_bosh_env(secrets_mount => '/vault/');
+	is($env1->secrets_mount, '/vault/',
+		'secrets_mount returns configured value');
+
+	my $env2 = make_bosh_env(secrets_mount => 'custom');
+	is($env2->secrets_mount, '/custom/',
+		'secrets_mount normalizes bare name with leading+trailing slashes');
+
+	my $env3 = make_bosh_env(secrets_mount => 'custom/nested');
+	is($env3->secrets_mount, '/custom/nested/',
+		'secrets_mount normalizes multi-segment path');
+};
+
+subtest 'secrets_mount - memoization' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env();
+	my $first  = $env->secrets_mount;
+	my $second = $env->secrets_mount;
+	is($first, $second, 'secrets_mount returns same value on repeated calls');
+};
+
+# ============================================================================
+# secrets_slug
+# ============================================================================
+
+subtest 'secrets_slug - default derived from env name and type' => sub {
+	plan tests => 2;
+
+	my $env = make_bosh_env(env => 'us-west-1-preprod');
+	is($env->secrets_slug, 'us/west/1/preprod/bosh',
+		'secrets_slug converts hyphens to slashes and appends deployment type');
+
+	my $env2 = make_bosh_env(env => 'prod');
+	is($env2->secrets_slug, 'prod/bosh',
+		'secrets_slug works for single-segment env name');
+};
+
+subtest 'secrets_slug - explicit genesis.secrets_path' => sub {
+	plan tests => 2;
+
+	my $env = make_bosh_env(secrets_path => 'my/custom/path');
+	is($env->secrets_slug, 'my/custom/path',
+		'secrets_slug returns genesis.secrets_path when set');
+
+	my $env2 = make_bosh_env(secrets_path => '/leading/slash/');
+	is($env2->secrets_slug, 'leading/slash',
+		'secrets_slug strips leading and trailing slashes from secrets_path');
+};
+
+subtest 'secrets_slug - memoization' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env(env => 'us-west-1-preprod');
+	my $first  = $env->secrets_slug;
+	my $second = $env->secrets_slug;
+	is($first, $second, 'secrets_slug returns same value on repeated calls');
+};
+
+# ============================================================================
+# secrets_base
+# ============================================================================
+
+subtest 'secrets_base - default full path' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env(env => 'us-west-1-preprod');
+	is($env->secrets_base, '/secret/us/west/1/preprod/bosh/',
+		'secrets_base is mount + slug + trailing slash');
+};
+
+subtest 'secrets_base - custom mount and slug' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env(
+		env           => 'us-west-1-preprod',
+		secrets_mount => '/vault/',
+		secrets_path  => 'ops/bosh',
+	);
+	is($env->secrets_base, '/vault/ops/bosh/',
+		'secrets_base combines custom mount and custom slug');
+};
+
+subtest 'secrets_base - memoization' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env(env => 'us-west-1-preprod');
+	my $first  = $env->secrets_base;
+	my $second = $env->secrets_base;
+	is($first, $second, 'secrets_base returns same value on repeated calls');
+};
+
+# ============================================================================
+# exodus_mount
+# ============================================================================
+
+subtest 'exodus_mount - default derived from secrets_mount' => sub {
+	plan tests => 2;
+
+	my $env = make_bosh_env();
+	is($env->exodus_mount, '/secret/exodus/',
+		'exodus_mount defaults to secrets_mount + exodus/');
+
+	my $env2 = make_bosh_env(secrets_mount => '/vault/');
+	is($env2->exodus_mount, '/vault/exodus/',
+		'exodus_mount follows custom secrets_mount');
+};
+
+subtest 'exodus_mount - explicit genesis.exodus_mount' => sub {
+	plan tests => 2;
+
+	my $env = make_bosh_env(exodus_mount => '/custom/exodus/');
+	is($env->exodus_mount, '/custom/exodus/',
+		'exodus_mount returns explicit value when configured');
+
+	my $env2 = make_bosh_env(exodus_mount => 'myexodus');
+	is($env2->exodus_mount, '/myexodus/',
+		'exodus_mount normalizes bare name with leading+trailing slashes');
+};
+
+subtest 'exodus_mount - memoization' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env();
+	my $first  = $env->exodus_mount;
+	my $second = $env->exodus_mount;
+	is($first, $second, 'exodus_mount returns same value on repeated calls');
+};
+
+# ============================================================================
+# exodus_slug
+# ============================================================================
+
+subtest 'exodus_slug - name/type format preserving hyphens' => sub {
+	plan tests => 3;
+
+	my $env1 = make_bosh_env(env => 'us-west-1-preprod');
+	is($env1->exodus_slug, 'us-west-1-preprod/bosh',
+		'exodus_slug is name/type with hyphens preserved');
+
+	my $env2 = make_bosh_env(env => 'prod');
+	is($env2->exodus_slug, 'prod/bosh',
+		'exodus_slug works for single-segment name');
+
+	my $env3 = make_bosh_env(env => 'a-b-c-d');
+	is($env3->exodus_slug, 'a-b-c-d/bosh',
+		'exodus_slug preserves all hyphens in env name');
+};
+
+subtest 'exodus_slug - distinct from secrets_slug' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env(env => 'us-west-1-preprod');
+	# secrets_slug uses slashes; exodus_slug uses original hyphenated name
+	isnt($env->exodus_slug, $env->secrets_slug,
+		'exodus_slug differs from secrets_slug for hyphenated name');
+};
+
+# ============================================================================
+# exodus_base
+# ============================================================================
+
+subtest 'exodus_base - default full path' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env(env => 'us-west-1-preprod');
+	is($env->exodus_base, '/secret/exodus/us-west-1-preprod/bosh',
+		'exodus_base is exodus_mount + exodus_slug (no trailing slash)');
+};
+
+subtest 'exodus_base - custom exodus_mount' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env(
+		env          => 'us-west-1-preprod',
+		exodus_mount => '/ops/exodus/',
+	);
+	is($env->exodus_base, '/ops/exodus/us-west-1-preprod/bosh',
+		'exodus_base uses custom exodus_mount');
+};
+
+subtest 'exodus_base - no trailing slash' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env(env => 'us-west-1-preprod');
+	unlike($env->exodus_base, qr/\/$/, 'exodus_base has no trailing slash');
+};
+
+subtest 'exodus_base - memoization' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env(env => 'us-west-1-preprod');
+	my $first  = $env->exodus_base;
+	my $second = $env->exodus_base;
+	is($first, $second, 'exodus_base returns same value on repeated calls');
+};
+
+# ============================================================================
+# ci_mount
+# ============================================================================
+
+subtest 'ci_mount - default derived from secrets_mount' => sub {
+	plan tests => 2;
+
+	my $env = make_bosh_env();
+	is($env->ci_mount, '/secret/ci/',
+		'ci_mount defaults to secrets_mount + ci/');
+
+	my $env2 = make_bosh_env(secrets_mount => '/vault/');
+	is($env2->ci_mount, '/vault/ci/',
+		'ci_mount follows custom secrets_mount');
+};
+
+subtest 'ci_mount - explicit genesis.ci_mount' => sub {
+	plan tests => 2;
+
+	my $env = make_bosh_env(ci_mount => '/pipeline/');
+	is($env->ci_mount, '/pipeline/',
+		'ci_mount returns explicit value when configured');
+
+	my $env2 = make_bosh_env(ci_mount => 'concourse');
+	is($env2->ci_mount, '/concourse/',
+		'ci_mount normalizes bare name with leading+trailing slashes');
+};
+
+# ============================================================================
+# ci_base
+# ============================================================================
+
+subtest 'ci_base - default full path' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env(env => 'us-west-1-preprod');
+	is($env->ci_base, '/secret/ci/bosh/us-west-1-preprod/',
+		'ci_base is ci_mount + type + / + name + trailing slash');
+};
+
+subtest 'ci_base - custom ci_mount' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env(
+		env      => 'us-west-1-preprod',
+		ci_mount => '/pipeline/',
+	);
+	is($env->ci_base, '/pipeline/bosh/us-west-1-preprod/',
+		'ci_base uses custom ci_mount');
+};
+
+subtest 'ci_base - explicit genesis.ci_base overrides computed value' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env(
+		env     => 'us-west-1-preprod',
+		ci_base => '/custom/ci/path',
+	);
+	is($env->ci_base, '/custom/ci/path/',
+		'explicit genesis.ci_base overrides computed value (normalized)');
+};
+
+subtest 'ci_base - memoization' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env(env => 'us-west-1-preprod');
+	my $first  = $env->ci_base;
+	my $second = $env->ci_base;
+	is($first, $second, 'ci_base returns same value on repeated calls');
+};
+
+# ============================================================================
+# ocfp_config_mount
+# ============================================================================
+
+subtest 'ocfp_config_mount - default derived from secrets_mount' => sub {
+	plan tests => 2;
+
+	my $env = make_bosh_env();
+	is($env->ocfp_config_mount, '/secret/config/',
+		'ocfp_config_mount defaults to secrets_mount + config/');
+
+	my $env2 = make_bosh_env(secrets_mount => '/vault/');
+	is($env2->ocfp_config_mount, '/vault/config/',
+		'ocfp_config_mount follows custom secrets_mount');
+};
+
+subtest 'ocfp_config_mount - custom params.ocfp_vault_config_prefix' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env_with_params(
+		'params.ocfp_vault_config_prefix' => 'cfg',
+	);
+	is($env->ocfp_config_mount, '/secret/cfg/',
+		'ocfp_config_mount uses params.ocfp_vault_config_prefix as suffix');
+};
+
+subtest 'ocfp_config_mount - explicit genesis.ocfp_config_mount' => sub {
+	plan tests => 2;
+
+	my $env = make_bosh_env(ocfp_config_mount => '/ops/config/');
+	is($env->ocfp_config_mount, '/ops/config/',
+		'ocfp_config_mount returns explicit value when configured');
+
+	my $env2 = make_bosh_env(ocfp_config_mount => 'myconfig');
+	is($env2->ocfp_config_mount, '/myconfig/',
+		'ocfp_config_mount normalizes bare name with leading+trailing slashes');
+};
+
+subtest 'ocfp_config_mount - memoization' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env();
+	my $first  = $env->ocfp_config_mount;
+	my $second = $env->ocfp_config_mount;
+	is($first, $second, 'ocfp_config_mount returns same value on repeated calls');
+};
+
+# ============================================================================
+# ocfp_config_slug
+# ============================================================================
+
+subtest 'ocfp_config_slug - fallback derived from env name (non-ocfp)' => sub {
+	plan tests => 2;
+
+	my $env = make_bosh_env(env => 'us-east-1-mgmt');
+	# Without params.ocfp_vault_config_slug or ocfp.bloc, falls back to ocfp_env
+	my $slug = $env->ocfp_config_slug;
+	is($slug, 'us-east-1/mgmt',
+		'ocfp_config_slug falls back to ocfp_env derived from env name');
+
+	my $env2 = make_bosh_env(env => 'us-west-1-preprod');
+	is($env2->ocfp_config_slug, 'us-west-1-preprod/ocf',
+		'ocfp_config_slug appends /ocf for non-mgmt env names');
+};
+
+subtest 'ocfp_config_slug - explicit params.ocfp_vault_config_slug' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env_with_params(
+		env                           => 'us-east-1-mgmt',
+		'params.ocfp_vault_config_slug' => 'us-east-1/mgmt',
+	);
+	is($env->ocfp_config_slug, 'us-east-1/mgmt',
+		'ocfp_config_slug returns params.ocfp_vault_config_slug when set');
+};
+
+# ============================================================================
+# ocfp_config_base
+# ============================================================================
+
+subtest 'ocfp_config_base - full path from mount and slug' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env(env => 'us-east-1-mgmt');
+	is($env->ocfp_config_base,
+		$env->ocfp_config_mount . $env->ocfp_config_slug,
+		'ocfp_config_base = ocfp_config_mount + ocfp_config_slug');
+};
+
+subtest 'ocfp_config_base - default path example from POD' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env_with_params(
+		env                           => 'us-east-1-mgmt',
+		'params.ocfp_vault_config_slug' => 'us-east-1/mgmt',
+	);
+	is($env->ocfp_config_base, '/secret/config/us-east-1/mgmt',
+		'ocfp_config_base matches POD example /secret/config/us-east-1/mgmt');
+};
+
+subtest 'ocfp_config_base - custom mount' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env(
+		env                => 'us-east-1-mgmt',
+		ocfp_config_mount  => '/ops/config/',
+	);
+	like($env->ocfp_config_base, qr{^/ops/config/},
+		'ocfp_config_base uses custom ocfp_config_mount');
+};
+
+subtest 'ocfp_config_base - memoization' => sub {
+	plan tests => 1;
+
+	my $env = make_bosh_env(env => 'us-east-1-mgmt');
+	my $first  = $env->ocfp_config_base;
+	my $second = $env->ocfp_config_base;
+	is($first, $second, 'ocfp_config_base returns same value on repeated calls');
+};
+
+# ============================================================================
+# Cross-cutting: custom secrets_mount propagates to all derived mounts
+# ============================================================================
+
+subtest 'custom secrets_mount propagates to exodus, ci, and ocfp_config' => sub {
+	plan tests => 3;
+
+	my $env = make_bosh_env(
+		env           => 'us-west-1-preprod',
+		secrets_mount => '/vault/',
+	);
+
+	like($env->exodus_mount, qr{^/vault/},
+		'exodus_mount inherits custom secrets_mount');
+	like($env->ci_mount, qr{^/vault/},
+		'ci_mount inherits custom secrets_mount');
+	like($env->ocfp_config_mount, qr{^/vault/},
+		'ocfp_config_mount inherits custom secrets_mount');
+};
+
+# ============================================================================
+# Cross-cutting: different env names produce different paths
+# ============================================================================
+
+subtest 'different env names produce different exodus slugs' => sub {
+	plan tests => 2;
+
+	my $env1 = make_bosh_env(env => 'us-west-1-preprod');
+	my $env2 = make_bosh_env(env => 'us-east-1-prod');
+
+	isnt($env1->exodus_slug, $env2->exodus_slug,
+		'different env names produce different exodus slugs');
+	isnt($env1->exodus_base, $env2->exodus_base,
+		'different env names produce different exodus base paths');
+};
+
+done_testing;
+
+# vim: ts=2 sw=2 sts=2 noet fdm=marker foldlevel=1 nu

--- a/t/unit-tests/genesis_env-lookups.t
+++ b/t/unit-tests/genesis_env-lookups.t
@@ -1,0 +1,204 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+
+use lib 'lib';
+use lib 't';
+use helper;
+
+use Test::More;
+use Test::Deep;
+use Test::Exception;
+
+use Genesis;
+$Genesis::VERSION = '999.999.999';
+use_ok 'Genesis::Config';
+$Genesis::RC = Genesis::Config->new("$ENV{HOME}/.genesis/config");
+
+use_ok 'Genesis::Top';
+use_ok 'Genesis::Env';
+
+$ENV{GENESIS_OUTPUT_COLUMNS}=80;
+$ENV{NOCOLOR}=1;
+
+# ============================================================================
+# Shared fixture builder
+# ============================================================================
+
+sub build_env {
+	my $top = make_top(name => 'thing', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file($top->path('test-env.yml'),
+		"---\n" .
+		"kit:\n" .
+		"  name:    dev\n" .
+		"  version: latest\n" .
+		"  features: []\n" .
+		"\n" .
+		"genesis:\n" .
+		"  env: test-env\n" .
+		"\n" .
+		"params:\n" .
+		"  color: blue\n" .
+		"  count: 42\n" .
+		"  nested:\n" .
+		"    deep:\n" .
+		"      value: found-it\n" .
+		"  empty_list: []\n"
+	);
+	return $top->load_env('test-env');
+}
+
+# ============================================================================
+# lookup() - basic key retrieval
+# ============================================================================
+
+subtest 'lookup() - simple top-level param' => sub {
+	plan tests => 1;
+	my $env = build_env();
+	is($env->lookup('params.color'), 'blue',
+		'lookup returns value for simple dot-notation key');
+};
+
+subtest 'lookup() - numeric value' => sub {
+	plan tests => 1;
+	my $env = build_env();
+	is($env->lookup('params.count'), 42,
+		'lookup returns numeric value correctly');
+};
+
+subtest 'lookup() - deeply nested dot-notation' => sub {
+	plan tests => 1;
+	my $env = build_env();
+	is($env->lookup('params.nested.deep.value'), 'found-it',
+		'lookup follows deep dot-notation path');
+};
+
+subtest 'lookup() - kit section accessible' => sub {
+	plan tests => 2;
+	my $env = build_env();
+	is($env->lookup('kit.name'), 'dev',
+		'lookup can reach kit.name');
+	is($env->lookup('kit.version'), 'latest',
+		'lookup can reach kit.version');
+};
+
+subtest 'lookup() - missing key returns undef' => sub {
+	plan tests => 1;
+	my $env = build_env();
+	is($env->lookup('params.no_such_key'), undef,
+		'lookup returns undef for missing key');
+};
+
+subtest 'lookup() - missing key returns provided scalar default' => sub {
+	plan tests => 1;
+	my $env = build_env();
+	is($env->lookup('params.no_such_key', 'fallback'), 'fallback',
+		'lookup returns scalar default when key not found');
+};
+
+subtest 'lookup() - coderef default not called when key exists' => sub {
+	plan tests => 2;
+	my $env = build_env();
+	my $called = 0;
+	my $val = $env->lookup('params.color', sub { $called++; 'computed' });
+	is($val, 'blue', 'coderef default not used when key exists');
+	is($called, 0, 'coderef not invoked when key found');
+};
+
+subtest 'lookup() - coderef default invoked when key missing' => sub {
+	plan tests => 2;
+	my $env = build_env();
+	my $called = 0;
+	my $val = $env->lookup('params.missing', sub { $called++; 'computed' });
+	is($val, 'computed', 'coderef default returns computed value');
+	is($called, 1, 'coderef invoked exactly once');
+};
+
+subtest 'lookup() - empty string key returns whole structure' => sub {
+	plan tests => 2;
+	my $env = build_env();
+	my $all = $env->lookup('');
+	ok(ref($all) eq 'HASH', 'empty key returns a hash reference');
+	ok(exists $all->{params}, 'returned structure contains params key');
+};
+
+subtest 'lookup() - arrayref of keys tries each in order' => sub {
+	plan tests => 2;
+	my $env = build_env();
+	my $val = $env->lookup(['params.no_such', 'params.color']);
+	is($val, 'blue', 'arrayref of keys falls through to second key');
+
+	$val = $env->lookup(['params.color', 'params.count']);
+	is($val, 'blue', 'arrayref returns first matching key');
+};
+
+subtest 'lookup() - arrayref all missing returns default' => sub {
+	plan tests => 1;
+	my $env = build_env();
+	my $val = $env->lookup(['params.gone', 'params.missing'], 'safe_default');
+	is($val, 'safe_default',
+		'arrayref returns default when all keys missing');
+};
+
+subtest 'lookup() - list context returns (value, matched_key)' => sub {
+	plan tests => 2;
+	my $env = build_env();
+	my ($val, $key) = $env->lookup('params.color');
+	is($val, 'blue', 'list context: value is correct');
+	is($key, 'params.color', 'list context: matched key is returned');
+};
+
+subtest 'lookup() - list context arrayref returns first matched key' => sub {
+	plan tests => 2;
+	my $env = build_env();
+	my ($val, $key) = $env->lookup(['params.gone', 'params.color']);
+	is($val, 'blue', 'list context arrayref: value from matching key');
+	is($key, 'params.color', 'list context arrayref: matched key reported');
+};
+
+subtest 'lookup() - list context no match returns (default, undef)' => sub {
+	plan tests => 2;
+	my $env = build_env();
+	my ($val, $key) = $env->lookup('params.missing', 'default_val');
+	is($val, 'default_val', 'list context no match: default returned');
+	is($key, undef, 'list context no match: key is undef');
+};
+
+# ============================================================================
+# lookup_unevaled() - raw unevaluated environment data
+# ============================================================================
+
+subtest 'lookup_unevaled() - returns value for existing key' => sub {
+	plan tests => 1;
+	my $env = build_env();
+	is($env->lookup_unevaled('params.color'), 'blue',
+		'lookup_unevaled returns value for existing key');
+};
+
+subtest 'lookup_unevaled() - returns default when key missing' => sub {
+	plan tests => 1;
+	my $env = build_env();
+	is($env->lookup_unevaled('params.nonexistent', 'raw_default'), 'raw_default',
+		'lookup_unevaled returns default for missing key');
+};
+
+subtest 'lookup_unevaled() - returns undef when no key and no default' => sub {
+	plan tests => 1;
+	my $env = build_env();
+	is($env->lookup_unevaled('params.nonexistent'), undef,
+		'lookup_unevaled returns undef with no default');
+};
+
+subtest 'lookup_unevaled() - deeply nested key' => sub {
+	plan tests => 1;
+	my $env = build_env();
+	is($env->lookup_unevaled('params.nested.deep.value'), 'found-it',
+		'lookup_unevaled follows deep dot-notation path');
+};
+
+done_testing;
+
+# vim: ts=2 sw=2 sts=2 noet fdm=marker foldlevel=1 nu

--- a/t/unit-tests/genesis_env-ocfp.t
+++ b/t/unit-tests/genesis_env-ocfp.t
@@ -1,0 +1,358 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+
+use lib 'lib';
+use lib 't';
+use helper;
+
+use Test::More;
+use Test::Deep;
+use Test::Exception;
+
+use Genesis;
+$Genesis::VERSION = '999.999.999';
+use_ok 'Genesis::Config';
+$Genesis::RC = Genesis::Config->new("$ENV{HOME}/.genesis/config");
+
+use_ok 'Genesis::Top';
+use_ok 'Genesis::Env';
+
+$ENV{GENESIS_OUTPUT_COLUMNS} = 80;
+$ENV{NOCOLOR} = 1;
+
+# ============================================================================
+# is_ocfp() tests
+# ============================================================================
+
+subtest 'is_ocfp() - returns false when ocfp feature is absent' => sub {
+	plan tests => 2;
+
+	my $top = make_top(name => 'cf', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file $top->path('no-ocfp.yml'), <<EOF;
+---
+kit:
+  name: dev
+  version: latest
+  features: []
+genesis:
+  env: no-ocfp
+EOF
+
+	my $env = $top->load_env('no-ocfp');
+	ok(!$env->is_ocfp, 'is_ocfp() returns false when features list is empty');
+
+	put_file $top->path('other-feature.yml'), <<EOF;
+---
+kit:
+  name: dev
+  version: latest
+  features:
+    - aws
+    - s3
+genesis:
+  env: other-feature
+EOF
+
+	$env = $top->load_env('other-feature');
+	ok(!$env->is_ocfp, 'is_ocfp() returns false when other features are active but not ocfp');
+};
+
+subtest 'is_ocfp() - returns true when ocfp feature is present' => sub {
+	plan tests => 2;
+
+	my $top = make_top(name => 'cf', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file $top->path('with-ocfp.yml'), <<EOF;
+---
+kit:
+  name: dev
+  version: latest
+  features:
+    - ocfp
+genesis:
+  env: with-ocfp
+EOF
+
+	my $env = $top->load_env('with-ocfp');
+	ok($env->is_ocfp, 'is_ocfp() returns true when ocfp feature is present');
+
+	put_file $top->path('ocfp-plus.yml'), <<EOF;
+---
+kit:
+  name: dev
+  version: latest
+  features:
+    - aws
+    - ocfp
+    - s3
+genesis:
+  env: ocfp-plus
+EOF
+
+	$env = $top->load_env('ocfp-plus');
+	ok($env->is_ocfp, 'is_ocfp() returns true when ocfp is among multiple features');
+};
+
+# ============================================================================
+# ocfp_type() tests
+# ============================================================================
+
+subtest 'ocfp_type() - returns empty string for non-OCFP environments' => sub {
+	plan tests => 1;
+
+	my $top = make_top(name => 'cf', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file $top->path('non-ocfp-type.yml'), <<EOF;
+---
+kit:
+  name: dev
+  version: latest
+  features: []
+genesis:
+  env: non-ocfp-type
+EOF
+
+	my $env = $top->load_env('non-ocfp-type');
+	is($env->ocfp_type, '', 'ocfp_type() returns empty string when is_ocfp is false');
+};
+
+subtest 'ocfp_type() - returns mgmt for management environments' => sub {
+	plan tests => 2;
+
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file $top->path('us-east-1-mgmt.yml'), <<EOF;
+---
+kit:
+  name: dev
+  version: latest
+  features:
+    - ocfp
+genesis:
+  env: us-east-1-mgmt
+EOF
+
+	my $env = $top->load_env('us-east-1-mgmt');
+	is($env->ocfp_type, 'mgmt', 'ocfp_type() returns mgmt for name ending in -mgmt');
+
+	put_file $top->path('us-west-2-mgmt.yml'), <<EOF;
+---
+kit:
+  name: dev
+  version: latest
+  features:
+    - ocfp
+genesis:
+  env: us-west-2-mgmt
+EOF
+
+	$env = $top->load_env('us-west-2-mgmt');
+	is($env->ocfp_type, 'mgmt', 'ocfp_type() returns mgmt for different region ending in -mgmt');
+};
+
+subtest 'ocfp_type() - returns ocf for OCF environments' => sub {
+	plan tests => 2;
+
+	my $top = make_top(name => 'cf', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file $top->path('us-east-1-ocf.yml'), <<EOF;
+---
+kit:
+  name: dev
+  version: latest
+  features:
+    - ocfp
+genesis:
+  env: us-east-1-ocf
+EOF
+
+	my $env = $top->load_env('us-east-1-ocf');
+	is($env->ocfp_type, 'ocf', 'ocfp_type() returns ocf for name ending in -ocf');
+
+	put_file $top->path('eu-central-1-ocf.yml'), <<EOF;
+---
+kit:
+  name: dev
+  version: latest
+  features:
+    - ocfp
+genesis:
+  env: eu-central-1-ocf
+EOF
+
+	$env = $top->load_env('eu-central-1-ocf');
+	is($env->ocfp_type, 'ocf', 'ocfp_type() returns ocf for eu region ending in -ocf');
+};
+
+subtest 'ocfp_type() - returns ocf when no type suffix matches' => sub {
+	plan tests => 1;
+
+	my $top = make_top(name => 'cf', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file $top->path('us-east-1-prod.yml'), <<EOF;
+---
+kit:
+  name: dev
+  version: latest
+  features:
+    - ocfp
+genesis:
+  env: us-east-1-prod
+EOF
+
+	my $env = $top->load_env('us-east-1-prod');
+	is($env->ocfp_type, 'ocf',
+		'ocfp_type() returns ocf as default when name has no -mgmt/-ocf suffix');
+};
+
+# ============================================================================
+# ocfp_env() tests
+# ============================================================================
+
+subtest 'ocfp_env() - converts trailing -mgmt to slash form' => sub {
+	plan tests => 2;
+
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file $top->path('us-east-1-mgmt.yml'), <<EOF;
+---
+kit:
+  name: dev
+  version: latest
+  features:
+    - ocfp
+genesis:
+  env: us-east-1-mgmt
+EOF
+
+	my $env = $top->load_env('us-east-1-mgmt');
+	is($env->ocfp_env, 'us-east-1/mgmt',
+		'ocfp_env() converts us-east-1-mgmt to us-east-1/mgmt');
+
+	put_file $top->path('ap-southeast-1-mgmt.yml'), <<EOF;
+---
+kit:
+  name: dev
+  version: latest
+  features:
+    - ocfp
+genesis:
+  env: ap-southeast-1-mgmt
+EOF
+
+	$env = $top->load_env('ap-southeast-1-mgmt');
+	is($env->ocfp_env, 'ap-southeast-1/mgmt',
+		'ocfp_env() converts ap-southeast-1-mgmt to ap-southeast-1/mgmt');
+};
+
+subtest 'ocfp_env() - converts trailing -ocf to slash form' => sub {
+	plan tests => 2;
+
+	my $top = make_top(name => 'cf', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file $top->path('us-west-2-ocf.yml'), <<EOF;
+---
+kit:
+  name: dev
+  version: latest
+  features:
+    - ocfp
+genesis:
+  env: us-west-2-ocf
+EOF
+
+	my $env = $top->load_env('us-west-2-ocf');
+	is($env->ocfp_env, 'us-west-2/ocf',
+		'ocfp_env() converts us-west-2-ocf to us-west-2/ocf');
+
+	put_file $top->path('eu-west-1-ocf.yml'), <<EOF;
+---
+kit:
+  name: dev
+  version: latest
+  features:
+    - ocfp
+genesis:
+  env: eu-west-1-ocf
+EOF
+
+	$env = $top->load_env('eu-west-1-ocf');
+	is($env->ocfp_env, 'eu-west-1/ocf',
+		'ocfp_env() converts eu-west-1-ocf to eu-west-1/ocf');
+};
+
+subtest 'ocfp_env() - appends type for non-terminal mgmt/ocf segment' => sub {
+	plan tests => 2;
+
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	# -mgmt- in the middle: ocfp-aws-mgmt-us-east-1 -> ocfp-aws-mgmt-us-east-1/mgmt
+	put_file $top->path('ocfp-aws-mgmt-us-east-1.yml'), <<EOF;
+---
+kit:
+  name: dev
+  version: latest
+  features:
+    - ocfp
+genesis:
+  env: ocfp-aws-mgmt-us-east-1
+EOF
+
+	my $env = $top->load_env('ocfp-aws-mgmt-us-east-1');
+	is($env->ocfp_env, 'ocfp-aws-mgmt-us-east-1/mgmt',
+		'ocfp_env() appends /mgmt when -mgmt- appears in middle of name');
+
+	# mgmt- at the beginning: mgmt-production -> mgmt-production/mgmt
+	put_file $top->path('mgmt-production.yml'), <<EOF;
+---
+kit:
+  name: dev
+  version: latest
+  features:
+    - ocfp
+genesis:
+  env: mgmt-production
+EOF
+
+	$env = $top->load_env('mgmt-production');
+	is($env->ocfp_env, 'mgmt-production/mgmt',
+		'ocfp_env() appends /mgmt when mgmt- appears at start of name');
+};
+
+subtest 'ocfp_env() - appends /ocf for names with no mgmt/ocf segment' => sub {
+	plan tests => 1;
+
+	my $top = make_top(name => 'cf', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file $top->path('us-east-1-prod.yml'), <<EOF;
+---
+kit:
+  name: dev
+  version: latest
+  features:
+    - ocfp
+genesis:
+  env: us-east-1-prod
+EOF
+
+	my $env = $top->load_env('us-east-1-prod');
+	is($env->ocfp_env, 'us-east-1-prod/ocf',
+		'ocfp_env() appends /ocf as default when no mgmt/ocf segment found');
+};
+
+done_testing;
+
+# vim: ts=2 sw=2 sts=2 noet fdm=marker foldlevel=1 nu

--- a/t/unit-tests/genesis_env-relations.t
+++ b/t/unit-tests/genesis_env-relations.t
@@ -1,0 +1,317 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+
+use lib 'lib';
+use lib 't';
+use helper;
+
+use Test::More;
+use Test::Deep;
+use Test::Exception;
+
+use Genesis;
+$Genesis::VERSION = '999.999.999';
+use_ok 'Genesis::Config';
+$Genesis::RC = Genesis::Config->new("$ENV{HOME}/.genesis/config");
+
+use_ok 'Genesis::Top';
+use_ok 'Genesis::Env';
+
+$ENV{GENESIS_OUTPUT_COLUMNS} = 80;
+$ENV{NOCOLOR} = 1;
+
+# Helper: create a top with the simple dev kit and one or more env files.
+# Returns (top, %envs) where %envs maps name => Genesis::Env object.
+sub make_envs {
+	my @names = @_;
+	my $top = make_top(name => 'thing', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	my %envs;
+	for my $n (@names) {
+		put_file($top->path("$n.yml"), <<"YAML");
+---
+kit:
+  name:    dev
+  version: latest
+  features: []
+genesis:
+  env: $n
+YAML
+		$envs{$n} = $top->load_env($n);
+	}
+	return ($top, %envs);
+}
+
+# ---------------------------------------------------------------------------
+subtest 'relate_by_name - list context, default bases' => sub {
+	plan tests => 2;
+
+	my @files = Genesis::Env::relate_by_name(
+		'us-west-1-preprod', 'us-west-1-prod'
+	);
+
+	is(scalar @files, 4,
+		'relate_by_name returns 4 files for preprod vs prod');
+
+	cmp_deeply(
+		\@files,
+		[
+			'./us.yml',
+			'./us-west.yml',
+			'./us-west-1.yml',
+			'./us-west-1-preprod.yml',
+		],
+		'relate_by_name list context: common files first, then unique'
+	);
+};
+
+# ---------------------------------------------------------------------------
+subtest 'relate_by_name - scalar context returns hashref' => sub {
+	plan tests => 3;
+
+	my $struct = Genesis::Env::relate_by_name(
+		'us-west-1-preprod', 'us-west-1-prod'
+	);
+
+	is(ref $struct, 'HASH',
+		'relate_by_name scalar context returns hashref');
+
+	cmp_deeply(
+		$struct->{common},
+		[ './us.yml', './us-west.yml', './us-west-1.yml' ],
+		'relate_by_name scalar context: common arrayref correct'
+	);
+
+	cmp_deeply(
+		$struct->{unique},
+		[ './us-west-1-preprod.yml' ],
+		'relate_by_name scalar context: unique arrayref correct'
+	);
+};
+
+# ---------------------------------------------------------------------------
+subtest 'relate_by_name - custom common_base' => sub {
+	plan tests => 1;
+
+	my @files = Genesis::Env::relate_by_name(
+		'us-west-1-preprod', 'us-west-1-prod', '.cache'
+	);
+
+	cmp_deeply(
+		\@files,
+		[
+			'.cache/us.yml',
+			'.cache/us-west.yml',
+			'.cache/us-west-1.yml',
+			'./us-west-1-preprod.yml',
+		],
+		'relate_by_name applies custom common_base to shared files'
+	);
+};
+
+# ---------------------------------------------------------------------------
+subtest 'relate_by_name - custom common_base and unique_base' => sub {
+	plan tests => 2;
+
+	my $struct = Genesis::Env::relate_by_name(
+		'us-west-1-preprod', 'us-west-1-prod', '.cache', 'NEW'
+	);
+
+	cmp_deeply(
+		$struct->{common},
+		[ '.cache/us.yml', '.cache/us-west.yml', '.cache/us-west-1.yml' ],
+		'custom common_base applied to common files in scalar context'
+	);
+
+	cmp_deeply(
+		$struct->{unique},
+		[ 'NEW/us-west-1-preprod.yml' ],
+		'custom unique_base applied to unique files in scalar context'
+	);
+};
+
+# ---------------------------------------------------------------------------
+subtest 'relate_by_name - completely different environments' => sub {
+	plan tests => 3;
+
+	my $struct = Genesis::Env::relate_by_name('eu-central-1-staging', 'us-west-1-prod');
+
+	is(scalar @{ $struct->{common} }, 0,
+		'no common files when env names share no prefixes');
+
+	cmp_deeply(
+		$struct->{unique},
+		[
+			'./eu.yml',
+			'./eu-central.yml',
+			'./eu-central-1.yml',
+			'./eu-central-1-staging.yml',
+		],
+		'all files are unique when env names share no prefixes'
+	);
+
+	my @flat = Genesis::Env::relate_by_name('eu-central-1-staging', 'us-west-1-prod');
+	is(scalar @flat, 4,
+		'flat list has all 4 files when no common prefix exists'
+	);
+};
+
+# ---------------------------------------------------------------------------
+subtest 'relate_by_name - single-segment names, one common token' => sub {
+	plan tests => 2;
+
+	my $struct = Genesis::Env::relate_by_name('us-east', 'us-west');
+
+	cmp_deeply(
+		$struct->{common},
+		[ './us.yml' ],
+		'single shared leading token produces one common file'
+	);
+
+	cmp_deeply(
+		$struct->{unique},
+		[ './us-east.yml' ],
+		'diverging token produces one unique file'
+	);
+};
+
+# ---------------------------------------------------------------------------
+subtest 'relate_by_name - identical environment names' => sub {
+	plan tests => 2;
+
+	my $struct = Genesis::Env::relate_by_name('us-west-1-preprod', 'us-west-1-preprod');
+
+	cmp_deeply(
+		$struct->{common},
+		[ './us.yml', './us-west.yml', './us-west-1.yml', './us-west-1-preprod.yml' ],
+		'all files are common when comparing env to itself'
+	);
+
+	cmp_deeply(
+		$struct->{unique},
+		[],
+		'no unique files when comparing env to itself'
+	);
+};
+
+# ---------------------------------------------------------------------------
+subtest 'relate - list context with Env object argument' => sub {
+	plan tests => 2;
+
+	my ($top, %envs) = make_envs('us-west-1-preprod', 'us-west-1-prod');
+	my $preprod = $envs{'us-west-1-preprod'};
+	my $prod    = $envs{'us-west-1-prod'};
+
+	my @files = $preprod->relate($prod);
+
+	is(scalar @files, 4,
+		'relate() with Env object returns 4 files');
+
+	cmp_deeply(
+		\@files,
+		[
+			'./us.yml',
+			'./us-west.yml',
+			'./us-west-1.yml',
+			'./us-west-1-preprod.yml',
+		],
+		'relate() with Env object: correct file list in list context'
+	);
+};
+
+# ---------------------------------------------------------------------------
+subtest 'relate - list context with name string argument' => sub {
+	plan tests => 1;
+
+	my ($top, %envs) = make_envs('us-west-1-preprod', 'us-west-1-prod');
+	my $preprod = $envs{'us-west-1-preprod'};
+
+	my @files = $preprod->relate('us-west-1-prod');
+
+	cmp_deeply(
+		\@files,
+		[
+			'./us.yml',
+			'./us-west.yml',
+			'./us-west-1.yml',
+			'./us-west-1-preprod.yml',
+		],
+		'relate() with name string: same result as with Env object'
+	);
+};
+
+# ---------------------------------------------------------------------------
+subtest 'relate - scalar context with Env object argument' => sub {
+	plan tests => 3;
+
+	my ($top, %envs) = make_envs('us-west-1-preprod', 'us-west-1-prod');
+	my $preprod = $envs{'us-west-1-preprod'};
+	my $prod    = $envs{'us-west-1-prod'};
+
+	my $struct = $preprod->relate($prod);
+
+	is(ref $struct, 'HASH',
+		'relate() scalar context returns hashref');
+
+	cmp_deeply(
+		$struct->{common},
+		[ './us.yml', './us-west.yml', './us-west-1.yml' ],
+		'relate() scalar context: common arrayref correct'
+	);
+
+	cmp_deeply(
+		$struct->{unique},
+		[ './us-west-1-preprod.yml' ],
+		'relate() scalar context: unique arrayref correct'
+	);
+};
+
+# ---------------------------------------------------------------------------
+subtest 'relate - custom common_base with Env object' => sub {
+	plan tests => 1;
+
+	my ($top, %envs) = make_envs('us-west-1-preprod', 'us-west-1-prod');
+	my $preprod = $envs{'us-west-1-preprod'};
+	my $prod    = $envs{'us-west-1-prod'};
+
+	my @files = $preprod->relate($prod, '.cache');
+
+	cmp_deeply(
+		\@files,
+		[
+			'.cache/us.yml',
+			'.cache/us-west.yml',
+			'.cache/us-west-1.yml',
+			'./us-west-1-preprod.yml',
+		],
+		'relate() with custom common_base prefixes shared files correctly'
+	);
+};
+
+# ---------------------------------------------------------------------------
+subtest 'relate - custom common_base and unique_base with Env object' => sub {
+	plan tests => 2;
+
+	my ($top, %envs) = make_envs('us-west-1-preprod', 'us-west-1-prod');
+	my $preprod = $envs{'us-west-1-preprod'};
+	my $prod    = $envs{'us-west-1-prod'};
+
+	my $struct = $preprod->relate($prod, '.cache', 'NEW');
+
+	cmp_deeply(
+		$struct->{common},
+		[ '.cache/us.yml', '.cache/us-west.yml', '.cache/us-west-1.yml' ],
+		'relate() custom bases: common files use common_base'
+	);
+
+	cmp_deeply(
+		$struct->{unique},
+		[ 'NEW/us-west-1-preprod.yml' ],
+		'relate() custom bases: unique files use unique_base'
+	);
+};
+
+done_testing;

--- a/t/unit-tests/genesis_env-vault_ops.t
+++ b/t/unit-tests/genesis_env-vault_ops.t
@@ -1,0 +1,245 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+
+use lib 'lib';
+use lib 't';
+use helper;
+
+use Test::More;
+use Test::Deep;
+use Test::Exception;
+
+use Genesis;
+$Genesis::VERSION = '999.999.999';
+use_ok 'Genesis::Config';
+$Genesis::RC = Genesis::Config->new("$ENV{HOME}/.genesis/config");
+
+use_ok 'Genesis::Top';
+use_ok 'Genesis::Env';
+
+$ENV{GENESIS_OUTPUT_COLUMNS} = 80;
+$ENV{NOCOLOR} = 1;
+
+# ============================================================================
+# Shared helpers
+# ============================================================================
+
+# Build an env with a genesis.vault value set in the YAML file.
+sub make_env_with_vault {
+	my (%opts) = @_;
+	my $vault_val = delete $opts{vault_val};
+	my $env_name  = delete $opts{env_name} // 'us-west-1-preprod';
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	my $vault_line = defined($vault_val) ? "  vault: $vault_val\n" : "";
+
+	put_file($top->path("$env_name.yml"), <<"EOF");
+---
+kit:
+  name:    dev
+  version: latest
+  features: []
+
+genesis:
+  env: $env_name
+$vault_line
+EOF
+
+	return $top->load_env($env_name);
+}
+
+# ============================================================================
+# get_ancestral_vault() - reads genesis.vault from env YAML, no Vault needed
+# ============================================================================
+
+subtest 'get_ancestral_vault - returns undef when genesis.vault not set' => sub {
+	plan tests => 1;
+
+	my $env = make_env_with_vault(env_name => 'prod');
+	is($env->get_ancestral_vault, undef,
+		'get_ancestral_vault returns undef when genesis.vault is absent');
+};
+
+subtest 'get_ancestral_vault - returns URL string from env YAML' => sub {
+	plan tests => 2;
+
+	my $env = make_env_with_vault(
+		env_name  => 'us-west-1-preprod',
+		vault_val => 'https://vault.example.com:8200',
+	);
+	my $result = $env->get_ancestral_vault;
+	is($result, 'https://vault.example.com:8200',
+		'get_ancestral_vault returns plain HTTPS vault URL');
+	ok(defined($result), 'get_ancestral_vault returns a defined value');
+};
+
+subtest 'get_ancestral_vault - returns descriptor with path component' => sub {
+	plan tests => 1;
+
+	my $env = make_env_with_vault(
+		env_name  => 'staging',
+		vault_val => 'https://vault.example.com:8200/secret/env',
+	);
+	is($env->get_ancestral_vault, 'https://vault.example.com:8200/secret/env',
+		'get_ancestral_vault returns URL with path component intact');
+};
+
+subtest 'get_ancestral_vault - rejects spruce operator value' => sub {
+	plan tests => 1;
+
+	my $env = make_env_with_vault(
+		env_name  => 'bad-env',
+		vault_val => '((some-operator))',
+	);
+	throws_ok { $env->get_ancestral_vault }
+		qr/Cannot use spruce operator.*genesis\.vault_info/i,
+		'get_ancestral_vault dies when genesis.vault starts with (( spruce operator';
+};
+
+subtest 'get_ancestral_vault - inherits from ancestor env file' => sub {
+	plan tests => 2;
+
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	# Parent file sets genesis.vault
+	put_file($top->path('us.yml'), <<"EOF");
+---
+kit:
+  name:    dev
+  version: latest
+  features: []
+
+genesis:
+  vault: https://shared-vault.example.com:8200
+EOF
+
+	# Child file does NOT override genesis.vault
+	put_file($top->path('us-west-1-preprod.yml'), <<"EOF");
+---
+kit:
+  name:    dev
+  version: latest
+  features: []
+
+genesis:
+  env: us-west-1-preprod
+EOF
+
+	my $env = $top->load_env('us-west-1-preprod');
+	my $result = $env->get_ancestral_vault;
+	is($result, 'https://shared-vault.example.com:8200',
+		'get_ancestral_vault inherits genesis.vault from ancestor env file');
+	ok(defined($result), 'inherited vault descriptor is defined');
+};
+
+subtest 'get_ancestral_vault - child overrides parent genesis.vault' => sub {
+	plan tests => 1;
+
+	my $top = make_top(name => 'cf', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	# Parent file sets one genesis.vault
+	put_file($top->path('us.yml'), <<"EOF");
+---
+kit:
+  name:    dev
+  version: latest
+  features: []
+
+genesis:
+  vault: https://parent-vault.example.com:8200
+EOF
+
+	# Child file overrides genesis.vault
+	put_file($top->path('us-west-1-prod.yml'), <<"EOF");
+---
+kit:
+  name:    dev
+  version: latest
+  features: []
+
+genesis:
+  env: us-west-1-prod
+  vault: https://child-vault.example.com:8200
+EOF
+
+	my $env = $top->load_env('us-west-1-prod');
+	is($env->get_ancestral_vault, 'https://child-vault.example.com:8200',
+		'child genesis.vault overrides parent genesis.vault');
+};
+
+subtest 'get_ancestral_vault - lightweight env object without YAML file returns undef' => sub {
+	plan tests => 1;
+
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	# Create a minimal env object directly (no YAML file on disk)
+	my $env = Genesis::Env->new(name => 'no-file-env', top => $top);
+	is($env->get_ancestral_vault, undef,
+		'get_ancestral_vault returns undef when no env YAML files exist');
+};
+
+subtest 'get_ancestral_vault - rejects reference value (non-scalar)' => sub {
+	plan tests => 1;
+
+	# We need lookup_unevaled to return a reference (e.g. a hashref) to
+	# trigger the "not a singular string value" bail.  Monkey-patch the
+	# Genesis::Env method temporarily using a local override.
+	my $top = make_top(name => 'bosh', no_vault => 1);
+	$top->link_dev_kit('t/src/simple');
+
+	put_file($top->path('ref-test.yml'), <<"EOF");
+---
+kit:
+  name:    dev
+  version: latest
+  features: []
+
+genesis:
+  env: ref-test
+EOF
+
+	my $env = $top->load_env('ref-test');
+
+	# Temporarily override lookup_unevaled in Genesis::Env to return a hashref
+	no warnings qw(redefine once);
+	local *Genesis::Env::lookup_unevaled = sub { return {bad => 'value'} };
+	use warnings qw(redefine once);
+
+	throws_ok { $env->get_ancestral_vault }
+		qr/Expecting.*genesis\.vault.*singular string value/i,
+		'get_ancestral_vault dies when genesis.vault value is a reference';
+};
+
+# ============================================================================
+# exodus_lookup() - requires live Vault server
+# ============================================================================
+
+subtest 'exodus_lookup - SKIP: requires live Vault' => sub {
+	plan skip_all => 'exodus_lookup() requires a live Vault server; use integration tests';
+};
+
+subtest 'exodus_lookup - SKIP: extended path /path:key format requires live Vault' => sub {
+	plan skip_all => 'exodus_lookup() /path:key format requires a live Vault server; use integration tests';
+};
+
+subtest 'exodus_lookup - SKIP: custom $for slug requires live Vault' => sub {
+	plan skip_all => 'exodus_lookup() custom $for slug requires a live Vault server; use integration tests';
+};
+
+# ============================================================================
+# vault_paths() - requires spruce manifest build and live Vault
+# ============================================================================
+
+subtest 'vault_paths - SKIP: requires spruce manifest build and live Vault' => sub {
+	plan skip_all => 'vault_paths() requires manifest_provider->base_manifest which needs spruce and Vault; use integration tests';
+};
+
+done_testing;
+
+# vim: ts=2 sw=2 sts=2 noet fdm=marker foldlevel=1 nu


### PR DESCRIPTION
## Summary

- Adds 7 new unit test files for Genesis::Env methods previously untested, driven from POD documentation as the test specification
- Covers 35 methods across lookups, BOSH environment, OCFP configuration, path construction, config management, environment relations, and vault operations
- 210 real assertions total, exceeding the ticket target of ~100+
- Registers all new test files in the test execution manifest

## New Test Files

| File | Methods | Assertions |
|------|---------|------------|
| `genesis_env-lookups.t` | lookup, lookup_unevaled | 26 |
| `genesis_env-relations.t` | relate, relate_by_name | 24 |
| `genesis_env-ocfp.t` | is_ocfp, ocfp_type, ocfp_env | 17 |
| `genesis_env-bosh.t` | _parse_bosh_env, is_bosh_director, bosh_env, bosh_alias | 41 |
| `genesis_env-exodus.t` | secrets/exodus/ci/ocfp_config mount/slug/base | 53 |
| `genesis_env-configs.t` | configs, required_configs, missing/has_required, has_config | 39 |
| `genesis_env-vault_ops.t` | get_ancestral_vault (+ skip stubs for vault-dependent) | 10 |

## Notable Finding

Discovered a pre-existing bug in `required_configs('deploy')` — the `_memoize` callback returns a scalar count instead of the array, causing the `deploy` expansion to pass `'3'` as a hook name. Tests work around this by testing hooks directly.

## Test plan

- [x] All 7 new test files pass individually (`prove -lv`)
- [x] All 17 Genesis::Env test files pass together (286 TAP assertions, zero regressions)
- [x] Code review passed with no blocking issues
- [x] Test manifest updated with all new entries

Closes FWT-569