### PR TITLE
Add Genesis::Hook POD-driven unit tests

### DIFF
--- a/t/test-manifest.txt
+++ b/t/test-manifest.txt
@@ -93,6 +93,16 @@ unit-tests/genesis_commands-core.t  # Genesis::Commands infrastructure (registra
 unit-tests/genesis_kit_provider-core.t              # Genesis::Kit::Provider base class/factory
 unit-tests/genesis_kit_provider_github-core.t        # Genesis::Kit::Provider::Github
 unit-tests/genesis_kit_provider_genesiscommunity-core.t  # Genesis::Kit::Provider::GenesisCommunity
+# Genesis::Hook tests (POD-driven, FWT-560)
+unit-tests/genesis_hook-core.t               # Genesis::Hook base class
+unit-tests/genesis_hook_addon-core.t         # Genesis::Hook::Addon
+unit-tests/genesis_hook_blueprint-core.t     # Genesis::Hook::Blueprint
+unit-tests/genesis_hook_check-core.t         # Genesis::Hook::Check
+unit-tests/genesis_hook_cpiconfig-core.t     # Genesis::Hook::CpiConfig
+unit-tests/genesis_hook_features-core.t      # Genesis::Hook::Features
+unit-tests/genesis_hook_postdeploy-core.t    # Genesis::Hook::PostDeploy
+unit-tests/genesis_hook_runtimeconfig-core.t # Genesis::Hook::RuntimeConfig
+unit-tests/genesis_hook_terminate-core.t     # Genesis::Hook::Terminate
 
 [integration-tests]
 # Multi-component interaction tests that require system interaction

--- a/t/unit-tests/genesis_hook-core.t
+++ b/t/unit-tests/genesis_hook-core.t
@@ -1,0 +1,1053 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+
+use lib 't';
+use helper;
+use Test::More;
+use Test::Exception;
+use Test::Deep;
+use Carp qw/croak/;
+use Genesis qw(logger struct_lookup bail);
+use Cwd qw(abs_path);
+use JSON::PP;
+use Digest::SHA qw(sha1_hex);
+
+$ENV{GENESIS_CALLBACK_BIN} ||= abs_path('bin/genesis');
+$ENV{GENESIS_LIB} ||= abs_path('lib');
+$ENV{GENESIS_OUTPUT_COLUMNS} = 80;
+$ENV{NOCOLOR} = 1;
+
+# ---------------------------------------------------------------------------
+# Load the module under test
+# ---------------------------------------------------------------------------
+require_ok 'Genesis::Hook';
+
+# ---------------------------------------------------------------------------
+# Test subclass - Genesis::Hook requires the class name to match
+# Genesis::Hook::<Type>::<KitName> so that label() can parse it.
+# We define a minimal subclass here for use throughout the test file.
+# ---------------------------------------------------------------------------
+{
+	package Genesis::Hook::Blueprint::test_kit;
+	use parent -norequire, 'Genesis::Hook';
+
+	# Minimal perform so the base-class abstract test can call the SUPER
+	# version explicitly, while subtest 'perform - base class' bypasses this.
+	sub perform {
+		my ($self) = @_;
+		$self->done('test-result');
+	}
+}
+
+# ---------------------------------------------------------------------------
+# Shared mock objects
+# ---------------------------------------------------------------------------
+
+my $test_seq = 0;
+
+my $kit = mock "Genesis::Kit" => {
+	name                => 'test-kit',
+	version             => '1.0.0',
+	genesis_version_min => '3.1.0-rc.10',
+	id                  => sub { return $_[0]->name . '/' . $_[0]->version },
+	kit_bug => sub {
+		my ($self, $msg, @args) = @_;
+		bail("Throwing a kit bug: ".$msg, @args);
+	},
+	path => sub {
+		my ($self, $file) = @_;
+		return "/mock/kit/path/$file";
+	},
+	metadata => { supports => ['aws', 'vsphere', 'openstack'] },
+	get_hook_module => sub { return undef },
+};
+
+my $bosh = mock "Genesis::BOSH" => {
+	alias                => 'mock-bosh',
+	connect_and_validate => sub { return $_[0] },
+};
+
+sub mock_env {
+	$test_seq++;
+	my $seq = $test_seq;
+	mock "Genesis::Env" => {(
+		name            => "test-env-$seq",
+		type            => 'test',
+		kit             => $kit,
+		bosh            => sub {
+			my $self = shift;
+			return $bosh;
+		},
+		use_create_env  => 0,
+		features        => Mock::ReferencedValue->new(['ha', 'tls']),
+		iaas            => 'aws',
+		scale           => 'dev',
+		is_ocfp         => 0,
+		cpi_name        => 'aws_cpi',
+		cpi_enabled     => 1,
+		deployments     => mock("Genesis::Env::Deployments::$seq" => {
+			current_state => 'deployed',
+		}),
+		workpath => sub {
+			my ($self, $path) = @_;
+			return "/tmp/genesis-test-work/$path";
+		},
+		exodus_lookup => sub {
+			my ($self, $key, $default) = @_;
+			return { director_url => 'https://bosh.example.com', admin_user => 'admin' }
+				if $key eq '.';
+			return $default;
+		},
+		lookup => sub {
+			my ($self, $key, $default) = @_;
+			return $default;
+		},
+		path => sub { return "/mock/env/path/$_[1]" },
+		file => 'test-env.yml',
+	), @_};
+}
+
+# Convenience: instantiate our test subclass
+sub make_hook {
+	my $env = shift || mock_env();
+	return Genesis::Hook::Blueprint::test_kit->init(env => $env, @_);
+}
+
+# ---------------------------------------------------------------------------
+# Globals set before all subtests
+# ---------------------------------------------------------------------------
+$Genesis::VERSION = '3.1.0-rc.10';
+$ENV{GENESIS_CALL_BIN} = 'genesis';
+$ENV{GENESIS_KIT_HOOK} = 'blueprint';
+
+# ---------------------------------------------------------------------------
+# Genesis::Hook must be loaded
+# ---------------------------------------------------------------------------
+subtest 'Genesis::Hook module loads' => sub {
+	plan tests => 1;
+	ok(defined(&Genesis::Hook::init), 'Genesis::Hook::init is defined');
+};
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+subtest 'init - missing env dies' => sub {
+	plan tests => 1;
+
+	throws_ok {
+		Genesis::Hook::Blueprint::test_kit->init()
+	} qr/Missing required arguments for a perl-based kit hook call: env/,
+		'init() without env argument dies with required-args message';
+};
+
+subtest 'init - returns blessed object with env set' => sub {
+	plan tests => 5;
+
+	my $env  = mock_env();
+	my $hook;
+	lives_ok {
+		$hook = Genesis::Hook::Blueprint::test_kit->init(env => $env)
+	} 'init() succeeds with valid env';
+
+	ok(defined $hook, 'init() returns a defined value');
+	isa_ok($hook, 'Genesis::Hook', 'returned object isa Genesis::Hook');
+	is($hook->env, $env,                    'env() returns the env passed to init()');
+	is($hook->{type}, $ENV{GENESIS_KIT_HOOK},
+		'type is set from GENESIS_KIT_HOOK env var');
+};
+
+subtest 'init - complete flag starts at 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	is($hook->{complete}, 0, 'complete flag initializes to 0');
+};
+
+subtest 'init - stores extra opts on object' => sub {
+	plan tests => 2;
+
+	my $env  = mock_env();
+	my $hook = Genesis::Hook::Blueprint::test_kit->init(
+		env     => $env,
+		purpose => 'extra',
+		count   => 42,
+	);
+	is($hook->{purpose}, 'extra', 'extra opt "purpose" stored on hook');
+	is($hook->{count},   42,      'extra opt "count" stored on hook');
+};
+
+subtest 'init - type read from GENESIS_KIT_HOOK at construction time' => sub {
+	plan tests => 1;
+
+	local $ENV{GENESIS_KIT_HOOK} = 'rotate';
+	my $hook = make_hook();
+	is($hook->{type}, 'rotate', 'type reflects GENESIS_KIT_HOOK at init() call time');
+};
+
+# ---------------------------------------------------------------------------
+# perform (abstract)
+# ---------------------------------------------------------------------------
+subtest 'perform - base class implementation calls kit_bug and dies' => sub {
+	plan tests => 1;
+
+	my $env  = mock_env();
+	# Bless a raw hook directly as base Genesis::Hook so label is bypassed by
+	# pre-populating {label}; then call the base perform via package-qualified call.
+	my $hook = bless(
+		{ env => $env, complete => 0, type => 'blueprint', label => '[test] ' },
+		'Genesis::Hook'
+	);
+
+	throws_ok {
+		Genesis::Hook::perform($hook)
+	} qr/Throwing a kit bug:[\s\S]*perform/i,
+		'Genesis::Hook::perform() calls kit_bug and dies';
+};
+
+# ---------------------------------------------------------------------------
+# done / completed / results
+# ---------------------------------------------------------------------------
+subtest 'done - no args marks complete with result 1' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook();
+	my $ret  = $hook->done();
+
+	is($ret,              1, 'done() with no args returns 1');
+	is($hook->{complete}, 1, 'complete flag set to 1');
+	is($hook->{results},  1, 'results stored as 1');
+};
+
+subtest 'done - with defined value stores value and marks complete' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook();
+	my $yaml = "name: foo\n";
+	my $ret  = $hook->done($yaml);
+
+	is($ret,              $yaml, 'done($value) returns the value');
+	is($hook->{complete}, 1,     'complete flag set to 1');
+	is($hook->{results},  $yaml, 'results stored as supplied value');
+};
+
+subtest 'done - undef argument marks NOT complete' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook();
+	my $ret  = $hook->done(undef);
+
+	ok(!defined($ret),             'done(undef) returns undef');
+	is($hook->{complete},  0,      'complete flag set to 0 when undef passed');
+	ok(!defined($hook->{results}), 'results is undef when done(undef)');
+};
+
+subtest 'done - returns value that was passed in' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $ret  = $hook->done('my-yaml-output');
+	is($ret, 'my-yaml-output', 'done($val) return value matches argument');
+};
+
+subtest 'completed - reflects complete flag' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	is($hook->completed, 0, 'completed() returns 0 before done()');
+	$hook->done('something');
+	is($hook->completed, 1, 'completed() returns 1 after done($value)');
+};
+
+subtest 'results - returns undef when not complete, value when complete' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	ok(!defined($hook->results), 'results() returns undef when not complete');
+
+	$hook->done('my-result');
+	is($hook->results, 'my-result', 'results() returns stored value after done()');
+};
+
+subtest 'results - returns undef when done(undef) called' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->done(undef);
+
+	is($hook->completed, 0, 'completed() is 0 after done(undef)');
+	ok(!defined($hook->results), 'results() returns undef after done(undef)');
+};
+
+# ---------------------------------------------------------------------------
+# check_minimum_genesis_version
+# ---------------------------------------------------------------------------
+subtest 'check_minimum_genesis_version - passes when version meets requirement' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+
+	lives_ok {
+		$hook->check_minimum_genesis_version('3.0.0')
+	} 'does not die when running version exceeds minimum';
+
+	lives_ok {
+		$hook->check_minimum_genesis_version('3.1.0-rc.10')
+	} 'does not die when running version exactly equals minimum';
+};
+
+subtest 'check_minimum_genesis_version - passes for older minimum' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	lives_ok {
+		$hook->check_minimum_genesis_version('2.0.0')
+	} 'does not die when minimum is much older than current';
+};
+
+subtest 'check_minimum_genesis_version - dies when version too old' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	throws_ok {
+		$hook->check_minimum_genesis_version('99.0.0')
+	} qr/requires Genesis v99\.0\.0 or higher/,
+		'dies with upgrade message when running version is too old';
+};
+
+subtest 'check_minimum_genesis_version - dies on invalid minimum version string' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	throws_ok {
+		$hook->check_minimum_genesis_version('not-a-version')
+	} qr/requires Genesis v/,
+		'dies when minimum version is not a valid semver string';
+};
+
+# ---------------------------------------------------------------------------
+# env / deployed / use_create_env
+# ---------------------------------------------------------------------------
+subtest 'env - returns env object passed to init()' => sub {
+	plan tests => 1;
+
+	my $env  = mock_env();
+	my $hook = make_hook($env);
+	is($hook->env, $env, 'env() returns the stored env object');
+};
+
+subtest 'deployed - returns 1 when deployment state is "deployed"' => sub {
+	plan tests => 1;
+
+	# mock_env defaults to current_state => 'deployed'
+	my $hook = make_hook();
+	is($hook->deployed, 1, 'deployed() returns 1 when current_state is "deployed"');
+};
+
+subtest 'deployed - returns 0 when deployment state is not "deployed"' => sub {
+	plan tests => 1;
+
+	my $seq = $test_seq + 1;
+	my $env = mock_env(
+		deployments => mock("Genesis::Env::Deployments::nd$seq" => {
+			current_state => 'undeployed',
+		})
+	);
+	my $hook = make_hook($env);
+	is($hook->deployed, 0, 'deployed() returns 0 when current_state is not "deployed"');
+};
+
+subtest 'use_create_env - returns env->use_create_env' => sub {
+	plan tests => 2;
+
+	my $env0 = mock_env(use_create_env => 0);
+	is(make_hook($env0)->use_create_env, 0,
+		'use_create_env() returns 0 when env returns 0');
+
+	my $env1 = mock_env(use_create_env => 1);
+	is(make_hook($env1)->use_create_env, 1,
+		'use_create_env() returns 1 when env returns 1');
+};
+
+# ---------------------------------------------------------------------------
+# features / set_features / want_feature / wants_feature
+# ---------------------------------------------------------------------------
+subtest 'features - returns feature list from env' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my @got  = $hook->features();
+	cmp_deeply(\@got, ['ha', 'tls'], 'features() returns list from env');
+};
+
+subtest 'features - caches result after first call' => sub {
+	plan tests => 2;
+
+	my $env  = mock_env();
+	my $hook = make_hook($env);
+
+	# First call populates cache
+	my @first = $hook->features();
+	is(scalar @first, 2, 'initial feature list has 2 entries');
+
+	# Change what env->features returns for subsequent calls
+	$env->_mock_set_responses(
+		'features' => Mock::ReferencedValue->new(['other'])
+	);
+	my @second = $hook->features();
+	cmp_deeply(\@second, ['ha', 'tls'],
+		'features() returns cached list, ignoring updated env response');
+};
+
+subtest 'set_features - replaces cached list' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->set_features('proto', 'db');
+
+	my @got = $hook->features();
+	cmp_deeply(\@got, ['proto', 'db'],
+		'set_features() replaces the cached feature list');
+};
+
+subtest 'set_features - clears __wanted_features lookup cache' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	# Prime the wanted-features cache
+	$hook->want_feature('ha');
+	ok(defined $hook->{__wanted_features}, '__wanted_features populated after want_feature');
+
+	$hook->set_features('proto', 'db');
+	ok(!defined($hook->{__wanted_features}),
+		'set_features() clears the __wanted_features cache');
+};
+
+subtest 'want_feature - exact string: present feature returns true' => sub {
+	plan tests => 1;
+	ok(make_hook()->want_feature('ha'),
+		'want_feature("ha") returns true for present feature');
+};
+
+subtest 'want_feature - exact string: absent feature returns false' => sub {
+	plan tests => 1;
+	ok(!make_hook()->want_feature('missing-feature'),
+		'want_feature("missing-feature") returns false for absent feature');
+};
+
+subtest 'want_feature - regex: returns 1 when a feature name matches' => sub {
+	plan tests => 1;
+	is(make_hook()->want_feature(qr/^t/), 1,
+		'want_feature(qr/^t/) returns 1 when feature "tls" matches');
+};
+
+subtest 'want_feature - regex: returns 0 when no feature matches' => sub {
+	plan tests => 1;
+	is(make_hook()->want_feature(qr/^xyz/), 0,
+		'want_feature(qr/^xyz/) returns 0 when no feature matches regex');
+};
+
+subtest 'want_feature - regex matches partial name' => sub {
+	plan tests => 1;
+	is(make_hook()->want_feature(qr/ls$/), 1,
+		'want_feature(qr/ls$/) returns 1 matching end of "tls"');
+};
+
+subtest 'wants_feature - alias for want_feature' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	ok($hook->wants_feature('ha'),
+		'wants_feature("ha") returns true (alias works)');
+	ok(!$hook->wants_feature('absent'),
+		'wants_feature("absent") returns false (alias works)');
+};
+
+# ---------------------------------------------------------------------------
+# iaas / scale / is_ocfp / cpi_name / cpi_enabled
+# ---------------------------------------------------------------------------
+subtest 'iaas - delegates to env->iaas' => sub {
+	plan tests => 1;
+	is(make_hook()->iaas, 'aws', 'iaas() returns env->iaas');
+};
+
+subtest 'scale - delegates to env->scale' => sub {
+	plan tests => 1;
+	is(make_hook()->scale, 'dev', 'scale() returns env->scale');
+};
+
+subtest 'is_ocfp - delegates to env->is_ocfp' => sub {
+	plan tests => 1;
+	is(make_hook()->is_ocfp, 0, 'is_ocfp() returns env->is_ocfp');
+};
+
+subtest 'cpi_name - delegates to env->cpi_name' => sub {
+	plan tests => 1;
+	is(make_hook()->cpi_name, 'aws_cpi', 'cpi_name() returns env->cpi_name');
+};
+
+subtest 'cpi_enabled - delegates to env->cpi_enabled' => sub {
+	plan tests => 1;
+	is(make_hook()->cpi_enabled, 1, 'cpi_enabled() returns env->cpi_enabled');
+};
+
+# ---------------------------------------------------------------------------
+# kit / kit_bug / kit_has_file / supports_iaas
+# ---------------------------------------------------------------------------
+subtest 'kit - returns kit object from env' => sub {
+	plan tests => 1;
+	is(make_hook()->kit, $kit, 'kit() returns env->kit');
+};
+
+subtest 'kit_bug - delegates to kit->kit_bug and terminates' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	throws_ok {
+		$hook->kit_bug("Something went wrong: %s", "bad value")
+	} qr/Throwing a kit bug: Something went wrong: bad value/,
+		'kit_bug() delegates to kit->kit_bug and terminates with bail()';
+};
+
+subtest 'kit_has_file - returns false for nonexistent file' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	# kit->path returns /mock/kit/path/<file> which does not exist on disk
+	ok(!$hook->kit_has_file('hooks/nonexistent.pm'),
+		'kit_has_file() returns false when file does not exist');
+};
+
+subtest 'kit_has_file - returns true for existing file' => sub {
+	plan tests => 1;
+
+	my $tmpdir  = workdir('kit-has-file-test');
+	my $tmpfile = "$tmpdir/real-hook.pm";
+	put_file($tmpfile, "# placeholder\n");
+
+	# Use a local kit so we do not mutate the shared $kit mock
+	my $local_kit = mock "Genesis::Kit::LocalForFileTest" => {
+		name     => 'test-kit',
+		version  => '1.0.0',
+		id       => sub { return $_[0]->name . '/' . $_[0]->version },
+		kit_bug  => sub {
+			my ($self, $msg, @args) = @_;
+			bail("Throwing a kit bug: ".$msg, @args);
+		},
+		path     => sub { return $tmpfile },
+		metadata => { supports => ['aws', 'vsphere', 'openstack'] },
+		get_hook_module => sub { return undef },
+	};
+	my $env  = mock_env(kit => $local_kit);
+	my $hook = make_hook($env);
+
+	ok($hook->kit_has_file('real-hook.pm'),
+		'kit_has_file() returns true for a file that exists on disk');
+};
+
+subtest 'supports_iaas - returns true when iaas is in kit supports list' => sub {
+	plan tests => 1;
+
+	# mock_env has iaas => 'aws'; kit metadata supports includes 'aws'
+	ok(make_hook()->supports_iaas,
+		'supports_iaas() returns true when IaaS is in kit supports list');
+};
+
+subtest 'supports_iaas - returns false when iaas not in kit supports list' => sub {
+	plan tests => 1;
+
+	my $env  = mock_env(iaas => 'gcp');
+	ok(!make_hook($env)->supports_iaas,
+		'supports_iaas() returns false when IaaS is not in kit supports list');
+};
+
+# ---------------------------------------------------------------------------
+# relative_env_path
+# ---------------------------------------------------------------------------
+subtest 'relative_env_path - returns a string path' => sub {
+	plan tests => 1;
+
+	local $ENV{GENESIS_ORIGINATING_DIR} = workdir();
+	my $hook = make_hook();
+
+	my $path;
+	lives_ok { $path = $hook->relative_env_path() }
+		'relative_env_path() lives without error';
+};
+
+# ---------------------------------------------------------------------------
+# titleize
+# NOTE: The POD documents titleize as applying title-case to each word.
+# The current implementation uses double-escaped regex substitution
+# (s/([\\w']+)/\\u\\L\$1/gr) which, due to the escaped \$1, does not
+# interpolate the capture group. The character class [\\w']+ matches
+# only literal backslash, 'w', or apostrophe characters rather than \w
+# word chars. As a result the function does not produce title-case output.
+# These tests document the intended (POD-specified) behaviour. The
+# implementation must be fixed to make them pass.
+# ---------------------------------------------------------------------------
+subtest 'titleize - capitalizes first letter, lowercases rest in each word' => sub {
+	plan tests => 1;
+
+	TODO: {
+		local $TODO = 'titleize() has a double-escaped substitution bug (HK-TODO)';
+		my @result = Genesis::Hook::titleize('hello world');
+		cmp_deeply(\@result, ['Hello World'],
+			'titleize("hello world") returns ("Hello World")');
+	}
+};
+
+subtest 'titleize - handles multiple string arguments' => sub {
+	plan tests => 1;
+
+	TODO: {
+		local $TODO = 'titleize() has a double-escaped substitution bug (HK-TODO)';
+		my @result = Genesis::Hook::titleize('foo bar', 'baz qux');
+		cmp_deeply(\@result, ['Foo Bar', 'Baz Qux'],
+			'titleize with two strings applies title case to each');
+	}
+};
+
+subtest 'titleize - lowercases non-initial letters' => sub {
+	plan tests => 1;
+
+	TODO: {
+		local $TODO = 'titleize() has a double-escaped substitution bug (HK-TODO)';
+		my @result = Genesis::Hook::titleize('HELLO WORLD');
+		cmp_deeply(\@result, ['Hello World'],
+			'titleize("HELLO WORLD") lowercases non-initial letters');
+	}
+};
+
+subtest 'titleize - single word' => sub {
+	plan tests => 1;
+
+	TODO: {
+		local $TODO = 'titleize() has a double-escaped substitution bug (HK-TODO)';
+		my @result = Genesis::Hook::titleize('genesis');
+		cmp_deeply(\@result, ['Genesis'],
+			'titleize("genesis") capitalizes single word');
+	}
+};
+
+# ---------------------------------------------------------------------------
+# TRUE / FALSE / NULL
+# ---------------------------------------------------------------------------
+subtest 'TRUE - returns JSON::PP boolean true' => sub {
+	plan tests => 2;
+
+	my $t = Genesis::Hook::TRUE();
+	ok(JSON::PP::is_bool($t), 'TRUE() returns a JSON boolean value');
+	ok($t,                    'TRUE() is truthy');
+};
+
+subtest 'FALSE - returns JSON::PP boolean false' => sub {
+	plan tests => 2;
+
+	my $f = Genesis::Hook::FALSE();
+	ok(JSON::PP::is_bool($f), 'FALSE() returns a JSON boolean value');
+	ok(!$f,                   'FALSE() is falsy');
+};
+
+subtest 'NULL - returns JSON null singleton' => sub {
+	plan tests => 1;
+
+	my $n = Genesis::Hook::NULL();
+	is($n, JSON::PP::null, 'NULL() returns the JSON::PP::null singleton');
+};
+
+# ---------------------------------------------------------------------------
+# check_for_required_args
+# ---------------------------------------------------------------------------
+subtest 'check_for_required_args - returns 1 when all required keys present' => sub {
+	plan tests => 2;
+
+	my $opts = { env => 'something', name => 'foo' };
+	my $ret;
+	lives_ok {
+		$ret = Genesis::Hook->check_for_required_args($opts, qw/env name/)
+	} 'check_for_required_args() lives when all required keys are present';
+	is($ret, 1, 'check_for_required_args() returns 1 on success');
+};
+
+subtest 'check_for_required_args - dies listing all missing keys' => sub {
+	plan tests => 1;
+
+	my $opts = { env => 'something' };
+	throws_ok {
+		Genesis::Hook->check_for_required_args($opts, qw/env name type/)
+	} qr/Missing required arguments for a perl-based kit hook call: /,
+		'check_for_required_args() dies listing missing keys';
+};
+
+subtest 'check_for_required_args - dies when the only required key is absent' => sub {
+	plan tests => 1;
+
+	throws_ok {
+		Genesis::Hook->check_for_required_args({}, qw/env/)
+	} qr/Missing required arguments for a perl-based kit hook call: env/,
+		'check_for_required_args() dies when required key is absent';
+};
+
+# ---------------------------------------------------------------------------
+# spruce_merge - argument validation
+# ---------------------------------------------------------------------------
+subtest 'spruce_merge - dies on unrecognized string argument' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	# 'not-a-real-file' is not a flag, not a hash, not an existing file, and
+	# kit->path() returns /mock/kit/path/not-a-real-file which also does not exist
+	throws_ok {
+		$hook->spruce_merge('not-a-real-file')
+	} qr/Invalid argument for spruce merge: not-a-real-file/,
+		'spruce_merge() dies when argument is not a file, hash, or flag';
+};
+
+# ---------------------------------------------------------------------------
+# exodus_data
+# ---------------------------------------------------------------------------
+subtest 'exodus_data - no args returns full hash ref' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	my $data = $hook->exodus_data();
+
+	ok(ref($data) eq 'HASH',
+		'exodus_data() with no args returns a HASH ref');
+	is($data->{director_url}, 'https://bosh.example.com',
+		'exodus_data() full hash contains expected director_url key');
+};
+
+subtest 'exodus_data - single key returns scalar value' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $url  = $hook->exodus_data('director_url');
+	is($url, 'https://bosh.example.com',
+		'exodus_data("director_url") returns scalar value for the key');
+};
+
+subtest 'exodus_data - multiple keys in list context returns list of values' => sub {
+	plan tests => 2;
+
+	my $hook          = make_hook();
+	my ($url, $user)  = $hook->exodus_data('director_url', 'admin_user');
+
+	is($url,  'https://bosh.example.com', 'first key value is correct');
+	is($user, 'admin',                    'second key value is correct');
+};
+
+subtest 'exodus_data - multiple keys in scalar context returns arrayref' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	my $aref = $hook->exodus_data('director_url', 'admin_user');
+
+	ok(ref($aref) eq 'ARRAY',
+		'scalar context with multiple keys returns ARRAY ref');
+	is($aref->[0], 'https://bosh.example.com',
+		'arrayref first element is the first key value');
+};
+
+subtest 'exodus_data - caches result after first call' => sub {
+	plan tests => 2;
+
+	my $env  = mock_env();
+	my $hook = make_hook($env);
+
+	# Populate cache
+	my $first = $hook->exodus_data();
+	ok(defined $hook->{__exodus_data},
+		'__exodus_data cache is populated after first call');
+
+	# Change what env->exodus_lookup returns
+	$env->_mock_set_responses(
+		exodus_lookup => sub { return { director_url => 'https://changed.example.com' } }
+	);
+
+	my $second = $hook->exodus_data();
+	is($second->{director_url}, 'https://bosh.example.com',
+		'exodus_data() returns cached value on second call despite changed env response');
+};
+
+# ---------------------------------------------------------------------------
+# get_credhub_variable
+# ---------------------------------------------------------------------------
+subtest 'get_credhub_variable - returns deterministic credential name' => sub {
+	plan tests => 1;
+
+	my $hook         = make_hook();
+	my $prefix       = '/bosh/';
+	my $path         = 'certs';
+	my $key          = 'ca';
+	my $value        = 'pem-data-here';
+	my $expected_sha = substr(sha1_hex("$path--$key--$value"), 0, 8);
+	my $expected     = "${prefix}${path}--${key}--${expected_sha}";
+
+	my $result = $hook->get_credhub_variable($prefix, $path, $key, $value);
+	is($result, $expected,
+		'get_credhub_variable() returns the expected deterministic credential name');
+};
+
+subtest 'get_credhub_variable - is deterministic for identical inputs' => sub {
+	plan tests => 1;
+
+	my $hook    = make_hook();
+	my $result1 = $hook->get_credhub_variable('/p/', 'mypath', 'mykey', 'myval');
+	my $result2 = $hook->get_credhub_variable('/p/', 'mypath', 'mykey', 'myval');
+	is($result1, $result2,
+		'get_credhub_variable() produces the same name for identical inputs');
+};
+
+subtest 'get_credhub_variable - different value produces different name' => sub {
+	plan tests => 1;
+
+	my $hook    = make_hook();
+	my $result1 = $hook->get_credhub_variable('/p/', 'mypath', 'mykey', 'value-A');
+	my $result2 = $hook->get_credhub_variable('/p/', 'mypath', 'mykey', 'value-B');
+	isnt($result1, $result2,
+		'get_credhub_variable() produces different names when value differs');
+};
+
+subtest 'get_credhub_variable - sha1 prefix is exactly 8 hex characters' => sub {
+	plan tests => 1;
+
+	my $hook   = make_hook();
+	my $result = $hook->get_credhub_variable('/prefix/', 'mypath', 'mykey', 'myval');
+	like($result, qr/--[0-9a-f]{8}$/,
+		'credential name ends with exactly 8 lowercase hex sha1 characters');
+};
+
+subtest 'get_credhub_variable - name format is prefix+path--key--sha' => sub {
+	plan tests => 1;
+
+	my $hook   = make_hook();
+	my $result = $hook->get_credhub_variable('/bosh/', 'certs', 'ca', 'val');
+	like($result, qr{^/bosh/certs--ca--[0-9a-f]{8}$},
+		'credential name matches expected format: prefix+path--key--sha8');
+};
+
+# ---------------------------------------------------------------------------
+# tempfile / tempdir
+# ---------------------------------------------------------------------------
+subtest 'tempfile - with explicit name returns workpath for that name' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $path = $hook->tempfile('manifest.yml');
+	is($path, '/tmp/genesis-test-work/manifest.yml',
+		'tempfile("manifest.yml") returns env->workpath("manifest.yml")');
+};
+
+subtest 'tempfile - without name generates auto-named path under workpath' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $path = $hook->tempfile();
+	like($path, qr{/tmp/genesis-test-work/tempfile-\d+-\d+$},
+		'tempfile() with no name generates a timestamped path');
+};
+
+subtest 'tempdir - with explicit name returns correct path' => sub {
+	plan tests => 1;
+
+	my $tmpbase = workdir('tempdir-test-named');
+	my $env     = mock_env(
+		workpath => sub {
+			my ($self, $path) = @_;
+			return "$tmpbase/$path";
+		}
+	);
+	my $hook = make_hook($env);
+	my $dir  = $hook->tempdir('staging');
+	is($dir, "$tmpbase/staging", 'tempdir("staging") returns expected path');
+};
+
+subtest 'tempdir - without name generates auto-named path' => sub {
+	plan tests => 1;
+
+	my $tmpbase = workdir('tempdir-test-auto');
+	my $env     = mock_env(
+		workpath => sub {
+			my ($self, $path) = @_;
+			return "$tmpbase/$path";
+		}
+	);
+	my $hook = make_hook($env);
+	my $dir  = $hook->tempdir();
+	like($dir, qr{tempdir-\d+-\d+$},
+		'tempdir() with no name generates a timestamped path');
+};
+
+subtest 'tempdir - creates directory on disk' => sub {
+	plan tests => 1;
+
+	my $tmpbase = workdir('tempdir-test-create');
+	my $env     = mock_env(
+		workpath => sub {
+			my ($self, $path) = @_;
+			return "$tmpbase/$path";
+		}
+	);
+	my $hook = make_hook($env);
+	my $dir  = $hook->tempdir('mydir');
+	ok(-d $dir, 'tempdir() creates the directory on disk');
+};
+
+subtest 'tempdir - returns existing path if directory already present' => sub {
+	plan tests => 2;
+
+	my $tmpbase = workdir('tempdir-test-exists');
+	my $env     = mock_env(
+		workpath => sub {
+			my ($self, $path) = @_;
+			return "$tmpbase/$path";
+		}
+	);
+	my $hook = make_hook($env);
+
+	my $dir1 = $hook->tempdir('existing');
+	my $dir2 = $hook->tempdir('existing');
+	ok(-d $dir1, 'directory created by first call');
+	is($dir1, $dir2, 'second call returns same path without error');
+};
+
+# ---------------------------------------------------------------------------
+# load_hook_module
+# ---------------------------------------------------------------------------
+subtest 'load_hook_module - dies when kit returns no module name' => sub {
+	plan tests => 1;
+
+	# kit->get_hook_module returns undef (as set in shared $kit definition).
+	# bail() wraps output at 80 columns so the error may span multiple lines;
+	# match the two key fragments independently using [\s\S]* to cross lines.
+	throws_ok {
+		Genesis::Hook->load_hook_module('hooks/blueprint.pm', $kit)
+	} qr/does not exist for kit[\s\S]*test-kit\/1\.0\.0/,
+		'load_hook_module() dies when kit->get_hook_module returns undef';
+};
+
+# ---------------------------------------------------------------------------
+# bosh
+# ---------------------------------------------------------------------------
+subtest 'bosh - returns connected bosh client' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	my $got;
+	lives_ok { $got = $hook->bosh() } 'bosh() lives without error';
+	is($got, $bosh, 'bosh() returns the bosh object from env->bosh');
+};
+
+subtest 'bosh - caches the result' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $got1 = $hook->bosh();
+	my $got2 = $hook->bosh();
+	is($got1, $got2, 'bosh() returns the same cached object on second call');
+};
+
+# ---------------------------------------------------------------------------
+# get_config_override
+# ---------------------------------------------------------------------------
+subtest 'get_config_override - CloudConfig subclass resolves under bosh-configs.cloud' => sub {
+	plan tests => 1;
+
+	my $env = mock_env(
+		lookup => sub {
+			my ($self, $key, $default) = @_;
+			return 'found-value' if $key eq 'bosh-configs.cloud.networks';
+			return $default;
+		}
+	);
+
+	require Genesis::Hook::CloudConfig;
+	my $hook = bless(
+		{ env => $env, complete => 0, type => 'cloud-config', label => '[test] ' },
+		'Genesis::Hook::CloudConfig'
+	);
+
+	my $val = $hook->get_config_override('networks', 'default-val');
+	is($val, 'found-value',
+		'CloudConfig hook resolves key under bosh-configs.cloud.*');
+};
+
+subtest 'get_config_override - RuntimeConfig subclass resolves under bosh-configs.runtime' => sub {
+	plan tests => 1;
+
+	my $env = mock_env(
+		lookup => sub {
+			my ($self, $key, $default) = @_;
+			return 'runtime-found' if $key eq 'bosh-configs.runtime.addons';
+			return $default;
+		}
+	);
+
+	require Genesis::Hook::RuntimeConfig;
+	my $hook = bless(
+		{ env => $env, complete => 0, type => 'runtime-config', label => '[test] ' },
+		'Genesis::Hook::RuntimeConfig'
+	);
+
+	my $val = $hook->get_config_override('addons', []);
+	is($val, 'runtime-found',
+		'RuntimeConfig hook resolves key under bosh-configs.runtime.*');
+};
+
+subtest 'get_config_override - falls back to default when key is absent' => sub {
+	plan tests => 1;
+
+	my $env = mock_env();  # lookup always returns $default
+
+	require Genesis::Hook::CloudConfig;
+	my $hook = bless(
+		{ env => $env, complete => 0, type => 'cloud-config', label => '[test] ' },
+		'Genesis::Hook::CloudConfig'
+	);
+
+	my $val = $hook->get_config_override('nonexistent', 'the-default');
+	is($val, 'the-default',
+		'get_config_override() returns default when key is not found');
+};
+
+subtest 'get_config_override - explicit type prefix bypasses class detection' => sub {
+	plan tests => 1;
+
+	my $env = mock_env(
+		lookup => sub {
+			my ($self, $key, $default) = @_;
+			return 'runtime-value' if $key eq 'bosh-configs.runtime.addons';
+			return $default;
+		}
+	);
+
+	require Genesis::Hook::CloudConfig;
+	my $hook = bless(
+		{ env => $env, complete => 0, type => 'cloud-config', label => '[test] ' },
+		'Genesis::Hook::CloudConfig'
+	);
+
+	my $val = $hook->get_config_override('runtime.addons', []);
+	is($val, 'runtime-value',
+		'explicit "runtime." prefix is used as-is regardless of hook class');
+};
+
+subtest 'get_config_override - dies for base Genesis::Hook without type prefix' => sub {
+	plan tests => 1;
+
+	my $hook = bless(
+		{ env => mock_env(), complete => 0, type => 'blueprint', label => '[test] ' },
+		'Genesis::Hook'
+	);
+
+	throws_ok {
+		$hook->get_config_override('networks', [])
+	} qr/hooks must specify the bosh_config type/,
+		'get_config_override() dies when hook is base class and key has no type prefix';
+};
+
+done_testing;
+# vim: fdm=marker:ts=2:sw=2:sts=2:noet:cc=80

--- a/t/unit-tests/genesis_hook_addon-core.t
+++ b/t/unit-tests/genesis_hook_addon-core.t
@@ -1,0 +1,479 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+
+use lib 't';
+use helper;
+use Test::More;
+use Test::Exception;
+use Test::Deep;
+use Genesis qw(bail);
+use Cwd qw(abs_path);
+
+$ENV{GENESIS_CALLBACK_BIN} ||= abs_path('bin/genesis');
+$ENV{GENESIS_LIB} ||= abs_path('lib');
+$ENV{GENESIS_OUTPUT_COLUMNS} = 80;
+$ENV{NOCOLOR} = 1;
+
+# ---------------------------------------------------------------------------
+# Load the module under test
+# ---------------------------------------------------------------------------
+require_ok 'Genesis::Hook::Addon';
+
+# ---------------------------------------------------------------------------
+# Test subclass - Genesis::Hook::Addon requires the class name to match
+# Genesis::Hook::<Type>::<KitName> so that label() can parse it.
+# ---------------------------------------------------------------------------
+{
+	package Genesis::Hook::Addon::test_kit;
+	use parent -norequire, 'Genesis::Hook::Addon';
+
+	sub perform {
+		my ($self) = @_;
+		$self->done('addon-result');
+	}
+}
+
+# ---------------------------------------------------------------------------
+# Shared mock objects
+# ---------------------------------------------------------------------------
+
+my $test_seq = 0;
+
+my $vault_service = mock "Genesis::Vault::Service" => {
+	type => 'vault',
+};
+
+my $secrets_store = mock "Genesis::Env::SecretsStore" => {
+	service => sub { return $vault_service },
+};
+
+my $kit = mock "Genesis::Kit" => {
+	name                => 'test-kit',
+	version             => '1.0.0',
+	genesis_version_min => '3.1.0-rc.10',
+	id                  => sub { return $_[0]->name . '/' . $_[0]->version },
+	kit_bug => sub {
+		my ($self, $msg, @args) = @_;
+		bail("Throwing a kit bug: ".$msg, @args);
+	},
+	path => sub {
+		my ($self, $file) = @_;
+		return defined($file) ? "/mock/kit/path/$file" : "/mock/kit/path";
+	},
+	metadata => { supports => ['aws', 'vsphere', 'openstack'] },
+	get_hook_module => sub { return undef },
+};
+
+my $bosh = mock "Genesis::BOSH" => {
+	alias                => 'mock-bosh',
+	connect_and_validate => sub { return $_[0] },
+};
+
+sub mock_env {
+	$test_seq++;
+	my $seq = $test_seq;
+	mock "Genesis::Env" => {(
+		name            => "test-env-$seq",
+		type            => 'test',
+		kit             => $kit,
+		bosh            => sub {
+			my $self = shift;
+			return $bosh;
+		},
+		use_create_env  => 0,
+		features        => Mock::ReferencedValue->new(['ha', 'tls']),
+		iaas            => 'aws',
+		scale           => 'dev',
+		is_ocfp         => 0,
+		cpi_name        => 'aws_cpi',
+		cpi_enabled     => 1,
+		secrets_store   => sub { return $secrets_store },
+		deployments     => mock("Genesis::Env::Deployments::$seq" => {
+			current_state => 'deployed',
+		}),
+		workpath => sub {
+			my ($self, $path) = @_;
+			return "/tmp/genesis-test-work/$path";
+		},
+		exodus_lookup => sub {
+			my ($self, $key, $default) = @_;
+			return { director_url => 'https://bosh.example.com', admin_user => 'admin' }
+				if $key eq '.';
+			return $default;
+		},
+		lookup => sub {
+			my ($self, $key, $default) = @_;
+			return $default;
+		},
+		path => sub { return "/mock/env/path/$_[1]" },
+		file => 'test-env.yml',
+	), @_};
+}
+
+# Convenience: instantiate our Addon test subclass
+sub make_hook {
+	my %args = @_;
+	my $env    = delete $args{env}    || mock_env();
+	my $script = delete $args{script} || 'test-cmd';
+	my $args   = delete $args{args}   || [];
+	return Genesis::Hook::Addon::test_kit->init(
+		env    => $env,
+		kit    => $kit,
+		script => $script,
+		args   => $args,
+		%args,
+	);
+}
+
+# ---------------------------------------------------------------------------
+# Globals set before all subtests
+# ---------------------------------------------------------------------------
+$Genesis::VERSION = '3.1.0-rc.10';
+$ENV{GENESIS_CALL_BIN} = 'genesis';
+$ENV{GENESIS_KIT_HOOK} = 'addon';
+
+# ---------------------------------------------------------------------------
+# Genesis::Hook::Addon must be loaded
+# ---------------------------------------------------------------------------
+subtest 'Genesis::Hook::Addon module loads' => sub {
+	plan tests => 1;
+	ok(defined(&Genesis::Hook::Addon::init), 'Genesis::Hook::Addon::init is defined');
+};
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+subtest 'init - missing env dies' => sub {
+	plan tests => 1;
+
+	throws_ok {
+		Genesis::Hook::Addon::test_kit->init(
+			kit    => $kit,
+			script => 'test-cmd',
+			args   => [],
+		)
+	} qr/Missing required arguments for a perl-based kit hook call: env/,
+		'init() without env argument dies with required-args message';
+};
+
+subtest 'init - missing kit dies' => sub {
+	plan tests => 1;
+
+	my $env = mock_env();
+	throws_ok {
+		Genesis::Hook::Addon::test_kit->init(
+			env    => $env,
+			script => 'test-cmd',
+			args   => [],
+		)
+	} qr/Missing required arguments for a perl-based kit hook call: kit/,
+		'init() without kit argument dies with required-args message';
+};
+
+subtest 'init - missing script dies' => sub {
+	plan tests => 1;
+
+	my $env = mock_env();
+	throws_ok {
+		Genesis::Hook::Addon::test_kit->init(
+			env  => $env,
+			kit  => $kit,
+			args => [],
+		)
+	} qr/Missing required arguments for a perl-based kit hook call: script/,
+		'init() without script argument dies with required-args message';
+};
+
+subtest 'init - missing args dies' => sub {
+	plan tests => 1;
+
+	my $env = mock_env();
+	throws_ok {
+		Genesis::Hook::Addon::test_kit->init(
+			env    => $env,
+			kit    => $kit,
+			script => 'test-cmd',
+		)
+	} qr/Missing required arguments for a perl-based kit hook call: args/,
+		'init() without args argument dies with required-args message';
+};
+
+subtest 'init - returns blessed object with all required fields' => sub {
+	plan tests => 8;
+
+	my $env = mock_env();
+	my $hook;
+	lives_ok {
+		$hook = Genesis::Hook::Addon::test_kit->init(
+			env    => $env,
+			kit    => $kit,
+			script => 'rotate-creds',
+			args   => ['--force'],
+		)
+	} 'init() succeeds with all required arguments';
+
+	ok(defined $hook,                          'init() returns a defined value');
+	isa_ok($hook, 'Genesis::Hook::Addon',      'returned object isa Genesis::Hook::Addon');
+	isa_ok($hook, 'Genesis::Hook',             'returned object isa Genesis::Hook');
+	is($hook->env,       $env,                 'env() returns the env passed to init()');
+	is($hook->{script},  'rotate-creds',       'script is stored on the object');
+	is_deeply($hook->{args}, ['--force'],      'args are stored on the object');
+	is($hook->{type},    $ENV{GENESIS_KIT_HOOK}, 'type is set from GENESIS_KIT_HOOK');
+};
+
+subtest 'init - stores kit on object' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	is($hook->{kit}, $kit, 'kit is stored on the hook object');
+};
+
+subtest 'init - complete flag starts at 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	is($hook->{complete}, 0, 'complete flag initializes to 0');
+};
+
+subtest 'init - empty args array is valid' => sub {
+	plan tests => 2;
+
+	my $env = mock_env();
+	my $hook;
+	lives_ok {
+		$hook = Genesis::Hook::Addon::test_kit->init(
+			env    => $env,
+			kit    => $kit,
+			script => 'test-cmd',
+			args   => [],
+		)
+	} 'init() accepts empty args array ref';
+	is_deeply($hook->{args}, [], 'empty args array stored correctly');
+};
+
+# ---------------------------------------------------------------------------
+# parse_options
+# ---------------------------------------------------------------------------
+subtest 'parse_options - returns hash in list context' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook(args => ['--verbose', '--output', 'result.txt']);
+	my %opts;
+	lives_ok {
+		%opts = $hook->parse_options(['verbose|v', 'output|o=s']);
+	} 'parse_options() succeeds with matching args';
+
+	is($opts{verbose}, 1,            'verbose flag parsed correctly');
+	is($opts{output},  'result.txt', 'output option parsed correctly');
+};
+
+subtest 'parse_options - returns hashref in scalar context' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook(args => ['--dry-run']);
+	my $opts;
+	lives_ok {
+		$opts = $hook->parse_options(['dry-run|n']);
+	} 'parse_options() succeeds in scalar context';
+
+	ok(ref($opts) eq 'HASH', 'scalar context returns a hash reference');
+	is($opts->{'dry-run'}, 1, 'dry-run flag parsed correctly');
+};
+
+subtest 'parse_options - applies defaults for unset options' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook(args => []);
+	my %opts;
+	lives_ok {
+		%opts = $hook->parse_options(
+			['verbose|v', 'output|o=s'],
+			output => 'default.txt',
+		);
+	} 'parse_options() succeeds with no args and defaults';
+
+	ok(!$opts{verbose}, 'verbose is false/undef when not specified');
+	is($opts{output}, 'default.txt', 'output retains default when not in args');
+};
+
+subtest 'parse_options - command-line args override defaults' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook(args => ['--output', 'custom.txt']);
+	my %opts = $hook->parse_options(
+		['output|o=s'],
+		output => 'default.txt',
+	);
+	is($opts{output}, 'custom.txt', 'command-line arg overrides default value');
+};
+
+subtest 'parse_options - short flags work via bundling' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook(args => ['-v', '-o', 'out.txt']);
+	my %opts = $hook->parse_options(['verbose|v', 'output|o=s']);
+
+	is($opts{verbose}, 1,        'short flag -v parsed correctly');
+	is($opts{output},  'out.txt','short option -o parsed correctly');
+};
+
+subtest 'parse_options - unknown option dies' => sub {
+	plan tests => 1;
+
+	# With no_pass_through, GetOptionsFromArray rejects unknown flags and
+	# returns false, causing bail("Error parsing command line arguments").
+	my $hook = make_hook(args => ['--unknown-flag']);
+	throws_ok {
+		$hook->parse_options(['verbose|v']);
+	} qr/Error parsing command line arguments/,
+		'parse_options() dies when GetOptionsFromArray rejects unknown option';
+};
+
+subtest 'parse_options - non-option args remain in args array' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook(args => ['--verbose', 'positional-arg']);
+	my %opts = $hook->parse_options(['verbose|v']);
+
+	is($opts{verbose}, 1,               'flag parsed correctly alongside positional');
+	is_deeply($hook->{args}, ['positional-arg'],
+		'positional arg remains in args after parsing');
+};
+
+subtest 'parse_options - no args and no defaults yields empty-ish hash' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook(args => []);
+	my %opts = $hook->parse_options(['verbose|v', 'count|c=i']);
+	ok(!defined $opts{verbose} && !defined $opts{count},
+		'unprovided options are undef with no defaults');
+};
+
+# ---------------------------------------------------------------------------
+# vault
+# ---------------------------------------------------------------------------
+subtest 'vault - returns vault service from secrets_store' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	my $got;
+	lives_ok { $got = $hook->vault } 'vault() does not die';
+	is($got, $vault_service, 'vault() returns the vault service object');
+};
+
+subtest 'vault - caches vault service on second call' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	my $first  = $hook->vault;
+	my $second = $hook->vault;
+
+	is($first,  $vault_service, 'first call returns vault service');
+	is($second, $first,         'second call returns same cached object');
+};
+
+subtest 'vault - cached in {vault} slot on hook' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->vault;
+	is($hook->{vault}, $vault_service,
+		'vault service cached in {vault} slot after first call');
+};
+
+# ---------------------------------------------------------------------------
+# results
+# ---------------------------------------------------------------------------
+subtest 'results - returns 1 unconditionally' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	is($hook->results, 1, 'results() returns 1 without calling done()');
+};
+
+subtest 'results - returns 1 even after done(0)' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->done(0);
+	is($hook->results, 1, 'results() returns 1 even after done(0)');
+};
+
+subtest 'results - returns 1 even when complete flag is 0' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	is($hook->{complete}, 0, 'complete flag is 0 before done()');
+	is($hook->results, 1, 'results() still returns 1 when not yet complete');
+};
+
+subtest 'results - is independent of done() call' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook();
+	is($hook->results, 1, 'results() is 1 before done()');
+	$hook->done('something');
+	is($hook->results, 1, 'results() is still 1 after done("something")');
+	$hook->done(undef);
+	is($hook->results, 1, 'results() is still 1 after done(undef)');
+};
+
+# ---------------------------------------------------------------------------
+# help - no addons defined case
+# ---------------------------------------------------------------------------
+subtest 'help - returns 0 and prints message when no addon files exist' => sub {
+	plan tests => 2;
+
+	# Use a real temp directory that has no addon-* files
+	require File::Temp;
+	my $tmpdir = File::Temp::tempdir(CLEANUP => 1);
+	mkdir("$tmpdir/hooks") or die "cannot create hooks dir: $!";
+
+	# Create a kit mock whose path() points to the temp dir
+	my $empty_kit = mock "Genesis::Kit::Empty" => {
+		name    => 'empty-kit',
+		version => '0.0.1',
+		id      => sub { 'empty-kit/0.0.1' },
+		kit_bug => sub {
+			my ($self, $msg, @args) = @_;
+			bail("Throwing a kit bug: ".$msg, @args);
+		},
+		path => sub {
+			my ($self, $file) = @_;
+			return defined($file) ? "$tmpdir/$file" : $tmpdir;
+		},
+		metadata            => { supports => [] },
+		get_hook_module     => sub { return undef },
+		genesis_version_min => '3.1.0-rc.10',
+	};
+
+	# Build an env whose kit() returns the empty kit
+	my $env = mock_env(kit => $empty_kit);
+
+	# Build the hook pointing at this temp kit
+	my $hook = Genesis::Hook::Addon::test_kit->init(
+		env    => $env,
+		kit    => $empty_kit,
+		script => 'test-cmd',
+		args   => [],
+	);
+
+	# Capture STDERR output from help()
+	my $stderr_output = '';
+	{
+		local *STDERR;
+		open(STDERR, '>', \$stderr_output) or die "can't redirect STDERR: $!";
+		$hook->help;
+	}
+
+	ok(1, 'help() ran without dying when no addon files present');
+	like(
+		$stderr_output,
+		qr/No addons are defined for the empty-kit\/0\.0\.1 kit/,
+		'help() prints "no addons" message to STDERR',
+	);
+};
+
+done_testing;

--- a/t/unit-tests/genesis_hook_blueprint-core.t
+++ b/t/unit-tests/genesis_hook_blueprint-core.t
@@ -1,0 +1,859 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+
+use lib 't';
+use helper;
+use Test::More;
+use Test::Exception;
+use Test::Deep;
+use Genesis qw(bail);
+use Cwd qw(abs_path);
+
+$ENV{GENESIS_CALLBACK_BIN} ||= abs_path('bin/genesis');
+$ENV{GENESIS_LIB} ||= abs_path('lib');
+$ENV{GENESIS_OUTPUT_COLUMNS} = 80;
+$ENV{NOCOLOR} = 1;
+
+# ---------------------------------------------------------------------------
+# Load the module under test
+# ---------------------------------------------------------------------------
+require_ok 'Genesis::Hook::Blueprint';
+
+# ---------------------------------------------------------------------------
+# Test subclass - Genesis::Hook requires the class name to match
+# Genesis::Hook::<Type>::<KitName> so that label() can parse it.
+# ---------------------------------------------------------------------------
+{
+	package Genesis::Hook::Blueprint::test_kit;
+	use parent -norequire, 'Genesis::Hook::Blueprint';
+
+	sub perform {
+		my ($self) = @_;
+		$self->done($self->results);
+	}
+}
+
+# ---------------------------------------------------------------------------
+# Globals set before all subtests
+# ---------------------------------------------------------------------------
+$Genesis::VERSION = '3.1.0-rc.10';
+$ENV{GENESIS_CALL_BIN} = 'genesis';
+$ENV{GENESIS_KIT_HOOK} = 'blueprint';
+
+# ---------------------------------------------------------------------------
+# Shared mock objects
+# ---------------------------------------------------------------------------
+
+my $test_seq = 0;
+
+my $kit = mock "Genesis::Kit" => {
+	name                => 'test-kit',
+	version             => '1.0.0',
+	genesis_version_min => '3.1.0-rc.10',
+	id                  => sub { return $_[0]->name . '/' . $_[0]->version },
+	kit_bug => sub {
+		my ($self, $msg, @args) = @_;
+		bail("Throwing a kit bug: " . $msg, @args);
+	},
+	path => sub {
+		my ($self, $file) = @_;
+		return defined($file) ? "/mock/kit/path/$file" : "/mock/kit/path";
+	},
+	metadata            => { supports => ['aws', 'vsphere', 'openstack'] },
+	get_hook_module     => sub { return undef },
+};
+
+my $bosh = mock "Genesis::BOSH" => {
+	alias                => 'mock-bosh',
+	connect_and_validate => sub { return $_[0] },
+};
+
+sub mock_env {
+	$test_seq++;
+	my $seq = $test_seq;
+	my %overrides = @_;
+	mock "Genesis::Env::$seq" => {(
+		name           => "test-env-$seq",
+		type           => 'test',
+		kit            => $kit,
+		bosh           => sub { return $bosh },
+		use_create_env => 0,
+		features       => Mock::ReferencedValue->new(['ha', 'tls']),
+		iaas           => 'aws',
+		scale          => 'dev',
+		is_ocfp        => 0,
+		cpi_name       => 'aws_cpi',
+		cpi_enabled    => 1,
+		deployments    => mock("Genesis::Env::Deployments::$seq" => {
+			current_state => 'deployed',
+		}),
+		workpath => sub {
+			my ($self, $path) = @_;
+			return "/tmp/genesis-test-work/$path";
+		},
+		exodus_lookup => sub {
+			my ($self, $key, $default) = @_;
+			return { director_url => 'https://bosh.example.com', admin_user => 'admin' }
+				if $key eq '.';
+			return $default;
+		},
+		lookup => sub {
+			my ($self, $key, $default) = @_;
+			return $default;
+		},
+		path => sub {
+			my ($self, $file) = @_;
+			return defined($file) ? "/mock/env/path/$file" : "/mock/env/path";
+		},
+		file => 'test-env.yml',
+	), %overrides};
+}
+
+sub make_hook {
+	my $env = ref($_[0]) ? shift : mock_env();
+	return Genesis::Hook::Blueprint::test_kit->init(env => $env, @_);
+}
+
+# ---------------------------------------------------------------------------
+# Genesis::Hook::Blueprint must be loaded
+# ---------------------------------------------------------------------------
+subtest 'Genesis::Hook::Blueprint module loads' => sub {
+	plan tests => 1;
+	ok(defined(&Genesis::Hook::Blueprint::init),
+		'Genesis::Hook::Blueprint::init is defined');
+};
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+subtest 'init - delegates to parent and returns blessed object' => sub {
+	plan tests => 4;
+
+	my $env  = mock_env();
+	my $hook;
+	lives_ok {
+		$hook = Genesis::Hook::Blueprint::test_kit->init(env => $env)
+	} 'init() succeeds with valid env';
+
+	ok(defined $hook, 'init() returns a defined value');
+	isa_ok($hook, 'Genesis::Hook::Blueprint',
+		'returned object isa Genesis::Hook::Blueprint');
+	isa_ok($hook, 'Genesis::Hook', 'returned object isa Genesis::Hook');
+};
+
+subtest 'init - initializes features from env' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	ok(defined $hook->{features}, 'features array ref is defined after init');
+	cmp_deeply(
+		$hook->{features},
+		['ha', 'tls'],
+		'features initialized from env->features'
+	);
+};
+
+subtest 'init - initializes files to empty array ref' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	ok(defined $hook->{files}, 'files array ref is defined after init');
+	cmp_deeply($hook->{files}, [], 'files starts as empty array ref');
+};
+
+subtest 'init - complete flag starts at 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	is($hook->{complete}, 0, 'complete flag initializes to 0');
+};
+
+# ---------------------------------------------------------------------------
+# add_files
+# ---------------------------------------------------------------------------
+subtest 'add_files - appends a single file' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->add_files('base/base.yml');
+
+	is(scalar(@{$hook->{files}}), 1, 'one file in list after add_files');
+	is($hook->{files}[0], 'base/base.yml', 'correct file appended');
+};
+
+subtest 'add_files - appends multiple files in one call' => sub {
+	plan tests => 4;
+
+	my $hook = make_hook();
+	$hook->add_files('base/base.yml', 'base/ha.yml', 'base/tls.yml');
+
+	is(scalar(@{$hook->{files}}), 3, 'three files in list');
+	is($hook->{files}[0], 'base/base.yml',  'first file correct');
+	is($hook->{files}[1], 'base/ha.yml',    'second file correct');
+	is($hook->{files}[2], 'base/tls.yml',   'third file correct');
+};
+
+subtest 'add_files - preserves insertion order across multiple calls' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook();
+	$hook->add_files('first.yml');
+	$hook->add_files('second.yml');
+	$hook->add_files('third.yml');
+
+	is($hook->{files}[0], 'first.yml',  'first call order preserved');
+	is($hook->{files}[1], 'second.yml', 'second call order preserved');
+	is($hook->{files}[2], 'third.yml',  'third call order preserved');
+};
+
+# ---------------------------------------------------------------------------
+# add_files_if_wants
+# ---------------------------------------------------------------------------
+subtest 'add_files_if_wants - adds file when feature is active' => sub {
+	plan tests => 2;
+
+	# env has 'ha' and 'tls' features
+	my $hook = make_hook();
+	$hook->add_files_if_wants('ha', 'base/ha.yml');
+
+	is(scalar(@{$hook->{files}}), 1, 'one file added when feature active');
+	is($hook->{files}[0], 'base/ha.yml', 'correct file added for active feature');
+};
+
+subtest 'add_files_if_wants - no-op when feature not active' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->add_files_if_wants('external-db', 'base/external-db.yml');
+
+	is(scalar(@{$hook->{files}}), 0, 'no files added when feature not active');
+};
+
+subtest 'add_files_if_wants - adds multiple files when feature active' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook();
+	$hook->add_files_if_wants('tls', 'base/tls.yml', 'base/tls-certs.yml');
+
+	is(scalar(@{$hook->{files}}), 2, 'both files added when feature active');
+	is($hook->{files}[0], 'base/tls.yml',       'first file correct');
+	is($hook->{files}[1], 'base/tls-certs.yml', 'second file correct');
+};
+
+subtest 'add_files_if_wants - accepts regexp feature test' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->add_files_if_wants(qr/^ha$/, 'base/ha.yml');
+
+	is(scalar(@{$hook->{files}}), 1, 'one file added on regexp match');
+	is($hook->{files}[0], 'base/ha.yml', 'correct file added via regexp');
+};
+
+subtest 'add_files_if_wants - regexp no-op when no feature matches' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->add_files_if_wants(qr/^proto-/, 'base/proto.yml');
+
+	is(scalar(@{$hook->{files}}), 0, 'no files added when regexp does not match');
+};
+
+# ---------------------------------------------------------------------------
+# add_files_if_exists
+# ---------------------------------------------------------------------------
+subtest 'add_files_if_exists - adds relative file when it exists under kit root' => sub {
+	plan tests => 2;
+
+	my $dir = workdir();
+	put_file("$dir/overlays/custom.yml", "---\n# custom\n");
+
+	my $local_kit = mock "Genesis::Kit::Exists" => {
+		name    => 'test-kit',
+		version => '1.0.0',
+		id      => sub { $_[0]->name . '/' . $_[0]->version },
+		kit_bug => sub { bail("Throwing a kit bug: " . $_[1]) },
+		path    => sub {
+			my ($self, $file) = @_;
+			return defined($file) ? "$dir/$file" : $dir;
+		},
+		metadata        => { supports => ['aws'] },
+		get_hook_module => sub { undef },
+	};
+
+	my $env = mock_env(kit => $local_kit);
+	my $hook = make_hook($env);
+
+	$hook->add_files_if_exists('overlays/custom.yml');
+
+	is(scalar(@{$hook->{files}}), 1, 'one file added when relative file exists');
+	is($hook->{files}[0], 'overlays/custom.yml', 'relative path added as-is');
+};
+
+subtest 'add_files_if_exists - skips relative file when it does not exist' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->add_files_if_exists('overlays/nonexistent.yml');
+
+	is(scalar(@{$hook->{files}}), 0, 'no file added when relative path does not exist');
+};
+
+subtest 'add_files_if_exists - adds absolute path when within env dir and exists' => sub {
+	plan tests => 2;
+
+	my $dir = workdir();
+	my $env_dir = "$dir/myenv";
+	put_file("$env_dir/ops/override.yml", "---\n# override\n");
+
+	my $local_kit = mock "Genesis::Kit::AbsExists" => {
+		name    => 'test-kit',
+		version => '1.0.0',
+		id      => sub { $_[0]->name . '/' . $_[0]->version },
+		kit_bug => sub { bail("Throwing a kit bug: " . $_[1]) },
+		path    => sub {
+			my ($self, $file) = @_;
+			return defined($file) ? "$env_dir/$file" : $env_dir;
+		},
+		metadata        => { supports => ['aws'] },
+		get_hook_module => sub { undef },
+	};
+
+	my $env = mock_env(
+		kit  => $local_kit,
+		path => sub {
+			my ($self, $file) = @_;
+			return defined($file) ? "$env_dir/$file" : $env_dir;
+		},
+	);
+
+	my $hook = make_hook($env);
+	my $abs_path = "$env_dir/ops/override.yml";
+	$hook->add_files_if_exists($abs_path);
+
+	is(scalar(@{$hook->{files}}), 1, 'one file added for existing absolute path in env dir');
+	is($hook->{files}[0], $abs_path, 'absolute path stored as-is');
+};
+
+subtest 'add_files_if_exists - skips absolute path outside env dir' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->add_files_if_exists('/etc/passwd');
+
+	is(scalar(@{$hook->{files}}), 0,
+		'absolute path outside env dir silently skipped');
+};
+
+subtest 'add_files_if_exists - processes multiple files independently' => sub {
+	plan tests => 2;
+
+	my $dir = workdir();
+	put_file("$dir/exists.yml", "---\n# exists\n");
+
+	my $local_kit = mock "Genesis::Kit::MultiExists" => {
+		name    => 'test-kit',
+		version => '1.0.0',
+		id      => sub { $_[0]->name . '/' . $_[0]->version },
+		kit_bug => sub { bail("Throwing a kit bug: " . $_[1]) },
+		path    => sub {
+			my ($self, $file) = @_;
+			return defined($file) ? "$dir/$file" : $dir;
+		},
+		metadata        => { supports => ['aws'] },
+		get_hook_module => sub { undef },
+	};
+
+	my $env = mock_env(kit => $local_kit);
+	my $hook = make_hook($env);
+
+	$hook->add_files_if_exists('exists.yml', 'missing.yml');
+
+	is(scalar(@{$hook->{files}}), 1, 'only existing file added');
+	is($hook->{files}[0], 'exists.yml', 'correct existing file in list');
+};
+
+# ---------------------------------------------------------------------------
+# remove_files
+# ---------------------------------------------------------------------------
+subtest 'remove_files - removes a file from the list' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->add_files('a.yml', 'b.yml', 'c.yml');
+	$hook->remove_files('b.yml');
+
+	is(scalar(@{$hook->{files}}), 2, 'two files remain after removal');
+	cmp_deeply($hook->{files}, ['a.yml', 'c.yml'],
+		'remaining files in original order');
+};
+
+subtest 'remove_files - silently ignores files not in the list' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->add_files('a.yml', 'b.yml');
+	$hook->remove_files('nonexistent.yml');
+
+	is(scalar(@{$hook->{files}}), 2, 'list unchanged when file not found');
+	cmp_deeply($hook->{files}, ['a.yml', 'b.yml'], 'original files still present');
+};
+
+subtest 'remove_files - removes multiple files at once' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->add_files('a.yml', 'b.yml', 'c.yml', 'd.yml');
+	$hook->remove_files('a.yml', 'c.yml');
+
+	is(scalar(@{$hook->{files}}), 2, 'two files remain after removing two');
+	cmp_deeply($hook->{files}, ['b.yml', 'd.yml'],
+		'remaining files in original order');
+};
+
+subtest 'remove_files - preserves order of remaining files' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->add_files('first.yml', 'second.yml', 'third.yml', 'fourth.yml');
+	$hook->remove_files('second.yml');
+
+	cmp_deeply(
+		$hook->{files},
+		['first.yml', 'third.yml', 'fourth.yml'],
+		'order of remaining files preserved after removal'
+	);
+};
+
+# ---------------------------------------------------------------------------
+# exchange_files
+# ---------------------------------------------------------------------------
+subtest 'exchange_files - replaces a file in-place' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->add_files('base/networking-v1.yml', 'base/ha.yml');
+	$hook->exchange_files('base/networking-v1.yml' => 'base/networking-v2.yml');
+
+	is(scalar(@{$hook->{files}}), 2, 'file count unchanged after exchange');
+	is($hook->{files}[0], 'base/networking-v2.yml',
+		'old file replaced with new file at same position');
+};
+
+subtest 'exchange_files - preserves position of exchanged file' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook();
+	$hook->add_files('a.yml', 'old.yml', 'c.yml');
+	$hook->exchange_files('old.yml' => 'new.yml');
+
+	is($hook->{files}[0], 'a.yml',   'file before exchange unchanged');
+	is($hook->{files}[1], 'new.yml', 'exchanged file at original position');
+	is($hook->{files}[2], 'c.yml',   'file after exchange unchanged');
+};
+
+subtest 'exchange_files - ignores keys not in file list' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->add_files('a.yml', 'b.yml');
+	$hook->exchange_files('nonexistent.yml' => 'replacement.yml');
+
+	is(scalar(@{$hook->{files}}), 2, 'list unchanged when key not found');
+	cmp_deeply($hook->{files}, ['a.yml', 'b.yml'],
+		'original files unchanged after non-matching exchange');
+};
+
+subtest 'exchange_files - handles multiple exchanges at once' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->add_files('old-a.yml', 'middle.yml', 'old-b.yml');
+	$hook->exchange_files(
+		'old-a.yml' => 'new-a.yml',
+		'old-b.yml' => 'new-b.yml',
+	);
+
+	is($hook->{files}[0], 'new-a.yml', 'first exchange applied');
+	is($hook->{files}[2], 'new-b.yml', 'second exchange applied');
+};
+
+# ---------------------------------------------------------------------------
+# ops_dir
+# ---------------------------------------------------------------------------
+subtest 'ops_dir - returns default ops when genesis.ops_dir not set' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	is($hook->ops_dir, 'ops', 'ops_dir returns default "ops"');
+};
+
+subtest 'ops_dir - returns configured genesis.ops_dir value' => sub {
+	plan tests => 1;
+
+	my $env = mock_env(
+		lookup => sub {
+			my ($self, $key, $default) = @_;
+			return 'custom-ops' if $key eq 'genesis.ops_dir';
+			return $default;
+		},
+	);
+	my $hook = make_hook($env);
+
+	is($hook->ops_dir, 'custom-ops',
+		'ops_dir returns value from genesis.ops_dir lookup');
+};
+
+# ---------------------------------------------------------------------------
+# upstream_dir
+# ---------------------------------------------------------------------------
+subtest 'upstream_dir - returns undef when not configured' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	is($hook->upstream_dir, undef,
+		'upstream_dir returns undef when upstream_dir not set');
+};
+
+subtest 'upstream_dir - returns value with trailing slash' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->{upstream_dir} = 'upstream';
+	is($hook->upstream_dir, 'upstream/', 'upstream_dir appends trailing slash');
+};
+
+subtest 'upstream_dir - does not double-append trailing slash' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->{upstream_dir} = 'upstream/';
+	is($hook->upstream_dir, 'upstream/',
+		'upstream_dir does not duplicate trailing slash');
+};
+
+# ---------------------------------------------------------------------------
+# upstream_pattern_match
+# ---------------------------------------------------------------------------
+subtest 'upstream_pattern_match - returns default regex when not configured' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	my $re = $hook->upstream_pattern_match;
+
+	ok(ref($re) eq 'Regexp', 'upstream_pattern_match returns a Regexp');
+	ok('operations/ha' =~ $re,
+		'default pattern matches operations/ha');
+};
+
+subtest 'upstream_pattern_match - default pattern does not match non-operations path' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	ok('ha' !~ $hook->upstream_pattern_match,
+		'default pattern does not match bare feature name');
+};
+
+subtest 'upstream_pattern_match - returns custom regex when configured' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	my $custom = qr/^features\/(.*)$/;
+	$hook->{upstream_pattern_match} = $custom;
+
+	my $re = $hook->upstream_pattern_match;
+	ok('features/ha' =~ $re, 'custom pattern matches features/ha');
+	ok('operations/ha' !~ $re, 'custom pattern does not match operations/ha');
+};
+
+# ---------------------------------------------------------------------------
+# validate_features
+# ---------------------------------------------------------------------------
+subtest 'validate_features - accepts valid features (array ref)' => sub {
+	plan tests => 2;
+
+	my $env = mock_env(
+		features => Mock::ReferencedValue->new(['ha', 'tls']),
+	);
+	my $hook = make_hook($env);
+
+	lives_ok {
+		$hook->validate_features(
+			valid_features => [qw(ha tls external-db)],
+		);
+	} 'validate_features lives with all valid features';
+
+	cmp_deeply([$hook->features], ['ha', 'tls'],
+		'valid features retained after validation');
+};
+
+subtest 'validate_features - accepts valid features (hash ref)' => sub {
+	plan tests => 1;
+
+	my $env = mock_env(
+		features => Mock::ReferencedValue->new(['ha']),
+	);
+	my $hook = make_hook($env);
+
+	lives_ok {
+		$hook->validate_features(
+			valid_features => { ha => 1, tls => 1 },
+		);
+	} 'validate_features accepts hash ref for valid_features';
+};
+
+subtest 'validate_features - dies on invalid valid_features type' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+
+	throws_ok {
+		$hook->validate_features(
+			valid_features => 'not-a-ref',
+		);
+	} qr/Invalid valid_features parameter/,
+		'validate_features bails when valid_features is a plain scalar';
+};
+
+subtest 'validate_features - dies on undef valid_features' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+
+	throws_ok {
+		$hook->validate_features(
+			valid_features => undef,
+		);
+	} qr/Invalid valid_features parameter/,
+		'validate_features bails when valid_features is undef';
+};
+
+subtest 'validate_features - bails on invalid feature' => sub {
+	plan tests => 1;
+
+	my $env = mock_env(
+		features => Mock::ReferencedValue->new(['unknown-feature']),
+	);
+	my $hook = make_hook($env);
+
+	throws_ok {
+		$hook->validate_features(
+			valid_features => [qw(ha tls)],
+		);
+	} qr/Feature validation encountered the following errors/,
+		'validate_features bails when feature is not valid';
+};
+
+subtest 'validate_features - deprecated feature with single string replacement' => sub {
+	plan tests => 2;
+
+	my $env = mock_env(
+		features => Mock::ReferencedValue->new(['postgres']),
+	);
+	my $hook = make_hook($env);
+
+	lives_ok {
+		$hook->validate_features(
+			valid_features => [qw(ha tls external-db)],
+			deprecated_features => {
+				'postgres' => { replace => 'external-db' },
+			},
+		);
+	} 'validate_features lives when deprecated feature has single replacement';
+
+	cmp_deeply([$hook->features], ['external-db'],
+		'deprecated feature replaced with its single replacement');
+};
+
+subtest 'validate_features - deprecated feature with array replacement' => sub {
+	plan tests => 2;
+
+	my $env = mock_env(
+		features => Mock::ReferencedValue->new(['old-tls']),
+	);
+	my $hook = make_hook($env);
+
+	lives_ok {
+		$hook->validate_features(
+			valid_features => [qw(ha tls mutual-tls)],
+			deprecated_features => {
+				'old-tls' => { replace => ['tls', 'mutual-tls'] },
+			},
+		);
+	} 'validate_features lives when deprecated feature has array replacement';
+
+	cmp_deeply([$hook->features], ['tls', 'mutual-tls'],
+		'deprecated feature replaced with all array replacements');
+};
+
+subtest 'validate_features - deprecated feature with empty array (now default)' => sub {
+	plan tests => 2;
+
+	my $env = mock_env(
+		features => Mock::ReferencedValue->new(['legacy']),
+	);
+	my $hook = make_hook($env);
+
+	lives_ok {
+		$hook->validate_features(
+			valid_features => [qw(ha tls)],
+			deprecated_features => {
+				'legacy' => { replace => [] },
+			},
+		);
+	} 'validate_features lives when deprecated feature is now default (empty array)';
+
+	cmp_deeply([$hook->features], [],
+		'deprecated default feature removed from feature list');
+};
+
+subtest 'validate_features - deprecated feature with undef replacement (removed)' => sub {
+	plan tests => 1;
+
+	my $env = mock_env(
+		features => Mock::ReferencedValue->new(['removed-feature']),
+	);
+	my $hook = make_hook($env);
+
+	throws_ok {
+		$hook->validate_features(
+			valid_features => [qw(ha tls)],
+			deprecated_features => {
+				'removed-feature' => { replace => undef },
+			},
+		);
+	} qr/Feature validation encountered the following errors/,
+		'validate_features bails when deprecated feature has been removed (undef replacement)';
+};
+
+subtest 'validate_features - mutually exclusive features error' => sub {
+	plan tests => 1;
+
+	my $env = mock_env(
+		features => Mock::ReferencedValue->new(['internal-db', 'external-db']),
+	);
+	my $hook = make_hook($env);
+
+	throws_ok {
+		$hook->validate_features(
+			valid_features => [qw(internal-db external-db)],
+			mutually_exclusive_features => {
+				'database' => [qw(internal-db external-db)],
+			},
+		);
+	} qr/Feature validation encountered the following errors/,
+		'validate_features bails when mutually exclusive features both set';
+};
+
+subtest 'validate_features - single member of exclusive group is allowed' => sub {
+	plan tests => 2;
+
+	my $env = mock_env(
+		features => Mock::ReferencedValue->new(['external-db']),
+	);
+	my $hook = make_hook($env);
+
+	lives_ok {
+		$hook->validate_features(
+			valid_features => [qw(internal-db external-db)],
+			mutually_exclusive_features => {
+				'database' => [qw(internal-db external-db)],
+			},
+		);
+	} 'validate_features lives with only one member of exclusive group';
+
+	cmp_deeply([$hook->features], ['external-db'],
+		'single exclusive feature retained');
+};
+
+subtest 'validate_features - updates features list after validation' => sub {
+	plan tests => 1;
+
+	my $env = mock_env(
+		features => Mock::ReferencedValue->new(['ha', 'tls']),
+	);
+	my $hook = make_hook($env);
+
+	$hook->validate_features(
+		valid_features => [qw(ha tls external-db)],
+	);
+
+	cmp_deeply([$hook->features], bag('ha', 'tls'),
+		'feature list updated via set_features after validation');
+};
+
+subtest 'validate_features - accepts ops file feature from env ops_dir' => sub {
+	plan tests => 2;
+
+	my $dir = workdir();
+	my $ops_dir = "$dir/ops";
+	put_file("$ops_dir/custom-ops.yml", "---\n# custom ops\n");
+
+	my $env = mock_env(
+		features => Mock::ReferencedValue->new(['custom-ops']),
+		lookup   => sub {
+			my ($self, $key, $default) = @_;
+			return $default;
+		},
+		path => sub {
+			my ($self, $file) = @_;
+			return defined($file) ? "$dir/$file" : $dir;
+		},
+	);
+	my $hook = make_hook($env);
+
+	lives_ok {
+		$hook->validate_features(
+			valid_features => [qw(ha tls)],
+		);
+	} 'validate_features accepts feature backed by ops file in env ops_dir';
+
+	cmp_deeply([$hook->features], ['custom-ops'],
+		'ops-file-backed feature retained after validation');
+};
+
+# ---------------------------------------------------------------------------
+# results
+# ---------------------------------------------------------------------------
+subtest 'results - returns file list after done() called' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->add_files('base/base.yml', 'base/ha.yml');
+	$hook->{complete} = 1;
+
+	my $files;
+	lives_ok { $files = $hook->results } 'results() lives when hook is complete';
+	cmp_deeply($files, ['base/base.yml', 'base/ha.yml'],
+		'results() returns the file list array ref');
+};
+
+subtest 'results - dies when hook not complete' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->add_files('base/base.yml');
+	# complete remains 0
+
+	throws_ok {
+		$hook->results
+	} qr/Blueprint hook could not be run/,
+		'results() bails when hook not marked complete';
+};
+
+subtest 'results - dies when file list is empty after completion' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->{complete} = 1;
+	# files remains empty
+
+	throws_ok {
+		$hook->results
+	} qr/Could not determine which YAML files to merge/,
+		'results() bails when hook complete but no files were added';
+};
+
+done_testing;

--- a/t/unit-tests/genesis_hook_check-core.t
+++ b/t/unit-tests/genesis_hook_check-core.t
@@ -1,0 +1,780 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+
+use lib 't';
+use helper;
+use Test::More;
+use Test::Exception;
+use Test::Deep;
+use Genesis qw(bail);
+use Cwd qw(abs_path);
+
+$ENV{GENESIS_CALLBACK_BIN} ||= abs_path('bin/genesis');
+$ENV{GENESIS_LIB} ||= abs_path('lib');
+$ENV{GENESIS_OUTPUT_COLUMNS} = 80;
+$ENV{NOCOLOR} = 1;
+
+# ---------------------------------------------------------------------------
+# Load the module under test
+# ---------------------------------------------------------------------------
+require_ok 'Genesis::Hook::Check';
+
+# ---------------------------------------------------------------------------
+# Test subclass — Genesis::Hook requires class name
+# Genesis::Hook::<Type>::<KitName> so that label() can parse it.
+# ---------------------------------------------------------------------------
+{
+	package Genesis::Hook::Check::test_kit;
+	use parent -norequire, 'Genesis::Hook::Check';
+
+	sub perform {
+		my ($self) = @_;
+		$self->done(0);
+	}
+}
+
+# ---------------------------------------------------------------------------
+# Shared mock objects
+# ---------------------------------------------------------------------------
+
+my $test_seq = 0;
+
+my $kit = mock "Genesis::Kit" => {
+	name                => 'test-kit',
+	version             => '1.0.0',
+	genesis_version_min => '3.1.0-rc.10',
+	id                  => sub { return $_[0]->name . '/' . $_[0]->version },
+	kit_bug => sub {
+		my ($self, $msg, @args) = @_;
+		bail("Throwing a kit bug: " . $msg, @args);
+	},
+	path => sub {
+		my ($self, $file) = @_;
+		return "/mock/kit/path/$file";
+	},
+	metadata => { supports => ['aws', 'vsphere', 'openstack'] },
+	get_hook_module => sub { return undef },
+};
+
+my $bosh = mock "Genesis::BOSH" => {
+	alias                => 'mock-bosh',
+	connect_and_validate => sub { return $_[0] },
+};
+
+my $cloud_config_data = {
+	vm_types  => [ { name => 'small' }, { name => 'large' } ],
+	networks  => [ { name => 'default' } ],
+	disk_types => [ { name => 'default' } ],
+};
+
+my $runtime_config_data = {
+	addons => [
+		{
+			name => 'addon1',
+			jobs  => [ { name => 'bosh-dns' }, { name => 'syslog' } ],
+		},
+	],
+};
+
+my $env_lookup_data = {
+	params => {
+		base_domain     => 'example.com',
+		scale           => 'dev',
+		list_param      => [1, 2, 3],
+	},
+};
+
+sub mock_env {
+	$test_seq++;
+	my $seq = $test_seq;
+	mock "Genesis::Env" => {(
+		name           => "test-env-$seq",
+		type           => 'test',
+		kit            => $kit,
+		bosh           => sub { return $bosh },
+		use_create_env => 0,
+		features       => Mock::ReferencedValue->new(['ha', 'tls']),
+		iaas           => 'aws',
+		scale          => 'dev',
+		is_ocfp        => 0,
+		cpi_name       => 'aws_cpi',
+		cpi_enabled    => 1,
+		deployments    => mock("Genesis::Env::Deployments::$seq" => {
+			current_state => 'deployed',
+		}),
+		workpath => sub {
+			my ($self, $path) = @_;
+			return "/tmp/genesis-test-work/$path";
+		},
+		config_contents => sub {
+			my ($self, %opts) = @_;
+			return $cloud_config_data   if ($opts{type} // '') eq 'cloud';
+			return $runtime_config_data if ($opts{type} // '') eq 'runtime';
+			return {};
+		},
+		exodus_lookup => sub {
+			my ($self, $key, $default, $for) = @_;
+			if ($key eq '.') {
+				return { name => 'test-env', director_url => 'https://bosh.example.com' };
+			}
+			# When $for ends in '/bosh' (env_name/bosh), return data for director_url
+			if (defined $for && $for =~ m{/bosh$}) {
+				return 'https://bosh.example.com' if $key eq 'director_url';
+			}
+			return $default;
+		},
+		lookup => sub {
+			my ($self, $key, $default) = @_;
+			return $env_lookup_data unless defined $key;
+			return $default;
+		},
+		path => sub { return "/mock/env/path/$_[1]" },
+		file => 'test-env.yml',
+	), @_};
+}
+
+sub make_hook {
+	my $env = shift || mock_env();
+	return Genesis::Hook::Check::test_kit->init(env => $env, kit => $kit, @_);
+}
+
+# ---------------------------------------------------------------------------
+# Globals set before all subtests
+# ---------------------------------------------------------------------------
+$Genesis::VERSION = '3.1.0-rc.10';
+$ENV{GENESIS_CALL_BIN}  = 'genesis';
+$ENV{GENESIS_KIT_HOOK}  = 'check';
+
+# ---------------------------------------------------------------------------
+# Genesis::Hook::Check must be loaded
+# ---------------------------------------------------------------------------
+subtest 'Genesis::Hook::Check module loads' => sub {
+	plan tests => 1;
+	ok(defined(&Genesis::Hook::Check::init), 'Genesis::Hook::Check::init is defined');
+};
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+subtest 'init - missing env dies' => sub {
+	plan tests => 1;
+
+	throws_ok {
+		Genesis::Hook::Check::test_kit->init(kit => $kit)
+	} qr/Missing required arguments for a perl-based kit hook call: env/,
+		'init() without env argument dies with required-args message';
+};
+
+subtest 'init - missing kit dies' => sub {
+	plan tests => 1;
+
+	my $env = mock_env();
+	throws_ok {
+		Genesis::Hook::Check::test_kit->init(env => $env)
+	} qr/Missing required arguments for a perl-based kit hook call: kit/,
+		'init() without kit argument dies with required-args message';
+};
+
+subtest 'init - returns blessed object' => sub {
+	plan tests => 4;
+
+	my $env  = mock_env();
+	my $hook;
+	lives_ok {
+		$hook = Genesis::Hook::Check::test_kit->init(env => $env, kit => $kit)
+	} 'init() succeeds with env and kit';
+
+	ok(defined $hook, 'init() returns a defined value');
+	isa_ok($hook, 'Genesis::Hook::Check', 'returned object isa Genesis::Hook::Check');
+	isa_ok($hook, 'Genesis::Hook',        'returned object isa Genesis::Hook');
+};
+
+subtest 'init - env stored on object' => sub {
+	plan tests => 1;
+
+	my $env  = mock_env();
+	my $hook = Genesis::Hook::Check::test_kit->init(env => $env, kit => $kit);
+	is($hook->env, $env, 'env() returns the env passed to init()');
+};
+
+subtest 'init - type set from GENESIS_KIT_HOOK' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	is($hook->{type}, 'check', 'type is set to "check" from GENESIS_KIT_HOOK');
+};
+
+subtest 'init - complete flag starts at 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	is($hook->{complete}, 0, 'complete flag initializes to 0');
+};
+
+# ---------------------------------------------------------------------------
+# start_check
+# ---------------------------------------------------------------------------
+subtest 'start_check - does not die on cloud-config' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	lives_ok {
+		quietly { $hook->start_check('cloud-config') }
+	} 'start_check("cloud-config") does not die';
+};
+
+subtest 'start_check - does not die on runtime-config' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	lives_ok {
+		quietly { $hook->start_check('runtime-config') }
+	} 'start_check("runtime-config") does not die';
+};
+
+subtest 'start_check - does not die on environment' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	lives_ok {
+		quietly { $hook->start_check('environment') }
+	} 'start_check("environment") does not die';
+};
+
+subtest 'start_check - does not die with underscore type' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	lives_ok {
+		quietly { $hook->start_check('runtime_config') }
+	} 'start_check("runtime_config") does not die';
+};
+
+# ---------------------------------------------------------------------------
+# check_result — explicit result values
+# ---------------------------------------------------------------------------
+subtest 'check_result - "passed" returns 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $ret;
+	quietly { $ret = $hook->check_result('cloud-config', 'passed') };
+	is($ret, 1, 'check_result with "passed" returns 1');
+};
+
+subtest 'check_result - "ok" normalized to passed returns 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $ret;
+	quietly { $ret = $hook->check_result('cloud-config', 'ok') };
+	is($ret, 1, 'check_result with "ok" returns 1');
+};
+
+subtest 'check_result - "1" normalized to passed returns 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $ret;
+	quietly { $ret = $hook->check_result('cloud-config', '1') };
+	is($ret, 1, 'check_result with "1" returns 1');
+};
+
+subtest 'check_result - "error" normalized to failed returns 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $ret;
+	quietly { $ret = $hook->check_result('cloud-config', 'error') };
+	is($ret, 0, 'check_result with "error" returns 0');
+};
+
+subtest 'check_result - false value returns 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $ret;
+	quietly { $ret = $hook->check_result('cloud-config', 0) };
+	is($ret, 0, 'check_result with 0 returns 0');
+};
+
+subtest 'check_result - truthy non-standard string returns 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $ret;
+	quietly { $ret = $hook->check_result('cloud-config', 'warning') };
+	is($ret, 1, 'check_result with "warning" (other truthy) returns 1');
+};
+
+subtest 'check_result - explicit message does not die' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	lives_ok {
+		quietly { $hook->check_result('environment', 0, 'missing required params') }
+	} 'check_result with message does not die';
+};
+
+# ---------------------------------------------------------------------------
+# check_result — derived from accumulated has_entry checks
+# ---------------------------------------------------------------------------
+subtest 'check_result - undef result: all passing checks yields 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	quietly {
+		$hook->has_entry('cloud-config', 'vm_type', 'small');
+		$hook->has_entry('cloud-config', 'network', 'default');
+	};
+	my $ret;
+	quietly { $ret = $hook->check_result('cloud-config') };
+	is($ret, 1, 'check_result(undef) returns 1 when all prior has_entry checks passed');
+};
+
+subtest 'check_result - undef result: any failing check yields 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	quietly {
+		$hook->has_entry('cloud-config', 'vm_type', 'small');
+		$hook->has_entry('cloud-config', 'vm_type', 'nonexistent');
+	};
+	my $ret;
+	quietly { $ret = $hook->check_result('cloud-config') };
+	is($ret, 0, 'check_result(undef) returns 0 when any prior has_entry check failed');
+};
+
+# ---------------------------------------------------------------------------
+# has_entry — dispatch and accumulation
+# ---------------------------------------------------------------------------
+subtest 'has_entry - unknown config type returns 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $ret;
+	quietly { $ret = $hook->has_entry('bogus-config', 'vm_type', 'small') };
+	is($ret, 0, 'has_entry with unknown config type returns 0');
+};
+
+subtest 'has_entry - unknown config type does not accumulate' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	quietly { $hook->has_entry('bogus-config', 'vm_type', 'small') };
+	ok(!exists $hook->{__entry_checks}{'bogus-config'},
+		'unknown config type does not store an entry check result');
+};
+
+subtest 'has_entry - cloud-config hit accumulates as true' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	quietly { $hook->has_entry('cloud-config', 'vm_type', 'small') };
+	is($hook->{__entry_checks}{'cloud-config'}{vm_type}{small}, 1,
+		'has_entry stores 1 for matching cloud-config vm_type');
+};
+
+subtest 'has_entry - cloud-config miss accumulates as false' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	quietly { $hook->has_entry('cloud-config', 'vm_type', 'xlarge') };
+	is($hook->{__entry_checks}{'cloud-config'}{vm_type}{xlarge}, 0,
+		'has_entry stores 0 for missing cloud-config vm_type');
+};
+
+subtest 'has_entry - runtime-config job hit accumulates as true' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	quietly { $hook->has_entry('runtime-config', 'job', 'bosh-dns') };
+	is($hook->{__entry_checks}{'runtime-config'}{job}{'bosh-dns'}, 1,
+		'has_entry stores 1 for matching runtime-config job');
+};
+
+subtest 'has_entry - runtime-config job miss accumulates as false' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	quietly { $hook->has_entry('runtime-config', 'job', 'nonexistent-job') };
+	is($hook->{__entry_checks}{'runtime-config'}{job}{'nonexistent-job'}, 0,
+		'has_entry stores 0 for missing runtime-config job');
+};
+
+subtest 'has_entry - environment params hit accumulates as true' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	quietly { $hook->has_entry('environment', 'params', 'base_domain') };
+	is($hook->{__entry_checks}{environment}{params}{base_domain}, 1,
+		'has_entry stores 1 for defined environment param');
+};
+
+subtest 'has_entry - environment params miss accumulates as false' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	quietly { $hook->has_entry('environment', 'params', 'undefined_param') };
+	is($hook->{__entry_checks}{environment}{params}{undefined_param}, 0,
+		'has_entry stores 0 for missing environment param');
+};
+
+# ---------------------------------------------------------------------------
+# has_cloud_config_entry
+# ---------------------------------------------------------------------------
+subtest 'has_cloud_config_entry - vm_type small exists returns 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $ret;
+	quietly { $ret = $hook->has_cloud_config_entry('vm_type', 'small') };
+	is($ret, 1, 'has_cloud_config_entry returns 1 for existing vm_type "small"');
+};
+
+subtest 'has_cloud_config_entry - vm_type large exists returns 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $ret;
+	quietly { $ret = $hook->has_cloud_config_entry('vm_type', 'large') };
+	is($ret, 1, 'has_cloud_config_entry returns 1 for existing vm_type "large"');
+};
+
+subtest 'has_cloud_config_entry - vm_type xlarge missing returns 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $ret;
+	quietly { $ret = $hook->has_cloud_config_entry('vm_type', 'xlarge') };
+	is($ret, 0, 'has_cloud_config_entry returns 0 for missing vm_type "xlarge"');
+};
+
+subtest 'has_cloud_config_entry - network default exists returns 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $ret;
+	quietly { $ret = $hook->has_cloud_config_entry('network', 'default') };
+	is($ret, 1, 'has_cloud_config_entry returns 1 for existing network "default"');
+};
+
+subtest 'has_cloud_config_entry - network missing returns 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $ret;
+	quietly { $ret = $hook->has_cloud_config_entry('network', 'private') };
+	is($ret, 0, 'has_cloud_config_entry returns 0 for missing network "private"');
+};
+
+subtest 'has_cloud_config_entry - empty type list returns 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $ret;
+	# 'az' is not in our cloud config mock, so the list is empty/absent
+	quietly { $ret = $hook->has_cloud_config_entry('az', 'z1') };
+	is($ret, 0, 'has_cloud_config_entry returns 0 when type list is absent');
+};
+
+subtest 'has_cloud_config_entry - cloud config is cached after first call' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	quietly {
+		$hook->has_cloud_config_entry('vm_type', 'small');
+		$hook->has_cloud_config_entry('network', 'default');
+	};
+	ok(exists $hook->{__cloud_config}, 'cloud config is cached in __cloud_config after first call');
+};
+
+# ---------------------------------------------------------------------------
+# has_runtime_config_entry
+# ---------------------------------------------------------------------------
+subtest 'has_runtime_config_entry - job bosh-dns exists returns 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my ($ret) = $hook->has_runtime_config_entry('job', 'bosh-dns');
+	is($ret, 1, 'has_runtime_config_entry returns 1 for job "bosh-dns" in addon');
+};
+
+subtest 'has_runtime_config_entry - job syslog exists returns 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my ($ret) = $hook->has_runtime_config_entry('job', 'syslog');
+	is($ret, 1, 'has_runtime_config_entry returns 1 for job "syslog" in addon');
+};
+
+subtest 'has_runtime_config_entry - missing job returns 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my ($ret) = $hook->has_runtime_config_entry('job', 'nonexistent-job');
+	is($ret, 0, 'has_runtime_config_entry returns 0 for missing job');
+};
+
+subtest 'has_runtime_config_entry - non-job type dies' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	throws_ok {
+		$hook->has_runtime_config_entry('addon', 'some-addon')
+	} qr/bug|Unknown check type/i,
+		'has_runtime_config_entry with non-job type calls bug() and dies';
+};
+
+subtest 'has_runtime_config_entry - runtime config cached after first call' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->has_runtime_config_entry('job', 'bosh-dns');
+	ok(exists $hook->{__runtime_config}, 'runtime config cached in __runtime_config after first call');
+};
+
+subtest 'has_runtime_config_entry - job list cached after first call' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->has_runtime_config_entry('job', 'bosh-dns');
+	ok(exists $hook->{__runtime_config_jobs}, 'job list cached in __runtime_config_jobs after first call');
+};
+
+# ---------------------------------------------------------------------------
+# has_environment_entry — params: plain existence
+# ---------------------------------------------------------------------------
+subtest 'has_environment_entry - params defined param returns 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my ($ret) = $hook->has_environment_entry('params', 'base_domain');
+	is($ret, 1, 'has_environment_entry returns 1 for defined params.base_domain');
+};
+
+subtest 'has_environment_entry - params undefined param returns 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my ($ret) = $hook->has_environment_entry('params', 'no_such_param');
+	is($ret, 0, 'has_environment_entry returns 0 for undefined params.no_such_param');
+};
+
+# ---------------------------------------------------------------------------
+# has_environment_entry — params: type check
+# ---------------------------------------------------------------------------
+subtest 'has_environment_entry - params type=string for string value returns 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my ($ret) = $hook->has_environment_entry('params', 'base_domain', type => 'string');
+	is($ret, 1, 'has_environment_entry returns 1 when param is a string and type=string');
+};
+
+subtest 'has_environment_entry - params type=string for array ref also returns 1' => sub {
+	plan tests => 1;
+
+	# The implementation computes actualtype as:
+	#   lc(ref($param) || defined($param) ? 'string' : 'undefined')
+	# Any truthy ref() causes the ternary to yield 'string', so array refs
+	# are also treated as type 'string' by the current implementation.
+	my $hook = make_hook();
+	my ($ret) = $hook->has_environment_entry('params', 'list_param', type => 'string');
+	is($ret, 1, 'has_environment_entry returns 1 for array ref with type=string (ref is truthy in ternary)');
+};
+
+subtest 'has_environment_entry - params type=undefined for absent param returns 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my ($ret) = $hook->has_environment_entry('params', 'no_such_param', type => 'undefined');
+	is($ret, 1, 'has_environment_entry returns 1 when param is absent and type=undefined');
+};
+
+subtest 'has_environment_entry - params type=undefined for defined param returns 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my ($ret) = $hook->has_environment_entry('params', 'base_domain', type => 'undefined');
+	is($ret, 0, 'has_environment_entry returns 0 when param is defined and type=undefined');
+};
+
+# ---------------------------------------------------------------------------
+# has_environment_entry — params: value_in
+# ---------------------------------------------------------------------------
+subtest 'has_environment_entry - params value_in matches returns 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my ($ret) = $hook->has_environment_entry('params', 'scale',
+		value_in => [qw(dev staging prod)]);
+	is($ret, 1, 'has_environment_entry returns 1 when param value is in allowed list');
+};
+
+subtest 'has_environment_entry - params value_in no match returns 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my ($ret) = $hook->has_environment_entry('params', 'scale',
+		value_in => [qw(staging prod)]);
+	is($ret, 0, 'has_environment_entry returns 0 when param value is not in allowed list');
+};
+
+subtest 'has_environment_entry - params value_in undefined param returns 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my ($ret) = $hook->has_environment_entry('params', 'no_such_param',
+		value_in => [qw(a b c)]);
+	is($ret, 0, 'has_environment_entry returns 0 when param is undefined and value_in used');
+};
+
+# ---------------------------------------------------------------------------
+# has_environment_entry — params: retired
+# ---------------------------------------------------------------------------
+subtest 'has_environment_entry - params retired and absent returns 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my ($ret) = $hook->has_environment_entry('params', 'no_such_param', retired => 1);
+	is($ret, 1, 'has_environment_entry returns 1 for retired param that is absent');
+};
+
+subtest 'has_environment_entry - params retired but still defined returns 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my ($ret) = $hook->has_environment_entry('params', 'base_domain', retired => 1);
+	is($ret, 0, 'has_environment_entry returns 0 for retired param that is still defined');
+};
+
+# ---------------------------------------------------------------------------
+# has_environment_entry — exodus type
+# ---------------------------------------------------------------------------
+subtest 'has_environment_entry - exodus name key present returns 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	# Without env/deployment opts, checks $self->exodus_data->{name}
+	my ($ret) = $hook->has_environment_entry('exodus', 'name');
+	is($ret, 1, 'has_environment_entry returns 1 when exodus_data has "name" key');
+};
+
+subtest 'has_environment_entry - exodus with deployment returns 1 for known key' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my ($ret) = $hook->has_environment_entry('exodus', 'director_url',
+		deployment => 'bosh');
+	is($ret, 1, 'has_environment_entry returns 1 for known exodus key with deployment');
+};
+
+subtest 'has_environment_entry - exodus with deployment returns 0 for unknown key' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my ($ret) = $hook->has_environment_entry('exodus', 'no_such_key',
+		deployment => 'bosh');
+	is($ret, 0, 'has_environment_entry returns 0 for missing exodus key with deployment');
+};
+
+# ---------------------------------------------------------------------------
+# has_environment_entry — unknown type dies
+# ---------------------------------------------------------------------------
+subtest 'has_environment_entry - unknown type dies' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	throws_ok {
+		$hook->has_environment_entry('unknown_type', 'some_name')
+	} qr/bug|Unknown check type/i,
+		'has_environment_entry with unknown type calls bug() and dies';
+};
+
+# ---------------------------------------------------------------------------
+# environment manifest is cached
+# ---------------------------------------------------------------------------
+subtest 'has_environment_entry - environment manifest cached after first call' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->has_environment_entry('params', 'base_domain');
+	ok(exists $hook->{__environment}, 'environment manifest cached in __environment');
+};
+
+# ---------------------------------------------------------------------------
+# Full check workflow integration
+# ---------------------------------------------------------------------------
+subtest 'full check workflow - cloud-config all pass' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook();
+	quietly { $hook->start_check('cloud-config') };
+	quietly { $hook->has_entry('cloud-config', 'vm_type', 'small') };
+	quietly { $hook->has_entry('cloud-config', 'network', 'default') };
+	my $ret;
+	quietly { $ret = $hook->check_result('cloud-config') };
+	is($ret, 1, 'full cloud-config check with all passing entries returns 1');
+	is($hook->{__entry_checks}{'cloud-config'}{vm_type}{small},  1, 'vm_type small recorded as pass');
+	is($hook->{__entry_checks}{'cloud-config'}{network}{default}, 1, 'network default recorded as pass');
+};
+
+subtest 'full check workflow - cloud-config with failure' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	quietly { $hook->start_check('cloud-config') };
+	quietly { $hook->has_entry('cloud-config', 'vm_type', 'small') };
+	quietly { $hook->has_entry('cloud-config', 'vm_type', 'missing') };
+	my $ret;
+	quietly { $ret = $hook->check_result('cloud-config') };
+	is($ret, 0, 'full cloud-config check with one failing entry returns 0');
+};
+
+subtest 'full check workflow - runtime-config job check' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	quietly { $hook->start_check('runtime-config') };
+	quietly { $hook->has_entry('runtime-config', 'job', 'bosh-dns') };
+	my $ret;
+	quietly { $ret = $hook->check_result('runtime-config') };
+	is($ret, 1, 'full runtime-config check with existing job returns 1');
+};
+
+subtest 'full check workflow - environment params check' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	quietly { $hook->start_check('environment') };
+	quietly { $hook->has_entry('environment', 'params', 'base_domain') };
+	my $ret;
+	quietly { $ret = $hook->check_result('environment') };
+	is($ret, 1, 'full environment check with defined param returns 1');
+};
+
+subtest 'full check workflow - independent check results per config' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	quietly {
+		$hook->start_check('cloud-config');
+		$hook->has_entry('cloud-config', 'vm_type', 'small');
+
+		$hook->start_check('environment');
+		$hook->has_entry('environment', 'params', 'no_such_param');
+	};
+
+	my ($cloud_ret, $env_ret);
+	quietly {
+		$cloud_ret = $hook->check_result('cloud-config');
+		$env_ret   = $hook->check_result('environment');
+	};
+	is($cloud_ret, 1, 'cloud-config check result is 1 (independent of env check)');
+	is($env_ret,   0, 'environment check result is 0 (independent of cloud-config check)');
+};
+
+done_testing;

--- a/t/unit-tests/genesis_hook_cpiconfig-core.t
+++ b/t/unit-tests/genesis_hook_cpiconfig-core.t
@@ -1,0 +1,711 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+
+use lib 't';
+use helper;
+use Test::More;
+use Test::Exception;
+use Test::Deep;
+use Genesis qw(bail);
+use Cwd qw(abs_path);
+use Digest::SHA qw(sha1_hex);
+
+$ENV{GENESIS_CALLBACK_BIN} ||= abs_path('bin/genesis');
+$ENV{GENESIS_LIB} ||= abs_path('lib');
+$ENV{GENESIS_OUTPUT_COLUMNS} = 80;
+$ENV{NOCOLOR} = 1;
+
+# ---------------------------------------------------------------------------
+# Load the module under test
+# ---------------------------------------------------------------------------
+require_ok 'Genesis::Hook::CpiConfig';
+
+# ---------------------------------------------------------------------------
+# Test subclass - Genesis::Hook requires the class name to match
+# Genesis::Hook::<Type>::<KitName> so that label() can parse it.
+# ---------------------------------------------------------------------------
+{
+	package Genesis::Hook::CpiConfig::test_kit;
+	use parent -norequire, 'Genesis::Hook::CpiConfig';
+
+	sub perform {
+		my ($self) = @_;
+		my $config = $self->build_cpi_config_for_iaas(
+			aws => { region => 'us-east-1' },
+		);
+		$self->done($config);
+	}
+}
+
+# ---------------------------------------------------------------------------
+# Shared kit and bosh mocks
+# ---------------------------------------------------------------------------
+
+my $kit = mock "Genesis::Kit::CpiConfig" => {
+	name                => 'test-kit',
+	version             => '1.0.0',
+	genesis_version_min => '3.1.0-rc.10',
+	id                  => sub { return $_[0]->name . '/' . $_[0]->version },
+	kit_bug => sub {
+		my ($self, $msg, @args) = @_;
+		bail("Throwing a kit bug: " . $msg, @args);
+	},
+	path => sub {
+		my ($self, $file) = @_;
+		return "/mock/kit/path/$file";
+	},
+	metadata => { supports => ['aws', 'vsphere', 'openstack'] },
+	get_hook_module => sub { return undef },
+};
+
+my $bosh = mock "Genesis::BOSH::CpiConfig" => {
+	alias                => 'mock-bosh',
+	connect_and_validate => sub { return $_[0] },
+};
+
+# Each call to mock_env() uses a unique env name so each subtest gets a fresh
+# CpiConfig object from init().
+my $test_seq = 0;
+
+sub mock_env {
+	$test_seq++;
+	my $seq = $test_seq;
+	my $tmp = workdir("cpiconfig-$seq");
+	mock "Genesis::Env::CpiConfig::$seq" => {(
+		name            => "test-env-$seq",
+		type            => 'bosh',
+		kit             => $kit,
+		bosh            => $bosh,
+		use_create_env  => 0,
+		features        => Mock::ReferencedValue->new(['ha', 'tls']),
+		iaas            => 'aws',
+		scale           => 'dev',
+		is_ocfp         => 0,
+		cpi_name        => 'aws_cpi',
+		cpi_credhub_base => '/bosh/my-env/',
+		workdir         => $tmp,
+		workpath => sub {
+			my ($self, $path) = @_;
+			return "$tmp/$path";
+		},
+		lookup => sub {
+			my ($self, $key, $default) = @_;
+			return wantarray ? ($default, undef) : $default;
+		},
+		ocfp_config_lookup => sub {
+			my ($self, $key, $default) = @_;
+			return wantarray ? ($default, undef) : $default;
+		},
+		lookup_unevaled => sub {
+			my ($self, $key) = @_;
+			return {};
+		},
+		exodus_lookup => sub {
+			my ($self, $key, $default) = @_;
+			return $default;
+		},
+		deployments => mock("Genesis::Env::CpiConfig::Deployments::$seq" => {
+			current_state => 'deployed',
+		}),
+		file => 'test-env.yml',
+	), @_};
+}
+
+sub make_hook {
+	my $env = shift || mock_env();
+	return Genesis::Hook::CpiConfig::test_kit->init(env => $env, @_);
+}
+
+# ---------------------------------------------------------------------------
+# Globals set before all subtests
+# ---------------------------------------------------------------------------
+$Genesis::VERSION = '3.1.0-rc.10';
+$ENV{GENESIS_CALL_BIN} = 'genesis';
+$ENV{GENESIS_KIT_HOOK} = 'cpi-config';
+
+# ---------------------------------------------------------------------------
+# Genesis::Hook::CpiConfig module loads
+# ---------------------------------------------------------------------------
+subtest 'Genesis::Hook::CpiConfig module loads' => sub {
+	plan tests => 1;
+	ok(defined(&Genesis::Hook::CpiConfig::init), 'Genesis::Hook::CpiConfig::init is defined');
+};
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+subtest 'init - missing env dies' => sub {
+	plan tests => 1;
+
+	throws_ok {
+		Genesis::Hook::CpiConfig::test_kit->init()
+	} qr/Missing required arguments for a perl-based kit hook call: env/,
+		'init() without env argument dies with required-args message';
+};
+
+subtest 'init - returns blessed object with env set' => sub {
+	plan tests => 4;
+
+	my $env = mock_env();
+	my $hook;
+	lives_ok {
+		$hook = Genesis::Hook::CpiConfig::test_kit->init(env => $env)
+	} 'init() succeeds with valid env';
+
+	ok(defined $hook, 'init() returns a defined value');
+	isa_ok($hook, 'Genesis::Hook::CpiConfig', 'returned object isa Genesis::Hook::CpiConfig');
+	is($hook->env, $env, 'env() returns the env passed to init()');
+};
+
+subtest 'init - initializes empty cpi_config hash' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+
+	ok(exists $hook->{cpi_config}, 'cpi_config key exists on hook after init');
+	cmp_deeply($hook->{cpi_config}, {}, 'cpi_config is an empty hashref after init');
+};
+
+subtest 'init - initializes empty credhub_secrets hash' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+
+	ok(exists $hook->{credhub_secrets}, 'credhub_secrets key exists on hook after init');
+	cmp_deeply($hook->{credhub_secrets}, {}, 'credhub_secrets is an empty hashref after init');
+};
+
+subtest 'init - complete flag starts at 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	is($hook->{complete}, 0, 'complete flag initializes to 0');
+};
+
+# ---------------------------------------------------------------------------
+# done
+# ---------------------------------------------------------------------------
+subtest 'done - with config: serializes to yaml and sets complete=1' => sub {
+	plan tests => 5;
+
+	my $hook = make_hook();
+
+	my $config = {
+		cpis => [
+			{ name => 'aws_cpi', type => 'aws', properties => { region => 'us-east-1' } }
+		]
+	};
+
+	my $ret;
+	lives_ok {
+		$ret = $hook->done($config);
+	} 'done($config) does not die';
+
+	is($ret, 1, 'done($config) returns 1');
+	is($hook->{complete}, 1, 'complete flag set to 1 after done($config)');
+	ok(defined $hook->{contents}, 'contents is defined after done($config)');
+	like($hook->{contents}, qr/cpis:/i, 'contents contains YAML with cpis key');
+};
+
+subtest 'done - with config: contents is a YAML string' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	my $config = {
+		cpis => [
+			{ name => 'test_cpi', type => 'vsphere', properties => { datacenter => 'my-dc' } }
+		]
+	};
+
+	$hook->done($config);
+
+	like($hook->{contents}, qr/name:.*test_cpi|test_cpi/s,
+		'YAML contents includes cpi name');
+	like($hook->{contents}, qr/vsphere/,
+		'YAML contents includes iaas type');
+};
+
+subtest 'done - without config: sets contents to undef and sets complete=1' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook();
+	my $ret = $hook->done(undef, undef);
+
+	is($ret, 1, 'done(undef) returns 1');
+	is($hook->{complete}, 1, 'complete flag set to 1 after done(undef)');
+	ok(!defined $hook->{contents}, 'contents is undef when done(undef)');
+};
+
+subtest 'done - with error message: stores error and sets complete=1' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook();
+	my $ret = $hook->done(undef, 'IaaS not supported');
+
+	is($ret, 1, 'done(undef, $error) returns 1');
+	is($hook->{complete}, 1, 'complete flag set to 1 after done with error');
+	is($hook->{error}, 'IaaS not supported', 'error stored from done(undef, $error)');
+};
+
+subtest 'done - without error: error field is undef' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $config = { cpis => [{ name => 'aws_cpi', type => 'aws', properties => {} }] };
+	$hook->done($config);
+
+	ok(!defined $hook->{error}, 'error is undef when done($config) called without error arg');
+};
+
+# ---------------------------------------------------------------------------
+# results
+# ---------------------------------------------------------------------------
+subtest 'results - returns undef in scalar context when not completed' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $r = $hook->results;
+	ok(!defined $r, 'results() returns undef in scalar context before done()');
+};
+
+subtest 'results - returns empty list in list context when not completed' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my @r = $hook->results;
+	is(scalar @r, 0, 'results() returns empty list in list context before done()');
+};
+
+subtest 'results - scalar context returns hashref after done($config)' => sub {
+	plan tests => 4;
+
+	my $hook = make_hook();
+	my $config = { cpis => [{ name => 'aws_cpi', type => 'aws', properties => {} }] };
+	$hook->done($config);
+
+	my $r = $hook->results;
+	ok(defined $r, 'results() returns defined value after done($config)');
+	ok(ref $r eq 'HASH', 'results() returns a hashref in scalar context');
+	ok(exists $r->{content}, 'hashref has "content" key');
+	ok(exists $r->{credhub_secrets}, 'hashref has "credhub_secrets" key');
+};
+
+subtest 'results - scalar context hashref has content/credhub_secrets/error keys' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook();
+	my $config = { cpis => [{ name => 'aws_cpi', type => 'aws', properties => {} }] };
+	$hook->done($config, 'some error');
+
+	my $r = $hook->results;
+	ok(exists $r->{error}, 'hashref has "error" key');
+	is($r->{error}, 'some error', 'error key holds the error message');
+	ok(defined $r->{content}, 'content key holds YAML string');
+};
+
+subtest 'results - list context returns 3-tuple after done($config)' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook();
+	my $config = { cpis => [{ name => 'aws_cpi', type => 'aws', properties => {} }] };
+	$hook->done($config);
+
+	my ($content, $secrets, $error) = $hook->results;
+	ok(defined $content, 'list context: first element (content) is defined');
+	ok(ref $secrets eq 'HASH', 'list context: second element (credhub_secrets) is a hashref');
+	ok(!defined $error, 'list context: third element (error) is undef when no error given');
+};
+
+subtest 'results - list context returns 3-tuple with undef content when no config' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook();
+	$hook->done(undef, 'no config produced');
+
+	my ($content, $secrets, $error) = $hook->results;
+	ok(!defined $content, 'list context: content is undef when no config given to done()');
+	ok(ref $secrets eq 'HASH', 'list context: secrets is always a hashref');
+	is($error, 'no config produced', 'list context: error message is returned');
+};
+
+subtest 'results - credhub_secrets in results is initially empty hashref' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $config = { cpis => [{ name => 'aws_cpi', type => 'aws', properties => {} }] };
+	$hook->done($config);
+
+	my $r = $hook->results;
+	cmp_deeply($r->{credhub_secrets}, {}, 'credhub_secrets is empty hashref when no secrets gathered');
+};
+
+# ---------------------------------------------------------------------------
+# build_cpi_config_for_iaas
+# ---------------------------------------------------------------------------
+subtest 'build_cpi_config_for_iaas - valid IaaS with hash value returns correct structure' => sub {
+	plan tests => 5;
+
+	my $hook = make_hook();
+	my $props = { region => 'us-east-1', default_key_name => 'bosh' };
+
+	my $config;
+	lives_ok {
+		$config = $hook->build_cpi_config_for_iaas(
+			aws     => $props,
+			vsphere => { datacenter => 'my-dc' },
+		);
+	} 'build_cpi_config_for_iaas() does not die for known IaaS';
+
+	ok(ref $config eq 'HASH', 'returned value is a hashref');
+	ok(exists $config->{cpis}, 'returned hashref has "cpis" key');
+	ok(ref $config->{cpis} eq 'ARRAY', '"cpis" value is an arrayref');
+	is(scalar @{$config->{cpis}}, 1, '"cpis" array has exactly one entry');
+};
+
+subtest 'build_cpi_config_for_iaas - cpi entry has correct name, type, and properties' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook();
+	my $props = { region => 'us-east-1' };
+
+	my $config = $hook->build_cpi_config_for_iaas(aws => $props);
+
+	my $cpi = $config->{cpis}[0];
+	is($cpi->{name}, 'aws_cpi', 'cpi name comes from env->cpi_name');
+	is($cpi->{type}, 'aws',     'cpi type matches the IaaS key selected');
+	cmp_deeply($cpi->{properties}, $props, 'cpi properties matches the supplied hashref');
+};
+
+subtest 'build_cpi_config_for_iaas - valid IaaS with code ref value: coderef is called' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	my $called = 0;
+	my $props  = { region => 'us-west-2', called => 1 };
+
+	my $config = $hook->build_cpi_config_for_iaas(
+		aws => sub { $called = 1; return $props },
+	);
+
+	is($called, 1, 'code ref was invoked by build_cpi_config_for_iaas');
+	cmp_deeply($config->{cpis}[0]{properties}, $props,
+		'properties come from the code ref return value');
+};
+
+subtest 'build_cpi_config_for_iaas - unsupported IaaS dies with descriptive message' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+
+	throws_ok {
+		$hook->build_cpi_config_for_iaas(
+			vsphere => { datacenter => 'my-dc' },
+		);
+	} qr/Unsupported IaaS: aws/,
+		'dies with "Unsupported IaaS: aws" when env IaaS not in dispatch table';
+};
+
+subtest 'build_cpi_config_for_iaas - selects only the matching IaaS entry' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();  # env->iaas = 'aws'
+	my $aws_props   = { region => 'us-east-1' };
+	my $vsph_props  = { datacenter => 'should-not-appear' };
+
+	my $config = $hook->build_cpi_config_for_iaas(
+		aws     => $aws_props,
+		vsphere => $vsph_props,
+	);
+
+	cmp_deeply($config->{cpis}[0]{properties}, $aws_props,
+		'aws properties are selected, not vsphere');
+	is($config->{cpis}[0]{type}, 'aws', 'type is aws, not vsphere');
+};
+
+# ---------------------------------------------------------------------------
+# cpi_entombment_path_for
+# ---------------------------------------------------------------------------
+subtest 'cpi_entombment_path_for - returns deterministic path for known key/value' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	my $key   = 'vcenter_password';
+	my $value = 's3cr3t';
+
+	my $stub = 'cpi-config-property';
+	my $expected_sha = substr(sha1_hex("$stub--$key--$value"), 0, 8);
+	my $expected_path = "/bosh/my-env/${stub}--${key}--${expected_sha}";
+
+	my $path;
+	lives_ok {
+		$path = $hook->cpi_entombment_path_for($key, $value);
+	} 'cpi_entombment_path_for() does not die';
+
+	is($path, $expected_path,
+		'returned path matches expected deterministic CredHub path');
+};
+
+subtest 'cpi_entombment_path_for - path uses env->cpi_credhub_base as prefix' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $path = $hook->cpi_entombment_path_for('region', 'us-east-1');
+
+	ok($path =~ m{^/bosh/my-env/}, 'path is prefixed with cpi_credhub_base from env');
+};
+
+subtest 'cpi_entombment_path_for - uses credhub_prefix override when set' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->{credhub_prefix} = '/cpi-config/properties/';
+
+	my $key   = 'api_key';
+	my $value = 'abc123';
+	my $stub  = 'cpi-config-property';
+	my $sha   = substr(sha1_hex("$stub--$key--$value"), 0, 8);
+
+	my $path = $hook->cpi_entombment_path_for($key, $value);
+	is($path, "/cpi-config/properties/${stub}--${key}--${sha}",
+		'credhub_prefix override is used when set on hook');
+};
+
+subtest 'cpi_entombment_path_for - different values produce different paths' => sub {
+	plan tests => 1;
+
+	my $hook   = make_hook();
+	my $path_a = $hook->cpi_entombment_path_for('password', 'secret-a');
+	my $path_b = $hook->cpi_entombment_path_for('password', 'secret-b');
+
+	isnt($path_a, $path_b, 'different values for the same key produce different CredHub paths');
+};
+
+subtest 'cpi_entombment_path_for - different keys produce different paths' => sub {
+	plan tests => 1;
+
+	my $hook   = make_hook();
+	my $path_a = $hook->cpi_entombment_path_for('key-one', 'same-value');
+	my $path_b = $hook->cpi_entombment_path_for('key-two', 'same-value');
+
+	isnt($path_a, $path_b, 'different keys with the same value produce different CredHub paths');
+};
+
+subtest 'cpi_entombment_path_for - same key/value is idempotent' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $path_a = $hook->cpi_entombment_path_for('region', 'us-east-1');
+	my $path_b = $hook->cpi_entombment_path_for('region', 'us-east-1');
+
+	is($path_a, $path_b, 'same key and value always produce the same CredHub path');
+};
+
+subtest 'cpi_entombment_path_for - SHA1 stub is exactly 8 hex characters' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $path = $hook->cpi_entombment_path_for('api_key', 'my-secret');
+
+	# The sha portion is the 8 hex chars at the end after the last '--'
+	my ($sha_part) = $path =~ /--([0-9a-f]+)$/;
+	is(length($sha_part), 8, 'SHA1 suffix in CredHub path is exactly 8 hex characters');
+};
+
+# ---------------------------------------------------------------------------
+# gather_properties - basic cases
+# ---------------------------------------------------------------------------
+subtest 'gather_properties - value found in env lookup (bosh-configs.cpi.*)' => sub {
+	plan tests => 2;
+
+	# Mock env where lookup returns a value with a source for the first lookup
+	my $tmp = workdir('gather-1');
+	my $env = mock "Genesis::Env::CpiConfig::GP1" => {(
+		name            => 'test-env-gp1',
+		type            => 'bosh',
+		kit             => $kit,
+		bosh            => $bosh,
+		use_create_env  => 0,
+		features        => Mock::ReferencedValue->new([]),
+		iaas            => 'aws',
+		scale           => 'dev',
+		is_ocfp         => 0,
+		cpi_name        => 'aws_cpi',
+		cpi_credhub_base => '/bosh/test-env-gp1/',
+		workdir         => $tmp,
+		deployments     => mock("Genesis::Env::CpiConfig::GP1Deployments" => {
+			current_state => 'deployed',
+		}),
+		lookup => sub {
+			my ($self, $key, $default) = @_;
+			# Return a value + source for bosh-configs.cpi.region
+			if ($key eq 'bosh-configs.cpi.region') {
+				return wantarray ? ('us-east-1', 'env-file') : 'us-east-1';
+			}
+			return wantarray ? ($default, undef) : $default;
+		},
+		ocfp_config_lookup => sub {
+			my ($self, $key, $default) = @_;
+			return wantarray ? ($default, undef) : $default;
+		},
+		lookup_unevaled => sub { return {} },
+	)};
+
+	my $hook = Genesis::Hook::CpiConfig::test_kit->init(env => $env);
+	my $props;
+	lives_ok {
+		$props = $hook->gather_properties('region');
+	} 'gather_properties() does not die when value found in env';
+
+	is($props->{region}, 'us-east-1',
+		'property value from env lookup is returned under its key');
+};
+
+subtest 'gather_properties - uses default when not found anywhere' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();  # lookup always returns ($default, undef)
+
+	my $props;
+	lives_ok {
+		$props = $hook->gather_properties('timeout:30');
+	} 'gather_properties() does not die when using a default value';
+
+	is($props->{timeout}, 30, 'JSON-parsed default integer is stored under property key');
+};
+
+subtest 'gather_properties - string default used verbatim when not valid JSON' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $props = $hook->gather_properties('datacenter:dc-west-2');
+	is($props->{datacenter}, 'dc-west-2',
+		'non-JSON default string is stored verbatim');
+};
+
+subtest 'gather_properties - optional property omitted when not found' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();  # all lookups return undef / no source
+
+	my $props;
+	lives_ok {
+		$props = $hook->gather_properties('optional_key?');
+	} 'gather_properties() does not die for optional missing property';
+
+	ok(!exists $props->{optional_key},
+		'optional property is absent from result when not found in any source');
+};
+
+subtest 'gather_properties - missing required property falls back to empty string default' => sub {
+	# NOTE: The bail("Missing default...") in CpiConfig.pm is unreachable dead
+	# code because $default //= '' is set unconditionally before the defined
+	# check.  A property with no ':' separator and no lookup match silently
+	# falls through to empty string, not bail.  This test documents that
+	# actual runtime behavior.
+	plan tests => 2;
+
+	my $hook = make_hook();  # all lookups return undef / no source
+
+	my $props;
+	lives_ok {
+		$props = $hook->gather_properties('required_prop');
+	} 'gather_properties() does not die for required property not found (falls back to empty string)';
+
+	is($props->{required_prop}, '',
+		'required property not found falls back to empty string (bail is unreachable dead code)');
+};
+
+subtest 'gather_properties - secret property entombed in credhub_secrets' => sub {
+	plan tests => 3;
+
+	my $tmp = workdir('gather-secret');
+	my $env = mock "Genesis::Env::CpiConfig::Secret1" => {(
+		name            => 'test-env-sec1',
+		type            => 'bosh',
+		kit             => $kit,
+		bosh            => $bosh,
+		use_create_env  => 0,
+		features        => Mock::ReferencedValue->new([]),
+		iaas            => 'aws',
+		scale           => 'dev',
+		is_ocfp         => 0,
+		cpi_name        => 'aws_cpi',
+		cpi_credhub_base => '/bosh/test-env-sec1/',
+		workdir         => $tmp,
+		deployments     => mock("Genesis::Env::CpiConfig::Sec1Deployments" => {
+			current_state => 'deployed',
+		}),
+		lookup => sub {
+			my ($self, $key, $default) = @_;
+			if ($key eq 'bosh-configs.cpi.api_key') {
+				return wantarray ? ('my-secret-value', 'env-file') : 'my-secret-value';
+			}
+			return wantarray ? ($default, undef) : $default;
+		},
+		ocfp_config_lookup => sub {
+			my ($self, $key, $default) = @_;
+			return wantarray ? ($default, undef) : $default;
+		},
+		lookup_unevaled => sub { return {} },
+	)};
+
+	my $hook = Genesis::Hook::CpiConfig::test_kit->init(env => $env);
+	my $props = $hook->gather_properties('!api_key');
+
+	# The value in props should be a CredHub reference
+	like($props->{api_key}, qr/^\(\(.*\)\)$/,
+		'secret property value in config is a CredHub ((reference))');
+
+	# The credhub_secrets hash should hold the real value
+	my $secrets = $hook->{credhub_secrets};
+	is(scalar keys %$secrets, 1, 'exactly one entry stored in credhub_secrets');
+
+	my ($path, $value) = each %$secrets;
+	is($value, 'my-secret-value', 'original secret value stored in credhub_secrets');
+};
+
+subtest 'gather_properties - config_path override (>) places value under alternate key' => sub {
+	plan tests => 2;
+
+	my $tmp = workdir('gather-path');
+	my $env = mock "Genesis::Env::CpiConfig::Path1" => {(
+		name            => 'test-env-path1',
+		type            => 'bosh',
+		kit             => $kit,
+		bosh            => $bosh,
+		use_create_env  => 0,
+		features        => Mock::ReferencedValue->new([]),
+		iaas            => 'aws',
+		scale           => 'dev',
+		is_ocfp         => 0,
+		cpi_name        => 'aws_cpi',
+		cpi_credhub_base => '/bosh/test-env-path1/',
+		workdir         => $tmp,
+		deployments     => mock("Genesis::Env::CpiConfig::Path1Deployments" => {
+			current_state => 'deployed',
+		}),
+		lookup => sub {
+			my ($self, $key, $default) = @_;
+			if ($key eq 'bosh-configs.cpi.ntp') {
+				return wantarray ? ('ntp.example.com', 'env-file') : 'ntp.example.com';
+			}
+			return wantarray ? ($default, undef) : $default;
+		},
+		ocfp_config_lookup => sub {
+			my ($self, $key, $default) = @_;
+			return wantarray ? ($default, undef) : $default;
+		},
+		lookup_unevaled => sub { return {} },
+	)};
+
+	my $hook = Genesis::Hook::CpiConfig::test_kit->init(env => $env);
+	my $props = $hook->gather_properties('ntp>global.ntp');
+
+	ok(!exists $props->{ntp}, 'original key "ntp" not present in output');
+	ok(exists $props->{global} && exists $props->{global}{ntp},
+		'value is placed at the nested path global.ntp via unflatten');
+};
+
+done_testing;

--- a/t/unit-tests/genesis_hook_features-core.t
+++ b/t/unit-tests/genesis_hook_features-core.t
@@ -1,0 +1,620 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+
+use lib 't';
+use helper;
+use Test::More;
+use Test::Exception;
+use Test::Deep;
+use Genesis qw(bail);
+use Cwd qw(abs_path);
+
+$ENV{GENESIS_CALLBACK_BIN} ||= abs_path('bin/genesis');
+$ENV{GENESIS_LIB} ||= abs_path('lib');
+$ENV{GENESIS_OUTPUT_COLUMNS} = 80;
+$ENV{NOCOLOR} = 1;
+
+# ---------------------------------------------------------------------------
+# Load the module under test
+# ---------------------------------------------------------------------------
+require_ok 'Genesis::Hook::Features';
+
+# ---------------------------------------------------------------------------
+# Test subclass — Genesis::Hook requires the class name to follow the pattern
+# Genesis::Hook::<Type>::<KitName> so that label() can parse it correctly.
+# ---------------------------------------------------------------------------
+{
+	package Genesis::Hook::Features::test_kit;
+	use parent -norequire, 'Genesis::Hook::Features';
+
+	sub perform {
+		my ($self) = @_;
+		$self->add_feature('ha');
+		$self->add_feature('mtls');
+		$self->done;
+	}
+}
+
+# ---------------------------------------------------------------------------
+# Shared mock objects
+# ---------------------------------------------------------------------------
+
+my $test_seq = 0;
+
+my $kit = mock "Genesis::Kit" => {
+	name                => 'test-kit',
+	version             => '1.0.0',
+	genesis_version_min => '3.1.0-rc.10',
+	id                  => sub { return $_[0]->name . '/' . $_[0]->version },
+	kit_bug => sub {
+		my ($self, $msg, @args) = @_;
+		bail("Throwing a kit bug: ".$msg, @args);
+	},
+	path => sub {
+		my ($self, $file) = @_;
+		return "/mock/kit/path/$file";
+	},
+	metadata => { supports => ['aws', 'vsphere', 'openstack'] },
+	get_hook_module => sub { return undef },
+};
+
+my $bosh = mock "Genesis::BOSH" => {
+	alias                => 'mock-bosh',
+	connect_and_validate => sub { return $_[0] },
+};
+
+sub mock_env {
+	$test_seq++;
+	my $seq = $test_seq;
+	mock "Genesis::Env" => {(
+		name            => "test-env-$seq",
+		type            => 'test',
+		kit             => $kit,
+		bosh            => sub {
+			my $self = shift;
+			return $bosh;
+		},
+		use_create_env  => 0,
+		features        => Mock::ReferencedValue->new(['ha', 'tls']),
+		iaas            => 'aws',
+		scale           => 'dev',
+		is_ocfp         => 0,
+		cpi_name        => 'aws_cpi',
+		cpi_enabled     => 1,
+		deployments     => mock("Genesis::Env::Deployments::$seq" => {
+			current_state => 'deployed',
+		}),
+		workpath => sub {
+			my ($self, $path) = @_;
+			return "/tmp/genesis-test-work/$path";
+		},
+		exodus_lookup => sub {
+			my ($self, $key, $default) = @_;
+			return { director_url => 'https://bosh.example.com', admin_user => 'admin' }
+				if $key eq '.';
+			return $default;
+		},
+		lookup => sub {
+			my ($self, $key, $default) = @_;
+			return $default;
+		},
+		path => sub { return "/mock/env/path/$_[1]" },
+		file => 'test-env.yml',
+	), @_};
+}
+
+# Convenience: instantiate our Features test subclass
+sub make_hook {
+	my $env = shift || mock_env();
+	return Genesis::Hook::Features::test_kit->init(
+		env      => $env,
+		kit      => $kit,
+		features => ['ha', 'tls'],
+		@_,
+	);
+}
+
+# ---------------------------------------------------------------------------
+# Globals set before all subtests
+# ---------------------------------------------------------------------------
+$Genesis::VERSION = '3.1.0-rc.10';
+$ENV{GENESIS_CALL_BIN} = 'genesis';
+$ENV{GENESIS_KIT_HOOK} = 'features';
+
+# ---------------------------------------------------------------------------
+# Module loads
+# ---------------------------------------------------------------------------
+subtest 'Genesis::Hook::Features module loads' => sub {
+	plan tests => 1;
+	ok(defined(&Genesis::Hook::Features::init),
+		'Genesis::Hook::Features::init is defined');
+};
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+subtest 'init - missing env dies' => sub {
+	plan tests => 1;
+
+	throws_ok {
+		Genesis::Hook::Features::test_kit->init(
+			kit      => $kit,
+			features => [],
+		)
+	} qr/Missing required arguments for a perl-based kit hook call: env/,
+		'init() without env dies with required-args message';
+};
+
+subtest 'init - missing kit dies' => sub {
+	plan tests => 1;
+
+	my $env = mock_env();
+	throws_ok {
+		Genesis::Hook::Features::test_kit->init(
+			env      => $env,
+			features => [],
+		)
+	} qr/Missing required arguments for a perl-based kit hook call: kit/,
+		'init() without kit dies with required-args message';
+};
+
+subtest 'init - missing features dies' => sub {
+	plan tests => 1;
+
+	my $env = mock_env();
+	throws_ok {
+		Genesis::Hook::Features::test_kit->init(
+			env => $env,
+			kit => $kit,
+		)
+	} qr/Missing required arguments for a perl-based kit hook call: features/,
+		'init() without features dies with required-args message';
+};
+
+subtest 'init - missing multiple required args lists all missing' => sub {
+	plan tests => 1;
+
+	throws_ok {
+		Genesis::Hook::Features::test_kit->init()
+	} qr/Missing required arguments for a perl-based kit hook call:/,
+		'init() with no args dies listing missing arguments';
+};
+
+subtest 'init - returns blessed Genesis::Hook::Features object' => sub {
+	plan tests => 4;
+
+	my $env  = mock_env();
+	my $hook;
+	lives_ok {
+		$hook = Genesis::Hook::Features::test_kit->init(
+			env      => $env,
+			kit      => $kit,
+			features => ['ha', 'tls'],
+		)
+	} 'init() succeeds with all required arguments';
+
+	ok(defined $hook, 'init() returns a defined value');
+	isa_ok($hook, 'Genesis::Hook::Features',
+		'returned object isa Genesis::Hook::Features');
+	isa_ok($hook, 'Genesis::Hook',
+		'returned object also isa Genesis::Hook');
+};
+
+subtest 'init - initialises all_features as empty array ref' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	ok(defined $hook->{all_features},
+		'all_features key exists after init()');
+	cmp_deeply($hook->{all_features}, [],
+		'all_features initialised as empty array ref');
+};
+
+subtest 'init - initialises has_feature as empty hash ref' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	ok(defined $hook->{has_feature},
+		'has_feature key exists after init()');
+	cmp_deeply($hook->{has_feature}, {},
+		'has_feature initialised as empty hash ref');
+};
+
+subtest 'init - stores env on object' => sub {
+	plan tests => 1;
+
+	my $env  = mock_env();
+	my $hook = Genesis::Hook::Features::test_kit->init(
+		env      => $env,
+		kit      => $kit,
+		features => [],
+	);
+	is($hook->env, $env, 'env() returns the env passed to init()');
+};
+
+subtest 'init - type set from GENESIS_KIT_HOOK env var' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	is($hook->{type}, 'features',
+		'type is set from GENESIS_KIT_HOOK env var');
+};
+
+subtest 'init - complete flag starts at 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	is($hook->{complete}, 0, 'complete flag initializes to 0');
+};
+
+# ---------------------------------------------------------------------------
+# add_feature
+# ---------------------------------------------------------------------------
+subtest 'add_feature - default value is 1 when set arg omitted' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->add_feature('ha');
+
+	is($hook->{has_feature}{'ha'}, 1,
+		'has_feature map records value 1 when $set omitted');
+	cmp_deeply($hook->{all_features}, ['ha'],
+		'feature appended to all_features list');
+};
+
+subtest 'add_feature - explicit truthy set value stored' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->add_feature('ha', 42);
+
+	is($hook->{has_feature}{'ha'}, 42,
+		'has_feature map records supplied truthy value');
+	cmp_deeply($hook->{all_features}, ['ha'],
+		'feature appended to all_features list');
+};
+
+subtest 'add_feature - explicit falsy set value 0 stored' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->add_feature('debug', 0);
+
+	is($hook->{has_feature}{'debug'}, 0,
+		'has_feature map records supplied falsy value 0');
+	cmp_deeply($hook->{all_features}, ['debug'],
+		'feature appended to all_features list even with falsy value');
+};
+
+subtest 'add_feature - preserves insertion order across multiple calls' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->add_feature('ha');
+	$hook->add_feature('mtls');
+	$hook->add_feature('debug');
+
+	cmp_deeply($hook->{all_features}, ['ha', 'mtls', 'debug'],
+		'all_features preserves insertion order');
+};
+
+subtest 'add_feature - returns nothing significant' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	# add_feature has no documented return value; we verify it does not die
+	lives_ok { $hook->add_feature('ha') } 'add_feature() lives without error';
+};
+
+# ---------------------------------------------------------------------------
+# has_feature
+# ---------------------------------------------------------------------------
+subtest 'has_feature - returns 1 for feature added with default value' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->add_feature('ha');
+	is($hook->has_feature('ha'), 1,
+		'has_feature() returns 1 for feature added with default value');
+};
+
+subtest 'has_feature - returns stored value for feature added with explicit value' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->add_feature('ha', 42);
+	is($hook->has_feature('ha'), 42,
+		'has_feature() returns the value supplied to add_feature()');
+};
+
+subtest 'has_feature - returns undef for unregistered feature' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	ok(!defined($hook->has_feature('nonexistent')),
+		'has_feature() returns undef for a feature that was never added');
+};
+
+subtest 'has_feature - returns 0 for feature registered with value 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->add_feature('debug', 0);
+	is($hook->has_feature('debug'), 0,
+		'has_feature() returns 0 when feature was registered with value 0');
+};
+
+# ---------------------------------------------------------------------------
+# delete_feature
+# ---------------------------------------------------------------------------
+subtest 'delete_feature - returns old value and removes from map' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->add_feature('ha');
+
+	my $old = $hook->delete_feature('ha');
+
+	is($old, 1, 'delete_feature() returns the previously stored value');
+	ok(!defined($hook->has_feature('ha')),
+		'has_feature() returns undef after delete_feature()');
+};
+
+subtest 'delete_feature - returns undef for feature not in map' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $old  = $hook->delete_feature('nonexistent');
+
+	ok(!defined($old),
+		'delete_feature() returns undef when feature was not registered');
+};
+
+subtest 'delete_feature - feature stays in all_features list but skipped by build_features_list' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->add_feature('ha');
+	$hook->add_feature('mtls');
+	$hook->delete_feature('ha');
+
+	cmp_deeply($hook->{all_features}, ['ha', 'mtls'],
+		'all_features still contains deleted feature name');
+
+	my @list = $hook->build_features_list();
+	cmp_deeply(\@list, ['mtls'],
+		'build_features_list() omits the deleted feature');
+};
+
+subtest 'delete_feature - returns stored value when explicit value was used' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->add_feature('ha', 99);
+	my $old = $hook->delete_feature('ha');
+
+	is($old, 99, 'delete_feature() returns the explicit value that was stored');
+};
+
+# ---------------------------------------------------------------------------
+# build_features_list
+# ---------------------------------------------------------------------------
+subtest 'build_features_list - returns active features in insertion order' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->add_feature('ha');
+	$hook->add_feature('mtls');
+	$hook->add_feature('debug');
+
+	my @list = $hook->build_features_list();
+	cmp_deeply(\@list, ['ha', 'mtls', 'debug'],
+		'build_features_list() returns features in insertion order');
+};
+
+subtest 'build_features_list - omits features with falsy value' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->add_feature('ha');
+	$hook->add_feature('debug', 0);
+	$hook->add_feature('mtls');
+
+	my @list = $hook->build_features_list();
+	cmp_deeply(\@list, ['ha', 'mtls'],
+		'build_features_list() skips feature registered with value 0');
+};
+
+subtest 'build_features_list - second call returns empty list' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->add_feature('ha');
+	$hook->add_feature('mtls');
+
+	my @first  = $hook->build_features_list();
+	my @second = $hook->build_features_list();
+
+	cmp_deeply(\@first,  ['ha', 'mtls'],
+		'first call returns expected features');
+	cmp_deeply(\@second, [],
+		'second call returns empty list because entries were deleted');
+};
+
+subtest 'build_features_list - deletes emitted features from map' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->add_feature('ha');
+
+	$hook->build_features_list();
+
+	ok(!defined($hook->has_feature('ha')),
+		'has_feature() returns undef after build_features_list() emitted it');
+	cmp_deeply($hook->{all_features}, ['ha'],
+		'all_features list still contains the feature name');
+};
+
+subtest 'build_features_list - virtual_features option promotes to + prefix' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->add_feature('+internal-blobstore');
+	$hook->add_feature('ocfp');
+
+	# 'internal-blobstore' appears in virtual_features so the method looks up
+	# '+internal-blobstore' in the map and emits that prefixed form.
+	my @list = $hook->build_features_list(
+		virtual_features => ['internal-blobstore'],
+	);
+	cmp_deeply(\@list, ['+internal-blobstore', 'ocfp'],
+		'build_features_list() emits + prefix for virtual features');
+};
+
+subtest 'build_features_list - virtual feature skipped when + entry absent' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->add_feature('internal-blobstore');
+	$hook->add_feature('ocfp');
+
+	# 'internal-blobstore' is in virtual_features, so the method looks for
+	# '+internal-blobstore', which was never added — the feature is skipped.
+	my @list = $hook->build_features_list(
+		virtual_features => ['internal-blobstore'],
+	);
+	cmp_deeply(\@list, ['ocfp'],
+		'virtual feature without + entry is skipped entirely');
+};
+
+subtest 'build_features_list - empty hook returns empty list' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my @list = $hook->build_features_list();
+	cmp_deeply(\@list, [],
+		'build_features_list() returns empty list when no features were added');
+};
+
+subtest 'build_features_list - default virtual_features is empty list' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	$hook->add_feature('ha');
+
+	# Calling with no options should behave the same as virtual_features => []
+	my @list = $hook->build_features_list();
+	cmp_deeply(\@list, ['ha'],
+		'omitting virtual_features option does not affect plain feature output');
+};
+
+# ---------------------------------------------------------------------------
+# done
+# ---------------------------------------------------------------------------
+subtest 'done - no args calls build_features_list and marks complete' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook();
+	$hook->add_feature('ha');
+	$hook->add_feature('mtls');
+
+	my $ret;
+	lives_ok { $ret = $hook->done() } 'done() with no args lives';
+
+	is($hook->{complete}, 1, 'complete flag set to 1');
+	cmp_deeply($ret, ['ha', 'mtls'],
+		'done() returns array ref built by build_features_list()');
+};
+
+subtest 'done - no args with empty feature registry returns empty array ref' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	my $ret  = $hook->done();
+
+	is($hook->{complete}, 1, 'complete flag set to 1');
+	cmp_deeply($ret, [], 'done() with no features returns empty array ref');
+};
+
+subtest 'done - array ref argument passed directly to parent done' => sub {
+	plan tests => 3;
+
+	my $hook     = make_hook();
+	my $features = ['ha', 'mtls', 'tls'];
+	my $ret      = $hook->done($features);
+
+	is($hook->{complete}, 1, 'complete flag set to 1');
+	is($ret, $features, 'done(\@ref) returns the same array reference');
+	cmp_deeply($hook->{results}, ['ha', 'mtls', 'tls'],
+		'results stored as the supplied array reference');
+};
+
+subtest 'done - multiple string args collected into array ref' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook();
+	my $ret  = $hook->done('ha', 'mtls', 'tls');
+
+	is($hook->{complete}, 1, 'complete flag set to 1');
+	isa_ok($ret, 'ARRAY', 'done(strings...) returns an array reference');
+	cmp_deeply($ret, ['ha', 'mtls', 'tls'],
+		'done(strings...) collects all string args into array ref');
+};
+
+subtest 'done - single string arg collected into array ref' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	my $ret  = $hook->done('ha');
+
+	isa_ok($ret, 'ARRAY', 'done(single_string) returns an array reference');
+	cmp_deeply($ret, ['ha'],
+		'done(single_string) wraps the string in an array ref');
+};
+
+subtest 'done - single undef marks hook as not complete' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook();
+	my $ret  = $hook->done(undef);
+
+	ok(!defined($ret), 'done(undef) returns undef');
+	is($hook->{complete}, 0, 'complete flag remains 0 when done(undef) called');
+	ok(!defined($hook->results), 'results() returns undef when not complete');
+};
+
+subtest 'done - single 0 delegates to parent done and marks complete' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	my $ret  = $hook->done(0);
+
+	is($ret, 0, 'done(0) returns 0');
+	# 0 is defined so SUPER::done records it and sets complete = 1
+	is($hook->{complete}, 1,
+		'complete flag is 1 after done(0) because 0 is defined');
+};
+
+subtest 'done - results accessible via results() after completion' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	$hook->add_feature('ha');
+	$hook->done();
+
+	is($hook->completed, 1, 'completed() returns 1 after done()');
+	cmp_deeply($hook->results, ['ha'],
+		'results() returns the feature array ref after done()');
+};
+
+subtest 'done - results() returns undef when not complete' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	ok(!defined($hook->results),
+		'results() returns undef before done() is called');
+};
+
+done_testing;

--- a/t/unit-tests/genesis_hook_postdeploy-core.t
+++ b/t/unit-tests/genesis_hook_postdeploy-core.t
@@ -1,0 +1,489 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+
+use lib 't';
+use helper;
+use Test::More;
+use Test::Exception;
+use Test::Deep;
+use Genesis qw(bail);
+use Cwd qw(abs_path);
+
+$ENV{GENESIS_CALLBACK_BIN} ||= abs_path('bin/genesis');
+$ENV{GENESIS_LIB} ||= abs_path('lib');
+$ENV{GENESIS_OUTPUT_COLUMNS} = 80;
+$ENV{NOCOLOR} = 1;
+
+# ---------------------------------------------------------------------------
+# Load the module under test
+# ---------------------------------------------------------------------------
+require_ok 'Genesis::Hook::PostDeploy';
+
+# ---------------------------------------------------------------------------
+# Test subclass - class name matches Genesis::Hook::<Type>::<KitName>
+# convention required by label() in the base class.
+# ---------------------------------------------------------------------------
+{
+	package Genesis::Hook::PostDeploy::test_kit;
+	use parent -norequire, 'Genesis::Hook::PostDeploy';
+
+	sub perform {
+		my ($self) = @_;
+		$self->done(1);
+	}
+}
+
+# ---------------------------------------------------------------------------
+# Shared mock objects
+# ---------------------------------------------------------------------------
+
+my $test_seq = 0;
+
+my $kit = mock "Genesis::Kit" => {
+	name                => 'test-kit',
+	version             => '1.0.0',
+	genesis_version_min => '3.1.0-rc.10',
+	id                  => sub { return $_[0]->name . '/' . $_[0]->version },
+	kit_bug => sub {
+		my ($self, $msg, @args) = @_;
+		bail("Throwing a kit bug: " . $msg, @args);
+	},
+	path => sub {
+		my ($self, $file) = @_;
+		return "/mock/kit/path/$file";
+	},
+	metadata => { supports => ['aws', 'vsphere', 'openstack'] },
+	get_hook_module => sub { return undef },
+};
+
+my $bosh = mock "Genesis::BOSH" => {
+	alias                => 'mock-bosh',
+	connect_and_validate => sub { return $_[0] },
+};
+
+sub mock_env {
+	$test_seq++;
+	my $seq = $test_seq;
+	mock "Genesis::Env" => {(
+		name            => "test-env-$seq",
+		type            => 'test',
+		kit             => $kit,
+		bosh            => sub {
+			my $self = shift;
+			return $bosh;
+		},
+		use_create_env  => 0,
+		features        => Mock::ReferencedValue->new(['ha', 'tls']),
+		iaas            => 'aws',
+		scale           => 'dev',
+		is_ocfp         => 0,
+		cpi_name        => 'aws_cpi',
+		cpi_enabled     => 1,
+		deployments     => mock("Genesis::Env::Deployments::$seq" => {
+			current_state => 'deployed',
+		}),
+		workpath => sub {
+			my ($self, $path) = @_;
+			return "/tmp/genesis-test-work/$path";
+		},
+		exodus_lookup => sub {
+			my ($self, $key, $default) = @_;
+			return { director_url => 'https://bosh.example.com', admin_user => 'admin' }
+				if $key eq '.';
+			return $default;
+		},
+		lookup => sub {
+			my ($self, $key, $default) = @_;
+			return $default;
+		},
+		path => sub { return "/mock/env/path/$_[1]" },
+		file => 'test-env.yml',
+	), @_};
+}
+
+# Convenience: instantiate the test subclass with minimal required args
+sub make_hook {
+	my %args = (
+		env => mock_env(),
+		rc  => 0,
+		@_,
+	);
+	return Genesis::Hook::PostDeploy::test_kit->init(%args);
+}
+
+# ---------------------------------------------------------------------------
+# Globals set before all subtests
+# ---------------------------------------------------------------------------
+$Genesis::VERSION = '3.1.0-rc.10';
+$ENV{GENESIS_CALL_BIN} = 'genesis';
+$ENV{GENESIS_KIT_HOOK} = 'post-deploy';
+$ENV{GENESIS_CALL_ENV} = 'genesis test-env';
+
+# ---------------------------------------------------------------------------
+# Module loads
+# ---------------------------------------------------------------------------
+subtest 'Genesis::Hook::PostDeploy module loads' => sub {
+	plan tests => 1;
+	ok(defined(&Genesis::Hook::PostDeploy::init),
+		'Genesis::Hook::PostDeploy::init is defined');
+};
+
+# ---------------------------------------------------------------------------
+# init - required arguments
+# ---------------------------------------------------------------------------
+subtest 'init - dies when env is missing' => sub {
+	plan tests => 1;
+
+	throws_ok {
+		Genesis::Hook::PostDeploy::test_kit->init(rc => 0)
+	} qr/Missing required arguments for a perl-based kit hook call:.*env/,
+		'init() without env dies with required-args message';
+};
+
+subtest 'init - dies when rc is missing' => sub {
+	plan tests => 1;
+
+	throws_ok {
+		Genesis::Hook::PostDeploy::test_kit->init(env => mock_env())
+	} qr/Missing required arguments for a perl-based kit hook call:.*rc/,
+		'init() without rc dies with required-args message';
+};
+
+subtest 'init - dies when both env and rc are missing' => sub {
+	plan tests => 1;
+
+	throws_ok {
+		Genesis::Hook::PostDeploy::test_kit->init()
+	} qr/Missing required arguments for a perl-based kit hook call:/,
+		'init() with no arguments dies with required-args message';
+};
+
+# ---------------------------------------------------------------------------
+# init - valid construction
+# ---------------------------------------------------------------------------
+subtest 'init - returns blessed object with rc=0' => sub {
+	plan tests => 6;
+
+	my $env = mock_env();
+	my $hook;
+	lives_ok {
+		$hook = Genesis::Hook::PostDeploy::test_kit->init(env => $env, rc => 0)
+	} 'init() with env and rc=0 succeeds';
+
+	ok(defined $hook, 'init() returns a defined value');
+	isa_ok($hook, 'Genesis::Hook::PostDeploy',
+		'returned object isa Genesis::Hook::PostDeploy');
+	isa_ok($hook, 'Genesis::Hook',
+		'returned object isa Genesis::Hook');
+	is($hook->env, $env,
+		'env() returns the env passed to init()');
+	is($hook->{rc}, 0,
+		'rc stored on object as 0');
+};
+
+subtest 'init - returns blessed object with rc=1' => sub {
+	plan tests => 3;
+
+	my $hook;
+	lives_ok {
+		$hook = Genesis::Hook::PostDeploy::test_kit->init(
+			env => mock_env(),
+			rc  => 1,
+		)
+	} 'init() with rc=1 succeeds';
+
+	ok(defined $hook, 'init() returns a defined value');
+	is($hook->{rc}, 1, 'rc stored on object as 1');
+};
+
+subtest 'init - complete flag starts at 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	is($hook->{complete}, 0, 'complete flag initializes to 0');
+};
+
+subtest 'init - type set from GENESIS_KIT_HOOK env var' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	is($hook->{type}, 'post-deploy',
+		'type reflects GENESIS_KIT_HOOK=post-deploy');
+};
+
+subtest 'init - stores extra opts on object' => sub {
+	plan tests => 2;
+
+	my $hook = Genesis::Hook::PostDeploy::test_kit->init(
+		env        => mock_env(),
+		rc         => 0,
+		interactive => 1,
+		purpose    => 'test-purpose',
+	);
+	is($hook->{interactive}, 1,              'extra opt "interactive" stored on hook');
+	is($hook->{purpose},     'test-purpose', 'extra opt "purpose" stored on hook');
+};
+
+# ---------------------------------------------------------------------------
+# deploy_successful
+# ---------------------------------------------------------------------------
+subtest 'deploy_successful - returns true when rc is 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook(rc => 0);
+	ok($hook->deploy_successful,
+		'deploy_successful() returns true when rc=0');
+};
+
+subtest 'deploy_successful - returns false when rc is 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook(rc => 1);
+	ok(!$hook->deploy_successful,
+		'deploy_successful() returns false when rc=1');
+};
+
+subtest 'deploy_successful - returns false when rc is 255' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook(rc => 255);
+	ok(!$hook->deploy_successful,
+		'deploy_successful() returns false when rc=255');
+};
+
+subtest 'deploy_successful - returns false for any non-zero rc' => sub {
+	plan tests => 3;
+
+	for my $rc (2, 127, 128) {
+		my $hook = make_hook(rc => $rc);
+		ok(!$hook->deploy_successful,
+			"deploy_successful() returns false when rc=$rc");
+	}
+};
+
+subtest 'deploy_successful - distinguishes rc=0 from rc=1 on same hook' => sub {
+	plan tests => 2;
+
+	my $success = make_hook(rc => 0);
+	my $failure = make_hook(rc => 1);
+
+	ok( $success->deploy_successful, 'rc=0 hook: deploy_successful is true');
+	ok(!$failure->deploy_successful, 'rc=1 hook: deploy_successful is false');
+};
+
+# ---------------------------------------------------------------------------
+# data
+# ---------------------------------------------------------------------------
+subtest 'data - returns a hash reference' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $data = $hook->data;
+	ok(ref($data) eq 'HASH', 'data() returns a hash reference');
+};
+
+subtest 'data - returns empty hash on first call' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $data = $hook->data;
+	is(scalar keys %$data, 0, 'data() returns empty hash on first call');
+};
+
+subtest 'data - returns the same reference on subsequent calls' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	my $first  = $hook->data;
+	my $second = $hook->data;
+
+	is(ref($first),  'HASH', 'first call returns hash reference');
+	is($first, $second, 'second call returns the same reference as first');
+};
+
+subtest 'data - mutations are visible across calls' => sub {
+	plan tests => 2;
+
+	my $hook = make_hook();
+	my $data = $hook->data;
+	$data->{custom_key} = 'custom_value';
+
+	my $again = $hook->data;
+	is($again->{custom_key}, 'custom_value',
+		'mutation on first ref visible through second call');
+	is(scalar keys %{$hook->data}, 1,
+		'data hash has exactly one key after one mutation');
+};
+
+subtest 'data - each new hook instance has its own hash' => sub {
+	plan tests => 2;
+
+	my $hook_a = make_hook();
+	my $hook_b = make_hook();
+
+	$hook_a->data->{x} = 1;
+
+	is($hook_a->data->{x}, 1, 'hook_a data has key x');
+	ok(!exists $hook_b->data->{x}, 'hook_b data does not have key x');
+};
+
+# ---------------------------------------------------------------------------
+# command
+# ---------------------------------------------------------------------------
+subtest 'command - simple args joined with spaces' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $cmd = $hook->command('do', 'test');
+	is($cmd, 'genesis test-env do test',
+		'command() joins GENESIS_CALL_ENV and simple args with spaces');
+};
+
+subtest 'command - no args returns just the call env' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $cmd = $hook->command();
+	is($cmd, 'genesis test-env',
+		'command() with no args returns GENESIS_CALL_ENV alone');
+};
+
+subtest 'command - multiple args all joined' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $cmd = $hook->command('do', 'upload-stemcells');
+	is($cmd, 'genesis test-env do upload-stemcells',
+		'command() with two args returns full joined string');
+};
+
+subtest 'command - uses GENESIS_CALL_ENV over GENESIS_CALL' => sub {
+	plan tests => 1;
+
+	local $ENV{GENESIS_CALL_ENV} = 'genesis my-env';
+	local $ENV{GENESIS_CALL}     = 'genesis other';
+
+	my $hook = make_hook();
+	my $cmd = $hook->command('action');
+	is($cmd, 'genesis my-env action',
+		'command() prefers GENESIS_CALL_ENV when both env vars are set');
+};
+
+subtest 'command - falls back to GENESIS_CALL when GENESIS_CALL_ENV is unset' => sub {
+	plan tests => 1;
+
+	local $ENV{GENESIS_CALL_ENV} = undef;
+	local $ENV{GENESIS_CALL}     = 'genesis fallback-env';
+
+	my $hook = make_hook();
+	my $cmd = $hook->command('do', 'something');
+	is($cmd, 'genesis fallback-env do something',
+		'command() falls back to GENESIS_CALL when GENESIS_CALL_ENV is unset');
+};
+
+subtest 'command - args without special chars are not quoted' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	my $cmd = $hook->command('deploy', '--dry-run');
+	is($cmd, 'genesis test-env deploy --dry-run',
+		'command() does not quote plain args');
+};
+
+subtest 'command - arg containing the quoting trigger sequence is quoted' => sub {
+	plan tests => 1;
+
+	# The regex in command() is / \(\)!\*\?/ -- a literal string match.
+	# Only an arg containing exactly that sequence (space, (, ), !, *, ?)
+	# will be wrapped in single quotes.
+	#
+	# NOTE: command() modifies its @_ aliases in place, so $trigger_arg is
+	# mutated after the call.  Build the expected string before calling.
+	my $hook = make_hook();
+	my $raw_arg  = 'x ()!*?';
+	my $expected = "genesis test-env '$raw_arg'";
+	my $cmd = $hook->command($raw_arg);
+	is($cmd, $expected,
+		'command() single-quotes arg that matches the special-char trigger sequence');
+};
+
+# ---------------------------------------------------------------------------
+# results
+# ---------------------------------------------------------------------------
+subtest 'results - returns 1 unconditionally' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	is($hook->results, 1,
+		'results() returns 1 unconditionally');
+};
+
+subtest 'results - returns 1 regardless of rc' => sub {
+	plan tests => 2;
+
+	my $success = make_hook(rc => 0);
+	my $failure = make_hook(rc => 1);
+
+	is($success->results, 1, 'results() returns 1 when rc=0');
+	is($failure->results, 1, 'results() returns 1 when rc=1');
+};
+
+# ---------------------------------------------------------------------------
+# Heavy methods exist as can() checks
+# ---------------------------------------------------------------------------
+subtest 'update_director_network_config - method exists' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	ok($hook->can('update_director_network_config'),
+		'hook can() update_director_network_config');
+};
+
+subtest 'upload_stemcells - method exists' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	ok($hook->can('upload_stemcells'),
+		'hook can() upload_stemcells');
+};
+
+subtest 'upload_runtime_configs - method exists' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	ok($hook->can('upload_runtime_configs'),
+		'hook can() upload_runtime_configs');
+};
+
+subtest 'upload_director_cpi_config - method exists' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	ok($hook->can('upload_director_cpi_config'),
+		'hook can() upload_director_cpi_config');
+};
+
+subtest '_commit_config_credhub_secrets - method exists' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	ok($hook->can('_commit_config_credhub_secrets'),
+		'hook can() _commit_config_credhub_secrets');
+};
+
+subtest 'upload_stemcells - returns immediately without action when rc is non-zero' => sub {
+	plan tests => 1;
+
+	# When deploy_successful is false, upload_stemcells must return early.
+	# We verify this by ensuring no BOSH call is attempted (the mock env has
+	# no get_target_bosh, so any BOSH access would die).
+	my $hook = make_hook(rc => 1);
+	my $ret;
+	lives_ok {
+		$ret = $hook->upload_stemcells
+	} 'upload_stemcells() with rc=1 returns early without BOSH access';
+};
+
+done_testing;

--- a/t/unit-tests/genesis_hook_runtimeconfig-core.t
+++ b/t/unit-tests/genesis_hook_runtimeconfig-core.t
@@ -1,0 +1,681 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+
+use lib 't';
+use helper;
+use Test::More;
+use Test::Exception;
+use Test::Deep;
+use Genesis qw(bail);
+use Cwd qw(abs_path);
+use JSON::PP;
+
+$ENV{GENESIS_CALLBACK_BIN} ||= abs_path('bin/genesis');
+$ENV{GENESIS_LIB} ||= abs_path('lib');
+$ENV{GENESIS_OUTPUT_COLUMNS} = 80;
+$ENV{NOCOLOR} = 1;
+
+# ---------------------------------------------------------------------------
+# Load the module under test
+# ---------------------------------------------------------------------------
+require_ok 'Genesis::Hook::RuntimeConfig';
+
+# ---------------------------------------------------------------------------
+# Test subclass - must match Genesis::Hook::<type>::<kit-name> pattern so
+# that label() can parse it.  We define build_dns_runtime and
+# build_logging_runtime methods here.
+# ---------------------------------------------------------------------------
+{
+	package Genesis::Hook::RuntimeConfig::test_kit;
+	use parent -norequire, 'Genesis::Hook::RuntimeConfig';
+
+	sub build_dns_runtime {
+		my ($self) = @_;
+		my $data = {
+			releases => [{name => 'bosh-dns', version => '1.31.0'}],
+			addons   => [{name => 'bosh-dns', jobs => []}],
+		};
+		return ($data, undef, undef);
+	}
+
+	sub build_logging_runtime {
+		my ($self) = @_;
+		my $yaml = "releases:\n- name: loggregator\n  version: '1.0'\n";
+		return ($yaml, undef, undef);
+	}
+
+	sub build_failing_runtime {
+		my ($self) = @_;
+		return (undef, 'failed', 'something went wrong');
+	}
+
+	sub build_skipped_runtime {
+		my ($self) = @_;
+		return (undef, 'skipped', 'not applicable here');
+	}
+}
+
+# ---------------------------------------------------------------------------
+# Shared mock objects
+# ---------------------------------------------------------------------------
+
+my $test_seq = 0;
+
+my $kit = mock "Genesis::Kit" => {
+	name                => 'test-kit',
+	version             => '1.0.0',
+	genesis_version_min => '3.1.0-rc.10',
+	id                  => sub { return $_[0]->name . '/' . $_[0]->version },
+	kit_bug => sub {
+		my ($self, $msg, @args) = @_;
+		bail("Throwing a kit bug: ".$msg, @args);
+	},
+	path => sub {
+		my ($self, $file) = @_;
+		return "/mock/kit/path/$file";
+	},
+	metadata => { supports => ['aws', 'vsphere', 'openstack'] },
+	get_hook_module => sub { return undef },
+};
+
+my $bosh = mock "Genesis::BOSH" => {
+	alias                => 'mock-bosh',
+	exodus_vault         => undef,
+	connect_and_validate => sub { return $_[0] },
+};
+
+sub mock_env {
+	$test_seq++;
+	my $seq = $test_seq;
+	mock "Genesis::Env" => {(
+		name             => "test-env-$seq",
+		type             => 'test',
+		kit              => $kit,
+		bosh             => sub { return $bosh },
+		is_bosh_director => 0,
+		bosh_config_name => 'test-env-bosh',
+		use_create_env   => 0,
+		features         => Mock::ReferencedValue->new(['ha', 'tls']),
+		iaas             => 'aws',
+		scale            => 'dev',
+		is_ocfp          => 0,
+		cpi_name         => 'aws_cpi',
+		cpi_enabled      => 1,
+		feature_compatibility => sub { return 0 },
+		deployments      => mock("Genesis::Env::Deployments::$seq" => {
+			current_state => 'deployed',
+		}),
+		workpath => sub {
+			my ($self, $path) = @_;
+			return "/tmp/genesis-test-work/$path";
+		},
+		exodus_lookup => sub {
+			my ($self, $key, $default) = @_;
+			return { director_url => 'https://bosh.example.com', admin_user => 'admin' }
+				if $key eq '.';
+			return $default;
+		},
+		lookup => sub {
+			my ($self, $key, $default) = @_;
+			return $default;
+		},
+		path => sub { return "/mock/env/path/$_[1]" },
+		file => 'test-env.yml',
+	), @_};
+}
+
+# Build a hook by manual blessing to avoid the Service::Credhub->from_bosh
+# call inside init().  This is the preferred approach when the constructor
+# has too many external dependencies.
+sub make_hook {
+	my (%args) = @_;
+	my $env = $args{env} || mock_env();
+	# Use exists check so that an explicit args => undef is preserved as undef,
+	# rather than defaulting to [] the way // would.
+	my $hook_args = exists $args{args} ? $args{args} : [];
+	my $hook = bless {
+		env              => $env,
+		complete         => 0,
+		type             => 'runtime-config',
+		label            => '[test_kit RuntimeConfig] ',
+		builds           => {},
+		bosh             => $bosh,
+		credhub          => undef,
+		secrets          => {},
+		args             => $hook_args,
+		dryrun           => $args{dryrun}      // 0,
+		interactive      => $args{interactive} // 0,
+		print            => $args{print}       // 0,
+		remove           => $args{remove}      // 0,
+		requests         => [],
+		request_options  => {},
+	}, 'Genesis::Hook::RuntimeConfig::test_kit';
+	return $hook;
+}
+
+# ---------------------------------------------------------------------------
+# Globals set before all subtests
+# ---------------------------------------------------------------------------
+$Genesis::VERSION = '3.1.0-rc.10';
+$ENV{GENESIS_CALL_BIN}  = 'genesis';
+$ENV{GENESIS_KIT_HOOK}  = 'runtime-config';
+
+# ---------------------------------------------------------------------------
+# Module loads
+# ---------------------------------------------------------------------------
+subtest 'Genesis::Hook::RuntimeConfig module loads' => sub {
+	plan tests => 1;
+	ok(defined(&Genesis::Hook::RuntimeConfig::init),
+		'Genesis::Hook::RuntimeConfig::init is defined');
+};
+
+# ---------------------------------------------------------------------------
+# Accessor: dryrun
+# ---------------------------------------------------------------------------
+subtest 'dryrun - defaults to 0' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	is($hook->dryrun, 0, 'dryrun() returns 0 by default');
+};
+
+subtest 'dryrun - returns 1 when set' => sub {
+	plan tests => 1;
+	my $hook = make_hook(dryrun => 1);
+	is($hook->dryrun, 1, 'dryrun() returns 1 when dryrun is set');
+};
+
+# ---------------------------------------------------------------------------
+# Accessor: interactive
+# ---------------------------------------------------------------------------
+subtest 'interactive - defaults to 0' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	is($hook->interactive, 0, 'interactive() returns 0 by default');
+};
+
+subtest 'interactive - returns 1 when set' => sub {
+	plan tests => 1;
+	my $hook = make_hook(interactive => 1);
+	is($hook->interactive, 1, 'interactive() returns 1 when interactive is set');
+};
+
+# ---------------------------------------------------------------------------
+# Accessor: print
+# ---------------------------------------------------------------------------
+subtest 'print - defaults to 0' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	is($hook->print, 0, 'print() returns 0 by default');
+};
+
+subtest 'print - returns 1 when set' => sub {
+	plan tests => 1;
+	my $hook = make_hook(print => 1);
+	is($hook->print, 1, 'print() returns 1 when print is set');
+};
+
+# ---------------------------------------------------------------------------
+# Accessor: remove
+# ---------------------------------------------------------------------------
+subtest 'remove - defaults to 0' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	is($hook->remove, 0, 'remove() returns 0 by default');
+};
+
+subtest 'remove - returns 1 when set' => sub {
+	plan tests => 1;
+	my $hook = make_hook(remove => 1);
+	is($hook->remove, 1, 'remove() returns 1 when remove is set');
+};
+
+# ---------------------------------------------------------------------------
+# action()
+# ---------------------------------------------------------------------------
+subtest 'action - default is generate and upload' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	is($hook->action, 'generate and upload',
+		'action() returns "generate and upload" in normal mode');
+};
+
+subtest 'action - dryrun mode returns generate' => sub {
+	plan tests => 1;
+	my $hook = make_hook(dryrun => 1);
+	is($hook->action, 'generate',
+		'action() returns "generate" in dryrun mode');
+};
+
+subtest 'action - remove mode returns remove' => sub {
+	plan tests => 1;
+	my $hook = make_hook(remove => 1);
+	is($hook->action, 'remove',
+		'action() returns "remove" in remove mode');
+};
+
+subtest 'action - remove takes precedence over dryrun' => sub {
+	plan tests => 1;
+	my $hook = make_hook(remove => 1, dryrun => 1);
+	is($hook->action, 'remove',
+		'action() returns "remove" when both remove and dryrun are set');
+};
+
+# ---------------------------------------------------------------------------
+# config_name_for()
+# ---------------------------------------------------------------------------
+subtest 'config_name_for - returns bosh_config_name dot build' => sub {
+	plan tests => 2;
+	my $hook = make_hook();
+	is($hook->config_name_for('dns'),     'test-env-bosh.dns',
+		'config_name_for("dns") returns correct name');
+	is($hook->config_name_for('logging'), 'test-env-bosh.logging',
+		'config_name_for("logging") returns correct name');
+};
+
+# ---------------------------------------------------------------------------
+# register_runtime_config_builds()
+# ---------------------------------------------------------------------------
+subtest 'register_runtime_config_builds - plain string derives description' => sub {
+	plan tests => 4;
+	my $hook = make_hook();
+	$hook->register_runtime_config_builds('dns');
+	ok(exists $hook->{builds}{dns}, 'dns build registered');
+	is($hook->{builds}{dns}{description}, 'Dns',
+		'single-word name title-cased as description');
+	is($hook->{builds}{dns}{method}, 'build_dns_runtime',
+		'method name is build_dns_runtime');
+	is($hook->{builds}{dns}{order}, 0, 'order is 0 for first registered build');
+};
+
+subtest 'register_runtime_config_builds - multi-word name derives description' => sub {
+	plan tests => 2;
+	my $hook = make_hook();
+	$hook->register_runtime_config_builds('dns', 'logging');
+	is($hook->{builds}{dns}{description},     'Dns',
+		'dns description auto-derived');
+	is($hook->{builds}{logging}{description}, 'Logging',
+		'logging description auto-derived');
+};
+
+subtest 'register_runtime_config_builds - arrayref uses explicit description' => sub {
+	plan tests => 2;
+	my $hook = make_hook();
+	$hook->register_runtime_config_builds(['logging', 'Log Aggregation']);
+	ok(exists $hook->{builds}{logging}, 'logging build registered');
+	is($hook->{builds}{logging}{description}, 'Log Aggregation',
+		'explicit description stored');
+};
+
+subtest 'register_runtime_config_builds - preserves registration order' => sub {
+	plan tests => 2;
+	my $hook = make_hook();
+	$hook->register_runtime_config_builds('logging', 'dns');
+	is($hook->{builds}{logging}{order}, 0, 'logging registered first has order 0');
+	is($hook->{builds}{dns}{order},     1, 'dns registered second has order 1');
+};
+
+subtest 'register_runtime_config_builds - resets builds on re-registration' => sub {
+	plan tests => 2;
+	my $hook = make_hook();
+	$hook->register_runtime_config_builds('dns', 'logging');
+	$hook->register_runtime_config_builds('logging');
+	ok(!exists $hook->{builds}{dns}, 'dns removed after re-registration');
+	ok( exists $hook->{builds}{logging}, 'logging present after re-registration');
+};
+
+subtest 'register_runtime_config_builds - returns self for chaining' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	my $ret = $hook->register_runtime_config_builds('dns');
+	is($ret, $hook, 'register_runtime_config_builds() returns $self');
+};
+
+subtest 'register_runtime_config_builds - dies on empty list' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	throws_ok {
+		$hook->register_runtime_config_builds()
+	} qr/No builds specified for registration/,
+		'dies with no-builds message when called with empty list';
+};
+
+subtest 'register_runtime_config_builds - dies on invalid name chars' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	throws_ok {
+		$hook->register_runtime_config_builds('dns!bad')
+	} qr/Invalid runtime config name 'dns!bad' specified/,
+		'dies when name contains invalid characters';
+};
+
+subtest 'register_runtime_config_builds - dies when build method missing' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	throws_ok {
+		$hook->register_runtime_config_builds('nonexistent')
+	} qr/Cannot find build method 'build_nonexistent_runtime'/,
+		'dies via kit_bug when build_<name>_runtime method does not exist';
+};
+
+subtest 'register_runtime_config_builds - hyphen converted to underscore in method name' => sub {
+	plan tests => 1;
+	# build_dns_runtime exists; 'dns' with hyphen variant is not testable unless we
+	# add a method.  Verify the method lookup converts hyphens.
+	# We add a method dynamically for this test only.
+	{
+		no warnings 'redefine', 'once';
+		*Genesis::Hook::RuntimeConfig::test_kit::build_my_config_runtime = sub {
+			return ({}, undef, undef);
+		};
+	}
+	my $hook = make_hook();
+	lives_ok {
+		$hook->register_runtime_config_builds('my-config')
+	} 'hyphen in name maps to underscore in method name (build_my_config_runtime)';
+	# clean up
+	no strict 'refs';
+	delete $Genesis::Hook::RuntimeConfig::test_kit::{build_my_config_runtime};
+};
+
+# ---------------------------------------------------------------------------
+# _get_req_names()
+# ---------------------------------------------------------------------------
+subtest '_get_req_names - star returns all sorted by order' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	$hook->register_runtime_config_builds('logging', 'dns');
+	my @names = $hook->_get_req_names('*');
+	cmp_deeply(\@names, ['logging', 'dns'],
+		'* returns builds in registration order');
+};
+
+subtest '_get_req_names - all returns all sorted by order' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	$hook->register_runtime_config_builds('dns', 'logging');
+	my @names = $hook->_get_req_names('all');
+	cmp_deeply(\@names, ['dns', 'logging'],
+		'"all" returns builds in registration order');
+};
+
+subtest '_get_req_names - single name returned as single-element list' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	$hook->register_runtime_config_builds('dns', 'logging');
+	my @names = $hook->_get_req_names('dns');
+	cmp_deeply(\@names, ['dns'], 'single name returns single-element list');
+};
+
+subtest '_get_req_names - comma-separated names split correctly' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	$hook->register_runtime_config_builds('dns', 'logging');
+	my @names = $hook->_get_req_names('dns,logging');
+	cmp_deeply(\@names, ['dns', 'logging'],
+		'comma-separated names split into list');
+};
+
+# ---------------------------------------------------------------------------
+# validate_runtime_config_requests()
+# ---------------------------------------------------------------------------
+subtest 'validate_runtime_config_requests - undef args requests all builds' => sub {
+	plan tests => 3;
+	my $hook = make_hook(args => undef);
+	$hook->register_runtime_config_builds('dns', 'logging');
+	my $ret = $hook->validate_runtime_config_requests();
+	is($ret, 1, 'returns 1 on success');
+	cmp_deeply($hook->{requests}, ['dns', 'logging'],
+		'requests contains all builds in order when args is undef');
+	cmp_deeply($hook->{request_options}, {},
+		'request_options is empty hash when args is undef');
+};
+
+subtest 'validate_runtime_config_requests - empty arrayref args yields empty requests' => sub {
+	plan tests => 2;
+	# An empty arrayref is truthy in Perl so it does NOT short-circuit to
+	# "all builds".  The ARRAY branch processes it into an empty hash, and
+	# step 2 finds no names and no excludes, leaving requests empty.
+	my $hook = make_hook(args => []);
+	$hook->register_runtime_config_builds('dns', 'logging');
+	$hook->validate_runtime_config_requests();
+	cmp_deeply($hook->{requests}, [],
+		'empty arrayref produces empty requests list');
+	cmp_deeply($hook->{request_options}, {},
+		'request_options is empty when args is empty array');
+};
+
+subtest 'validate_runtime_config_requests - JSON true args bails as invalid type' => sub {
+	plan tests => 1;
+	# JSON::PP::Boolean true is truthy so the early-exit guard
+	# ( !($args || ...) ) evaluates to false and does not short-circuit.
+	# It is not a string, array, or hash, so the code bails.
+	my $hook = make_hook(args => $JSON::PP::true);
+	$hook->register_runtime_config_builds('dns', 'logging');
+	throws_ok {
+		$hook->validate_runtime_config_requests()
+	} qr/Invalid runtime config request arguments/,
+		'JSON true alone bails because it is not string/array/hash';
+};
+
+subtest 'validate_runtime_config_requests - string requests single build' => sub {
+	plan tests => 2;
+	# A plain string is promoted to {$string => {}}.  Step 2 sees an empty
+	# options hash for the build, so request_options gets {dns => {}}.
+	my $hook = make_hook(args => 'dns');
+	$hook->register_runtime_config_builds('dns', 'logging');
+	$hook->validate_runtime_config_requests();
+	cmp_deeply($hook->{requests}, ['dns'],
+		'string arg requests only the named build');
+	cmp_deeply($hook->{request_options}, {dns => {}},
+		'request_options contains empty hash for the requested build');
+};
+
+subtest 'validate_runtime_config_requests - comma-separated string requests multiple' => sub {
+	plan tests => 1;
+	my $hook = make_hook(args => 'dns,logging');
+	$hook->register_runtime_config_builds('dns', 'logging');
+	$hook->validate_runtime_config_requests();
+	cmp_deeply([sort @{$hook->{requests}}], ['dns', 'logging'],
+		'comma-separated string requests both named builds');
+};
+
+subtest 'validate_runtime_config_requests - hash with options stores options' => sub {
+	plan tests => 2;
+	my $hook = make_hook(args => {dns => {ttl => 300}, logging => {}});
+	$hook->register_runtime_config_builds('dns', 'logging');
+	$hook->validate_runtime_config_requests();
+	cmp_deeply([sort @{$hook->{requests}}], ['dns', 'logging'],
+		'hash arg requests named builds');
+	is($hook->{request_options}{dns}{ttl}, 300,
+		'options stored in request_options under build name');
+};
+
+subtest 'validate_runtime_config_requests - hash with JSON true includes build' => sub {
+	plan tests => 1;
+	my $hook = make_hook(args => {dns => $JSON::PP::true, logging => $JSON::PP::false});
+	$hook->register_runtime_config_builds('dns', 'logging');
+	$hook->validate_runtime_config_requests();
+	cmp_deeply($hook->{requests}, ['dns'],
+		'JSON true includes build, JSON false excludes it');
+};
+
+subtest 'validate_runtime_config_requests - JSON false excludes build from all' => sub {
+	plan tests => 1;
+	my $hook = make_hook(args => {logging => $JSON::PP::false});
+	$hook->register_runtime_config_builds('dns', 'logging');
+	$hook->validate_runtime_config_requests();
+	cmp_deeply($hook->{requests}, ['dns'],
+		'JSON false on one build excludes it, leaving others from default all');
+};
+
+subtest 'validate_runtime_config_requests - invalid build name dies' => sub {
+	plan tests => 1;
+	my $hook = make_hook(args => 'nosuchbuild');
+	$hook->register_runtime_config_builds('dns', 'logging');
+	throws_ok {
+		$hook->validate_runtime_config_requests()
+	} qr/Invalid runtime config requests: nosuchbuild/,
+		'invalid build name raises error listing valid names';
+};
+
+subtest 'validate_runtime_config_requests - invalid args type dies' => sub {
+	plan tests => 1;
+	my $hook = make_hook(args => sub { 1 });
+	$hook->register_runtime_config_builds('dns');
+	throws_ok {
+		$hook->validate_runtime_config_requests()
+	} qr/Invalid runtime config request arguments/,
+		'CODE reference args raises invalid-args error';
+};
+
+subtest 'validate_runtime_config_requests - array of strings requests those builds' => sub {
+	plan tests => 1;
+	my $hook = make_hook(args => ['dns']);
+	$hook->register_runtime_config_builds('dns', 'logging');
+	$hook->validate_runtime_config_requests();
+	cmp_deeply($hook->{requests}, ['dns'],
+		'array with one string requests that build');
+};
+
+subtest 'validate_runtime_config_requests - array with hash uses build-keyed options' => sub {
+	plan tests => 2;
+	# Hash elements in the array are merged into %new_args at the top level of
+	# the final hash.  To set per-build options, the hash must use the build
+	# name as the key, e.g. {dns => {ttl => 300}}.
+	my $hook = make_hook(args => ['dns', {dns => {ttl => 300}}]);
+	$hook->register_runtime_config_builds('dns', 'logging');
+	$hook->validate_runtime_config_requests();
+	cmp_deeply([sort @{$hook->{requests}}], ['dns'],
+		'array with string and build-keyed hash requests the named build');
+	is($hook->{request_options}{dns}{ttl}, 300,
+		'per-build options stored in request_options under build name');
+};
+
+subtest 'validate_runtime_config_requests - returns 1 on success' => sub {
+	plan tests => 1;
+	my $hook = make_hook(args => undef);
+	$hook->register_runtime_config_builds('dns');
+	my $ret = $hook->validate_runtime_config_requests();
+	is($ret, 1, 'validate_runtime_config_requests returns 1 on success');
+};
+
+# ---------------------------------------------------------------------------
+# build()
+# ---------------------------------------------------------------------------
+subtest 'build - dies when no build name given' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	$hook->register_runtime_config_builds('dns');
+	throws_ok {
+		$hook->build(undef)
+	} qr/No runtime config name specified/,
+		'build(undef) dies with no-name message';
+};
+
+subtest 'build - dies for unregistered build name' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	$hook->register_runtime_config_builds('dns');
+	throws_ok {
+		$hook->build('logging')
+	} qr/Invalid runtime config name 'logging' specified/,
+		'build("logging") dies when logging not registered';
+};
+
+subtest 'build - returns YAML string for hash return value' => sub {
+	plan tests => 2;
+	my $hook = make_hook();
+	$hook->register_runtime_config_builds('dns');
+	my $result = $hook->build('dns');
+	ok(defined $result, 'build("dns") returns a defined value');
+	like($result, qr/releases/,
+		'returned value contains "releases" key from hash-to-YAML conversion');
+};
+
+subtest 'build - returns YAML string unchanged when build returns string' => sub {
+	plan tests => 2;
+	my $hook = make_hook();
+	$hook->register_runtime_config_builds('logging');
+	my $result = $hook->build('logging');
+	ok(defined $result, 'build("logging") returns a defined value');
+	like($result, qr/loggregator/,
+		'returned YAML contains loggregator release name');
+};
+
+subtest 'build - returns undef when build method returns failed status' => sub {
+	plan tests => 2;
+	{
+		no warnings 'redefine';
+		*Genesis::Hook::RuntimeConfig::test_kit::build_failing_runtime = sub {
+			return (undef, 'failed', 'something went wrong');
+		};
+	}
+	my $hook = make_hook();
+	$hook->register_runtime_config_builds('failing');
+	my $result;
+	lives_ok { $result = $hook->build('failing') }
+		'build() does not die when build method returns failed status';
+	ok(!defined $result, 'build() returns undef for failed status');
+};
+
+subtest 'build - returns undef when build method returns skipped status' => sub {
+	plan tests => 2;
+	{
+		no warnings 'redefine';
+		*Genesis::Hook::RuntimeConfig::test_kit::build_skipped_runtime = sub {
+			return (undef, 'skipped', 'not applicable here');
+		};
+	}
+	my $hook = make_hook();
+	$hook->register_runtime_config_builds('skipped');
+	my $result;
+	lives_ok { $result = $hook->build('skipped') }
+		'build() does not die when build method returns skipped status';
+	ok(!defined $result, 'build() returns undef for skipped status');
+};
+
+subtest 'build - clears secrets for failed build' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	$hook->{secrets}{failing} = {'/some/path:key' => 'value'};
+	$hook->register_runtime_config_builds('failing');
+	$hook->build('failing');
+	ok(!exists $hook->{secrets}{failing},
+		'secrets entry cleared for failed build');
+};
+
+# ---------------------------------------------------------------------------
+# bosh() accessor
+# ---------------------------------------------------------------------------
+subtest 'bosh - returns the bosh object set at construction' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	is($hook->bosh, $bosh, 'bosh() returns the bosh mock object');
+};
+
+# ---------------------------------------------------------------------------
+# credhub() accessor
+# ---------------------------------------------------------------------------
+subtest 'credhub - returns undef by default in manual-bless mode' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	ok(!defined $hook->credhub,
+		'credhub() returns undef when not set');
+};
+
+# ---------------------------------------------------------------------------
+# credhub_base() - feature_compatibility returns 0, so base is undef
+# ---------------------------------------------------------------------------
+subtest 'credhub_base - returns undef when feature_compatibility is false' => sub {
+	plan tests => 1;
+	my $hook = make_hook();
+	ok(!defined $hook->credhub_base,
+		'credhub_base() returns undef when feature_compatibility returns 0');
+};
+
+# ---------------------------------------------------------------------------
+# done testing
+# ---------------------------------------------------------------------------
+done_testing;

--- a/t/unit-tests/genesis_hook_terminate-core.t
+++ b/t/unit-tests/genesis_hook_terminate-core.t
@@ -1,0 +1,533 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+
+use lib 't';
+use helper;
+use Test::More;
+use Test::Exception;
+use Test::Deep;
+use Genesis qw(bail);
+use Cwd qw(abs_path);
+
+$ENV{GENESIS_CALLBACK_BIN} ||= abs_path('bin/genesis');
+$ENV{GENESIS_LIB} ||= abs_path('lib');
+$ENV{GENESIS_OUTPUT_COLUMNS} = 80;
+$ENV{NOCOLOR} = 1;
+
+# ---------------------------------------------------------------------------
+# Load the module under test
+# ---------------------------------------------------------------------------
+require_ok 'Genesis::Hook::Terminate';
+
+# ---------------------------------------------------------------------------
+# Test subclass - implements all three mode-specific methods.
+# Class name matches Genesis::Hook::<Type>::<KitName> convention for label().
+# ---------------------------------------------------------------------------
+{
+	package Genesis::Hook::Terminate::test_kit;
+	use parent -norequire, 'Genesis::Hook::Terminate';
+
+	sub before_terminate  { return 1 }
+	sub after_terminate   { return 1 }
+	sub failed_terminate  { return 1 }
+}
+
+# ---------------------------------------------------------------------------
+# Incomplete test subclass - no mode-specific methods implemented.
+# Used to verify kit_bug is raised for unimplemented dispatch targets.
+# ---------------------------------------------------------------------------
+{
+	package Genesis::Hook::Terminate::test_kit_empty;
+	use parent -norequire, 'Genesis::Hook::Terminate';
+}
+
+# ---------------------------------------------------------------------------
+# Shared mock objects
+# ---------------------------------------------------------------------------
+
+my $test_seq = 0;
+
+my $kit = mock "Genesis::Kit" => {
+	name                => 'test-kit',
+	version             => '1.0.0',
+	genesis_version_min => '3.1.0-rc.10',
+	id                  => sub { return $_[0]->name . '/' . $_[0]->version },
+	kit_bug => sub {
+		my ($self, $msg, @args) = @_;
+		bail("Throwing a kit bug: " . $msg, @args);
+	},
+	path => sub {
+		my ($self, $file) = @_;
+		return "/mock/kit/path/$file";
+	},
+	metadata => { supports => ['aws', 'vsphere', 'openstack'] },
+	get_hook_module => sub { return undef },
+};
+
+my $bosh = mock "Genesis::BOSH" => {
+	alias                => 'mock-bosh',
+	connect_and_validate => sub { return $_[0] },
+};
+
+sub mock_env {
+	$test_seq++;
+	my $seq = $test_seq;
+	mock "Genesis::Env" => {(
+		name            => "test-env-$seq",
+		type            => 'test',
+		kit             => $kit,
+		bosh            => sub {
+			my $self = shift;
+			return $bosh;
+		},
+		use_create_env  => 0,
+		features        => Mock::ReferencedValue->new(['ha', 'tls']),
+		iaas            => 'aws',
+		scale           => 'dev',
+		is_ocfp         => 0,
+		cpi_name        => 'aws_cpi',
+		cpi_enabled     => 1,
+		deployments     => mock("Genesis::Env::Deployments::$seq" => {
+			current_state => 'deployed',
+		}),
+		workpath => sub {
+			my ($self, $path) = @_;
+			return "/tmp/genesis-test-work/$path";
+		},
+		exodus_lookup => sub {
+			my ($self, $key, $default) = @_;
+			return { director_url => 'https://bosh.example.com', admin_user => 'admin' }
+				if $key eq '.';
+			return $default;
+		},
+		lookup => sub {
+			my ($self, $key, $default) = @_;
+			return $default;
+		},
+		path => sub { return "/mock/env/path/$_[1]" },
+		file => 'test-env.yml',
+	), @_};
+}
+
+# Convenience: instantiate the full test subclass with defaults
+sub make_hook {
+	my %args = (
+		env      => mock_env(),
+		kit      => $kit,
+		mode     => 'before',
+		dryrun   => 0,
+		force    => 0,
+		noprompt => 0,
+		@_,
+	);
+	return Genesis::Hook::Terminate::test_kit->init(%args);
+}
+
+# ---------------------------------------------------------------------------
+# Globals set before all subtests
+# ---------------------------------------------------------------------------
+$Genesis::VERSION = '3.1.0-rc.10';
+$ENV{GENESIS_CALL_BIN} = 'genesis';
+$ENV{GENESIS_KIT_HOOK} = 'terminate';
+
+# ---------------------------------------------------------------------------
+# Module loads
+# ---------------------------------------------------------------------------
+subtest 'Genesis::Hook::Terminate module loads' => sub {
+	plan tests => 1;
+	ok(defined(&Genesis::Hook::Terminate::init),
+		'Genesis::Hook::Terminate::init is defined');
+};
+
+# ---------------------------------------------------------------------------
+# init - required arguments
+# ---------------------------------------------------------------------------
+subtest 'init - dies when env is missing' => sub {
+	plan tests => 1;
+
+	throws_ok {
+		Genesis::Hook::Terminate::test_kit->init(
+			kit      => $kit,
+			mode     => 'before',
+			dryrun   => 0,
+			force    => 0,
+			noprompt => 0,
+		)
+	} qr/Missing required arguments for a perl-based kit hook call:.*env/,
+		'init() without env dies with required-args message';
+};
+
+subtest 'init - dies when kit is missing' => sub {
+	plan tests => 1;
+
+	throws_ok {
+		Genesis::Hook::Terminate::test_kit->init(
+			env      => mock_env(),
+			mode     => 'before',
+			dryrun   => 0,
+			force    => 0,
+			noprompt => 0,
+		)
+	} qr/Missing required arguments for a perl-based kit hook call:.*kit/,
+		'init() without kit dies with required-args message';
+};
+
+subtest 'init - dies when mode is missing' => sub {
+	plan tests => 1;
+
+	throws_ok {
+		Genesis::Hook::Terminate::test_kit->init(
+			env      => mock_env(),
+			kit      => $kit,
+			dryrun   => 0,
+			force    => 0,
+			noprompt => 0,
+		)
+	} qr/Missing required arguments for a perl-based kit hook call:.*mode/,
+		'init() without mode dies with required-args message';
+};
+
+subtest 'init - dies when dryrun is missing' => sub {
+	plan tests => 1;
+
+	throws_ok {
+		Genesis::Hook::Terminate::test_kit->init(
+			env      => mock_env(),
+			kit      => $kit,
+			mode     => 'before',
+			force    => 0,
+			noprompt => 0,
+		)
+	} qr/Missing required arguments for a perl-based kit hook call:.*dryrun/,
+		'init() without dryrun dies with required-args message';
+};
+
+subtest 'init - dies when force is missing' => sub {
+	plan tests => 1;
+
+	throws_ok {
+		Genesis::Hook::Terminate::test_kit->init(
+			env      => mock_env(),
+			kit      => $kit,
+			mode     => 'before',
+			dryrun   => 0,
+			noprompt => 0,
+		)
+	} qr/Missing required arguments for a perl-based kit hook call:.*force/,
+		'init() without force dies with required-args message';
+};
+
+subtest 'init - dies when noprompt is missing' => sub {
+	plan tests => 1;
+
+	throws_ok {
+		Genesis::Hook::Terminate::test_kit->init(
+			env    => mock_env(),
+			kit    => $kit,
+			mode   => 'before',
+			dryrun => 0,
+			force  => 0,
+		)
+	} qr/Missing required arguments for a perl-based kit hook call:.*noprompt/,
+		'init() without noprompt dies with required-args message';
+};
+
+# ---------------------------------------------------------------------------
+# init - valid construction
+# ---------------------------------------------------------------------------
+subtest 'init - returns blessed object with all args stored' => sub {
+	plan tests => 7;
+
+	my $env  = mock_env();
+	my $hook;
+	lives_ok {
+		$hook = Genesis::Hook::Terminate::test_kit->init(
+			env      => $env,
+			kit      => $kit,
+			mode     => 'before',
+			dryrun   => 0,
+			force    => 0,
+			noprompt => 0,
+		)
+	} 'init() with all required args succeeds';
+
+	ok(defined $hook,                        'init() returns a defined value');
+	isa_ok($hook, 'Genesis::Hook::Terminate', 'returned object isa Genesis::Hook::Terminate');
+	isa_ok($hook, 'Genesis::Hook',            'returned object isa Genesis::Hook');
+	is($hook->env,       $env,     'env() returns the env passed to init()');
+	is($hook->{mode},    'before', 'mode stored on object');
+	is($hook->{dryrun},  0,        'dryrun stored on object');
+};
+
+subtest 'init - complete flag starts at 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	is($hook->{complete}, 0, 'complete flag initializes to 0');
+};
+
+subtest 'init - type set from GENESIS_KIT_HOOK env var' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook();
+	is($hook->{type}, 'terminate', 'type reflects GENESIS_KIT_HOOK=terminate');
+};
+
+# ---------------------------------------------------------------------------
+# init - mode validation
+# ---------------------------------------------------------------------------
+subtest 'init - accepts mode "before"' => sub {
+	plan tests => 2;
+
+	my $hook;
+	lives_ok {
+		$hook = make_hook(mode => 'before')
+	} 'init() with mode "before" succeeds';
+	is($hook->{mode}, 'before', 'mode stored as "before"');
+};
+
+subtest 'init - accepts mode "after"' => sub {
+	plan tests => 2;
+
+	my $hook;
+	lives_ok {
+		$hook = make_hook(mode => 'after')
+	} 'init() with mode "after" succeeds';
+	is($hook->{mode}, 'after', 'mode stored as "after"');
+};
+
+subtest 'init - accepts mode "failed"' => sub {
+	plan tests => 2;
+
+	my $hook;
+	lives_ok {
+		$hook = make_hook(mode => 'failed')
+	} 'init() with mode "failed" succeeds';
+	is($hook->{mode}, 'failed', 'mode stored as "failed"');
+};
+
+subtest 'init - dies on invalid mode' => sub {
+	plan tests => 3;
+
+	for my $bad_mode (qw(start finish broken)) {
+		throws_ok {
+			make_hook(mode => $bad_mode)
+		} qr/Unknown termination mode '$bad_mode'/,
+			"init() dies with unknown mode '$bad_mode'";
+	}
+};
+
+subtest 'init - dies with message naming invalid mode value' => sub {
+	plan tests => 1;
+
+	throws_ok {
+		make_hook(mode => 'deploy')
+	} qr/expected.*before.*after.*failed/s,
+		'error message names the three valid modes';
+};
+
+# ---------------------------------------------------------------------------
+# init - dry_run alias is renamed to dryrun
+# ---------------------------------------------------------------------------
+subtest 'init - dry_run argument is renamed to dryrun' => sub {
+	plan tests => 3;
+
+	my $hook;
+	lives_ok {
+		$hook = Genesis::Hook::Terminate::test_kit->init(
+			env      => mock_env(),
+			kit      => $kit,
+			mode     => 'after',
+			dry_run  => 1,
+			force    => 0,
+			noprompt => 1,
+		)
+	} 'init() with dry_run (underscored) succeeds';
+
+	is($hook->{dryrun},  1,     'dryrun set to 1 from dry_run');
+	ok(!exists $hook->{dry_run}, 'dry_run key was removed from object');
+};
+
+subtest 'init - dry_run => 0 renamed to dryrun => 0' => sub {
+	plan tests => 2;
+
+	my $hook = Genesis::Hook::Terminate::test_kit->init(
+		env      => mock_env(),
+		kit      => $kit,
+		mode     => 'before',
+		dry_run  => 0,
+		force    => 0,
+		noprompt => 0,
+	);
+	is($hook->{dryrun},  0,     'dryrun set to 0 from dry_run => 0');
+	ok(!exists $hook->{dry_run}, 'dry_run key absent after rename');
+};
+
+# ---------------------------------------------------------------------------
+# is_dryrun
+# ---------------------------------------------------------------------------
+subtest 'is_dryrun - returns false when dryrun is 0' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook(dryrun => 0);
+	ok(!$hook->is_dryrun, 'is_dryrun() returns false when dryrun => 0');
+};
+
+subtest 'is_dryrun - returns true when dryrun is 1' => sub {
+	plan tests => 1;
+
+	my $hook = make_hook(dryrun => 1);
+	ok($hook->is_dryrun, 'is_dryrun() returns true when dryrun => 1');
+};
+
+subtest 'is_dryrun - reflects dry_run value supplied at init' => sub {
+	plan tests => 1;
+
+	my $hook = Genesis::Hook::Terminate::test_kit->init(
+		env      => mock_env(),
+		kit      => $kit,
+		mode     => 'before',
+		dry_run  => 1,
+		force    => 0,
+		noprompt => 0,
+	);
+	ok($hook->is_dryrun, 'is_dryrun() returns true when constructed with dry_run => 1');
+};
+
+# ---------------------------------------------------------------------------
+# perform - dispatch to mode-specific methods
+# ---------------------------------------------------------------------------
+subtest 'perform - dispatches to before_terminate for mode "before"' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook(mode => 'before');
+	my $ret;
+	lives_ok { $ret = $hook->perform } 'perform() with mode "before" lives';
+	is($ret, 1, 'perform() returns result of before_terminate()');
+	is($hook->completed, 1, 'hook is marked complete after perform()');
+};
+
+subtest 'perform - dispatches to after_terminate for mode "after"' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook(mode => 'after');
+	my $ret;
+	lives_ok { $ret = $hook->perform } 'perform() with mode "after" lives';
+	is($ret, 1, 'perform() returns result of after_terminate()');
+	is($hook->completed, 1, 'hook is marked complete after perform()');
+};
+
+subtest 'perform - dispatches to failed_terminate for mode "failed"' => sub {
+	plan tests => 3;
+
+	my $hook = make_hook(mode => 'failed');
+	my $ret;
+	lives_ok { $ret = $hook->perform } 'perform() with mode "failed" lives';
+	is($ret, 1, 'perform() returns result of failed_terminate()');
+	is($hook->completed, 1, 'hook is marked complete after perform()');
+};
+
+subtest 'perform - calls done() with method return value' => sub {
+	plan tests => 2;
+
+	# Subclass that returns a custom value
+	{
+		package Genesis::Hook::Terminate::test_kit_retval;
+		use parent -norequire, 'Genesis::Hook::Terminate';
+		sub before_terminate { return 'custom-result' }
+		sub after_terminate  { return 1 }
+		sub failed_terminate { return 1 }
+	}
+
+	my $hook = Genesis::Hook::Terminate::test_kit_retval->init(
+		env      => mock_env(),
+		kit      => $kit,
+		mode     => 'before',
+		dryrun   => 0,
+		force    => 0,
+		noprompt => 0,
+	);
+
+	my $ret = $hook->perform;
+	is($ret,           'custom-result', 'perform() returns the value from mode method');
+	is($hook->results, 'custom-result', 'results() returns the same value');
+};
+
+# ---------------------------------------------------------------------------
+# perform - kit_bug raised for unimplemented mode methods
+# ---------------------------------------------------------------------------
+subtest 'perform - raises kit_bug when before_terminate is not implemented' => sub {
+	plan tests => 1;
+
+	my $hook = Genesis::Hook::Terminate::test_kit_empty->init(
+		env      => mock_env(),
+		kit      => $kit,
+		mode     => 'before',
+		dryrun   => 0,
+		force    => 0,
+		noprompt => 0,
+	);
+
+	throws_ok {
+		$hook->perform
+	} qr/Throwing a kit bug:.*before_terminate/,
+		'perform() raises kit_bug when before_terminate is not implemented';
+};
+
+subtest 'perform - raises kit_bug when after_terminate is not implemented' => sub {
+	plan tests => 1;
+
+	my $hook = Genesis::Hook::Terminate::test_kit_empty->init(
+		env      => mock_env(),
+		kit      => $kit,
+		mode     => 'after',
+		dryrun   => 0,
+		force    => 0,
+		noprompt => 0,
+	);
+
+	throws_ok {
+		$hook->perform
+	} qr/Throwing a kit bug:.*after_terminate/,
+		'perform() raises kit_bug when after_terminate is not implemented';
+};
+
+subtest 'perform - raises kit_bug when failed_terminate is not implemented' => sub {
+	plan tests => 1;
+
+	my $hook = Genesis::Hook::Terminate::test_kit_empty->init(
+		env      => mock_env(),
+		kit      => $kit,
+		mode     => 'failed',
+		dryrun   => 0,
+		force    => 0,
+		noprompt => 0,
+	);
+
+	throws_ok {
+		$hook->perform
+	} qr/Throwing a kit bug:.*failed_terminate/,
+		'perform() raises kit_bug when failed_terminate is not implemented';
+};
+
+subtest 'perform - kit_bug message names the kit' => sub {
+	plan tests => 1;
+
+	my $hook = Genesis::Hook::Terminate::test_kit_empty->init(
+		env      => mock_env(),
+		kit      => $kit,
+		mode     => 'before',
+		dryrun   => 0,
+		force    => 0,
+		noprompt => 0,
+	);
+
+	throws_ok {
+		$hook->perform
+	} qr/Throwing a kit bug:[\s\S]*test-kit/,
+		'kit_bug message includes the kit name';
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

- Add 416 POD-driven unit tests for Genesis::Hook base class and all 8 hook subclasses
- Tests cover initialization, accessors, lifecycle, error handling, and integration workflows per POD documentation
- Register all 9 test files in the test execution manifest

## Test Coverage

| Module | Tests |
|--------|-------|
| Genesis::Hook (base) | 80 |
| Genesis::Hook::Addon | 26 |
| Genesis::Hook::Blueprint | 51 |
| Genesis::Hook::Check | 63 |
| Genesis::Hook::CpiConfig | 38 |
| Genesis::Hook::Features | 42 |
| Genesis::Hook::PostDeploy | 35 |
| Genesis::Hook::RuntimeConfig | 52 |
| Genesis::Hook::Terminate | 29 |
| **Total** | **416** |

## Test plan

- [x] All 416 tests pass via `prove -l t/unit-tests/genesis_hook*.t`
- [ ] CI passes on v3.1.x-dev base

Closes FWT-560